### PR TITLE
More efficient HYPRE operations in CellPoissonHypreSolver

### DIFF
--- a/source/SAMRAI/solv/CellPoissonHypreSolver.C
+++ b/source/SAMRAI/solv/CellPoissonHypreSolver.C
@@ -689,7 +689,7 @@ CellPoissonHypreSolver::copyToHypre(
       HYPRE_StructVectorSetBoxValues(
          vector, &lower[0], &upper[0], src.getPointer(depth)); 
    } else {
-      pdat::CellData<double> tmp(box,1,hier::IntVector::getZero(d_dim));
+      pdat::CellData<double> tmp(box, 1, hier::IntVector::getZero(d_dim));
       tmp.copyDepth(0, src, depth);
       HYPRE_StructVectorSetBoxValues(
          vector, &lower[0], &upper[0], tmp.getPointer());

--- a/source/SAMRAI/solv/CellPoissonHypreSolver.h
+++ b/source/SAMRAI/solv/CellPoissonHypreSolver.h
@@ -319,7 +319,8 @@ public:
     *        are assumed.
     * @param initial_zero Use a uniform zero vector as the initial guess of
     *                     the solution rather than the current contents of
-    *                     the u solution vector.
+    *                     the u solution variable.  This can be used as a
+    *                     small optimization to avoid some internal data copies.
     *
     * @return whether solver converged to specified level
     *

--- a/source/SAMRAI/solv/CellPoissonHypreSolver.h
+++ b/source/SAMRAI/solv/CellPoissonHypreSolver.h
@@ -317,6 +317,9 @@ public:
     * @param f Descriptor of cell-centered source variable.
     * @param homogeneous_bc Whether homogeneous boundary conditions
     *        are assumed.
+    * @param initial_zero Use a uniform zero vector as the initial guess of
+    *                     the solution rather than the current contents of
+    *                     the u solution vector.
     *
     * @return whether solver converged to specified level
     *
@@ -330,7 +333,8 @@ public:
    solveSystem(
       const int u,
       const int f,
-      bool homogeneous_bc = false);
+      bool homogeneous_bc = false,
+      bool initial_zero = false);
 
    /*!
     * @brief Return the number of iterations taken by the solver to converge.

--- a/source/test/hypre/HyprePoisson.C
+++ b/source/test/hypre/HyprePoisson.C
@@ -278,7 +278,7 @@ bool HyprePoisson::solvePoisson()
    tbox::plog << "solving..." << std::endl;
    int solver_ret;
    solver_ret = d_poisson_hypre->solveSystem(d_comp_soln_id,
-         d_rhs_id);
+         d_rhs_id, false, true);
    /*
     * Present data on the solve.
     */


### PR DESCRIPTION
Revision based on pull request #32  by @jeanlucf22 .   Avoids temporary data copy when ghost data for source and destination match, and adds an optional argument to use a zero vector as the initial guess for the solution vector.