### PR TITLE
Fix the virtual xsputn overload of tbox::ParallelBuffer

### DIFF
--- a/source/SAMRAI/tbox/ParallelBuffer.C
+++ b/source/SAMRAI/tbox/ParallelBuffer.C
@@ -266,7 +266,7 @@ ParallelBuffer::sync()
 #if !defined(__INTEL_COMPILER) && (defined(__GNUG__))
 std::streamsize
 ParallelBuffer::xsputn(
-   const std::string& text,
+   const char* text,
    std::streamsize n)
 {
    sync();

--- a/source/SAMRAI/tbox/ParallelBuffer.h
+++ b/source/SAMRAI/tbox/ParallelBuffer.h
@@ -113,7 +113,7 @@ public:
     * Synchronize the parallel buffer (called from streambuf).
     */
    int
-   sync();
+   sync() override;
 
 #if !defined(__INTEL_COMPILER) && (defined(__GNUG__))
    /**
@@ -122,8 +122,8 @@ public:
     */
    std::streamsize
    xsputn(
-      const std::string& text,
-      std::streamsize n);
+      const char* text,
+      std::streamsize n) override;
 #endif
 
    /**
@@ -132,7 +132,7 @@ public:
     */
    int
    overflow(
-      int ch);
+      int ch) override;
 
 #ifdef _MSC_VER
 
@@ -142,7 +142,7 @@ public:
     * MSVC++ stream implementation.
     */
    int
-   underflow()
+   underflow() override
    {
       return EOF;
    }


### PR DESCRIPTION
The current behavior of `std::ostream` is to ignore `ParallelBuffer::xsputn(std::string, std::streamsize)` because it does not override the virtual function `std::streambuf::xsputn(const char*, std::streamsize)`. Instead, the default implementation of `std::streambuf::xsputn(const char*, std::streamsize)` calls `ParallelBuffer::overflow(int)` for each single character which causes a call to `sync()` and `outputString()` for each single character.

This patch fixes this and also adds the `override` keyword to the virtual function overrides of ParallelBuffer. Functions which are marked by override but do not override any virtual function will lead to compile time errors.

It is hard to come up with a Unit Test for this because there is no observable effect wrt correctness. 
Do you have a policy for unit tests? 

~~Note: This is a PR against `feature/blt`~~

Edit: To make it clear, this has effect on `pout`, `perr` and `plog` in `tbox/PIO.h`