### PR TITLE
Fix typo and change add_doxygen_target to blt_add_doxygen_target.

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,4 +1,4 @@
 if (DOXYGEN_FOUND)
   set (top_srcdir ${CMAKE_SOURCE_DIR})
-  add_doxygen_target( samrai_doxygen )
+  blt_add_doxygen_target( samrai_doxygen )
 endif ()


### PR DESCRIPTION
Because of a type, the current `docs/CMakeLists.txt` was broken if `DOXYGEN_FOUND`. This patch fixes this and makes it possible to build the documentation from CMake.