### PR TITLE
tbox::MessageStream {un,}pack -> get{Read,Write}Buffer in pdat::ArrayData

### DIFF
--- a/source/SAMRAI/pdat/ArrayData.C
+++ b/source/SAMRAI/pdat/ArrayData.C
@@ -626,14 +626,10 @@ ArrayData<TYPE>::packStream(
    const hier::Box& dest_box,
    const hier::IntVector& src_shift) const
 {
-
    const size_t size = d_depth * dest_box.size();
-   std::vector<TYPE> buffer(size);
 
+   TYPE* buffer = stream.getWriteBuffer<TYPE>(size);
    packBuffer(&buffer[0], hier::Box::shift(dest_box, -src_shift));
-
-   stream.pack(&buffer[0], size);
-
 }
 
 template<class TYPE>
@@ -645,7 +641,7 @@ ArrayData<TYPE>::packStream(
 {
 
    const size_t size = d_depth * dest_boxes.getTotalSizeOfBoxes();
-   std::vector<TYPE> buffer(size);
+   TYPE* buffer = stream.getWriteBuffer<TYPE>(size);
 
    size_t ptr = 0;
    for (hier::BoxContainer::const_iterator b = dest_boxes.begin();
@@ -655,9 +651,6 @@ ArrayData<TYPE>::packStream(
    }
 
    TBOX_ASSERT(ptr == size);
-
-   stream.pack(&buffer[0], size);
-
 }
 
 template<class TYPE>
@@ -669,15 +662,12 @@ ArrayData<TYPE>::packStream(
 {
 
    const size_t size = d_depth * dest_box.size();
-   std::vector<TYPE> buffer(size);
+   TYPE* buffer = stream.getWriteBuffer<TYPE>(size);
 
    hier::Box pack_box(dest_box);
    transformation.inverseTransform(pack_box);
    packBuffer(&buffer[0], pack_box);
 //      hier::Box::shift(dest_box, -src_shift));
-
-   stream.pack(&buffer[0], size);
-
 }
 
 template<class TYPE>
@@ -689,7 +679,7 @@ ArrayData<TYPE>::packStream(
 {
 
    const size_t size = d_depth * dest_boxes.getTotalSizeOfBoxes();
-   std::vector<TYPE> buffer(size);
+   TYPE* buffer = stream.getWriteBuffer<TYPE>(size);
 
    size_t ptr = 0;
    for (hier::BoxContainer::const_iterator b = dest_boxes.begin();
@@ -702,9 +692,6 @@ ArrayData<TYPE>::packStream(
    }
 
    TBOX_ASSERT(ptr == size);
-
-   stream.pack(&buffer[0], size);
-
 }
 
 /*
@@ -726,15 +713,12 @@ ArrayData<TYPE>::unpackStream(
    const hier::Box& dest_box,
    const hier::IntVector& src_shift)
 {
-
    NULL_USE(src_shift);
 
    const size_t size = d_depth * dest_box.size();
-   std::vector<TYPE> buffer(size);
+   const TYPE* buffer = stream.getReadBuffer<TYPE>(size);
 
-   stream.unpack(&buffer[0], size);
    unpackBuffer(&buffer[0], dest_box);
-
 }
 
 template<class TYPE>
@@ -744,13 +728,10 @@ ArrayData<TYPE>::unpackStream(
    const hier::BoxContainer& dest_boxes,
    const hier::IntVector& src_shift)
 {
-
    NULL_USE(src_shift);
 
    const size_t size = d_depth * dest_boxes.getTotalSizeOfBoxes();
-   std::vector<TYPE> buffer(size);
-
-   stream.unpack(&buffer[0], size);
+   const TYPE* buffer = stream.getReadBuffer<TYPE>(size);
 
    size_t ptr = 0;
    for (hier::BoxContainer::const_iterator b = dest_boxes.begin();
@@ -781,15 +762,12 @@ ArrayData<TYPE>::unpackStreamAndSum(
    const hier::Box& dest_box,
    const hier::IntVector& src_shift)
 {
-
    NULL_USE(src_shift);
 
    const size_t size = d_depth * dest_box.size();
-   std::vector<TYPE> buffer(size);
+   const TYPE* buffer = stream.getReadBuffer<TYPE>(size);
 
-   stream.unpack(&buffer[0], size);
    unpackBufferAndSum(&buffer[0], dest_box);
-
 }
 
 template<class TYPE>
@@ -803,9 +781,7 @@ ArrayData<TYPE>::unpackStreamAndSum(
    NULL_USE(src_shift);
 
    const size_t size = d_depth * dest_boxes.getTotalSizeOfBoxes();
-   std::vector<TYPE> buffer(size);
-
-   stream.unpack(&buffer[0], size);
+   const TYPE* buffer = stream.getReadBuffer<TYPE>(size);
 
    size_t ptr = 0;
    for (hier::BoxContainer::const_iterator b = dest_boxes.begin();

--- a/source/SAMRAI/tbox/MessageStream.h
+++ b/source/SAMRAI/tbox/MessageStream.h
@@ -167,7 +167,7 @@ public:
       size_t num_entries)
    {
       TBOX_ASSERT(readMode());
-      const size_t num_bytes = num_entries * sizeof(DATA_TYPE);
+      const size_t num_bytes = getSizeof<DATA_TYPE>(num_entries);
       TBOX_ASSERT(canCopyOut(num_bytes));
       const DATA_TYPE *buffer =
          reinterpret_cast<const DATA_TYPE *>(&d_read_buffer[getCurrentSize()]);
@@ -189,7 +189,7 @@ public:
       size_t num_entries)
    {
       TBOX_ASSERT(writeMode());
-      const size_t num_bytes = num_entries * sizeof(DATA_TYPE);
+      const size_t num_bytes = getSizeof<DATA_TYPE>(num_entries);
       if (!growAsNeeded()) {
          TBOX_ASSERT(canCopyIn(num_bytes));
       }

--- a/source/SAMRAI/tbox/MessageStream.h
+++ b/source/SAMRAI/tbox/MessageStream.h
@@ -190,10 +190,7 @@ public:
    {
       TBOX_ASSERT(writeMode());
       const size_t num_bytes = getSizeof<DATA_TYPE>(num_entries);
-      if (!growAsNeeded()) {
-         TBOX_ASSERT(canCopyIn(num_bytes));
-      }
-      else if (num_bytes > 0) {
+      if (num_bytes > 0) {
          d_write_buffer.resize(getCurrentSize() + num_bytes);
          d_buffer_size = d_write_buffer.size();
       }

--- a/source/SAMRAI/tbox/MessageStream.h
+++ b/source/SAMRAI/tbox/MessageStream.h
@@ -154,6 +154,56 @@ public:
    }
 
    /*!
+    * @brief Returns a pointer into the message stream valid for
+    * num_bytes.
+    *
+    * @param[in] num_bytes  Number of bytes requested for window.
+    *
+    * @pre readMode()
+    */
+   template<typename DATA_TYPE>
+   const DATA_TYPE *
+   getReadBuffer(
+      size_t num_entries)
+   {
+      TBOX_ASSERT(readMode());
+      const size_t num_bytes = num_entries * sizeof(DATA_TYPE);
+      TBOX_ASSERT(canCopyOut(num_bytes));
+      const DATA_TYPE *buffer =
+         reinterpret_cast<const DATA_TYPE *>(&d_read_buffer[getCurrentSize()]);
+      d_buffer_index += num_bytes;
+      return buffer;
+   }
+
+   /*!
+    * @brief Returns a pointer into the message stream valid for
+    * num_bytes.
+    *
+    * @param[in] num_bytes  Number of bytes requested for window.
+    *
+    * @pre writeMode()
+    */
+   template<typename DATA_TYPE>
+   DATA_TYPE *
+   getWriteBuffer(
+      size_t num_entries)
+   {
+      TBOX_ASSERT(writeMode());
+      const size_t num_bytes = num_entries * sizeof(DATA_TYPE);
+      if (!growAsNeeded()) {
+         TBOX_ASSERT(canCopyIn(num_bytes));
+      }
+      else if (num_bytes > 0) {
+         d_write_buffer.resize(getCurrentSize() + num_bytes);
+         d_buffer_size = d_write_buffer.size();
+      }
+      DATA_TYPE *buffer =
+         reinterpret_cast<DATA_TYPE *>(&d_write_buffer[getCurrentSize()]);
+      d_buffer_index += num_bytes;
+      return buffer;
+   }
+
+   /*!
     * @brief Pack a single data item into message stream.
     *
     * @param[in] data  Single item of type DATA_TYPE to be copied


### PR DESCRIPTION
Removes extra vector buffer in packing and unpacking. Using the additional vectors, while nice from an implementation standpoint, requires many additional allocations and without a pool slows the calculation.