### PR TITLE
Fixed bug in deallocator of CellPoissonFACSolver

### DIFF
--- a/source/SAMRAI/solv/CellPoissonFACSolver.C
+++ b/source/SAMRAI/solv/CellPoissonFACSolver.C
@@ -209,8 +209,12 @@ CellPoissonFACSolver::initializeSolverState(
 
    int ln;
    for (ln = d_ln_min; ln <= d_ln_max; ++ln) {
-      d_hierarchy->getPatchLevel(ln)->allocatePatchData(
-         s_weight_id[d_dim.getValue() - 1]);
+      const int weight_id = s_weight_id[d_dim.getValue() - 1];
+      std::shared_ptr<hier::PatchLevel> level(
+         d_hierarchy->getPatchLevel(ln));
+      if (!level->checkAllocated(weight_id)) {
+         level->allocatePatchData(weight_id);
+      }
    }
 
    d_fac_ops->computeVectorWeights(d_hierarchy,
@@ -246,12 +250,17 @@ CellPoissonFACSolver::deallocateSolverState()
       d_fac_precond->deallocateSolverState();
 
       /*
-       * Delete internally managed data.
+       * Delete internally managed data if not already done by other
+       * instance of class
        */
       int ln;
       for (ln = d_ln_min; ln <= d_ln_max; ++ln) {
-         d_hierarchy->getPatchLevel(ln)->deallocatePatchData(
-            s_weight_id[d_dim.getValue() - 1]);
+         const int weight_id = s_weight_id[d_dim.getValue() - 1];
+         if( weight_id>=0 ){
+            std::shared_ptr<hier::PatchLevel> level(
+               d_hierarchy->getPatchLevel(ln));
+            level->deallocatePatchData(weight_id);
+         }
       }
 
       d_hierarchy.reset();


### PR DESCRIPTION
With two instances of objects of class CellPoissonFACSolver, the call to the second destructor would try to deallocate a data index of value -1 and trigger an assert.