### PR TITLE
This commit fixes an undefined behaviour in ParallelBuffer::xsputn

### DIFF
--- a/source/SAMRAI/tbox/ParallelBuffer.C
+++ b/source/SAMRAI/tbox/ParallelBuffer.C
@@ -270,7 +270,7 @@ ParallelBuffer::xsputn(
    std::streamsize n)
 {
    sync();
-   if (n > 0) outputString(text, static_cast<int>(n));
+   if (n > 0) outputString(std::string(text, n), static_cast<int>(n));
    return n;
 }
 #endif


### PR DESCRIPTION
Change the used `std::string` constructor from `std::string(const char*)` to
`std::string(const char*, long n)` such that we do not invoke undefined
behavior if the pointer points to a single character which is not
null-terminated.

You can reproduce the error with enabled address / undefined sanitizer and

```cpp
#include <SAMRAI/tbox/SAMRAIManager.h>
#include <SAMRAI/tbox/SAMRAI_MPI.h>
#include <SAMRAI/tbox/PIO.h>


int main(int argc, char** argv)
{
  SAMRAI::tbox::SAMRAI_MPI::init(&argc, &argv);
  SAMRAI::tbox::SAMRAIManager::initialize();
  SAMRAI::tbox::SAMRAIManager::startup();

  SAMRAI::tbox::pout << '\n';

  SAMRAI::tbox::SAMRAIManager::shutdown();
  SAMRAI::tbox::SAMRAIManager::finalize();
  SAMRAI::tbox::SAMRAI_MPI::finalize();
}
```