### PR TITLE
Only conditionally add source/tests as subdirectory to CMake.

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,2 +1,5 @@
 add_subdirectory(SAMRAI)
-add_subdirectory(test)
+
+if (ENABLE_TESTS)
+  add_subdirectory(test)
+endif()


### PR DESCRIPTION
This works in my local CI builds, where I use SAMRAI as a dependency and do not need to build the tests.