### PR TITLE
Parallel test changes

### DIFF
--- a/cmake/SAMRAIMacros.cmake
+++ b/cmake/SAMRAIMacros.cmake
@@ -3,6 +3,7 @@ macro (samrai_add_tests)
   set(singleValueArgs NAME EXECUTABLE PARALLEL)
   set(multiValueArgs INPUTS)
   set(counter 0)
+  set(base_name ${arg_NAME})
 
   cmake_parse_arguments(arg
       "${options}" "${singleValueArgs}" "${multiValueArgs}" ${ARGN} )
@@ -11,14 +12,29 @@ macro (samrai_add_tests)
 
     math(EXPR counter "${counter}+1")
 
+
     message(STATUS "Test: ${arg_NAME} with input ${test_file}")
 
     get_filename_component(short_test_file ${test_file} NAME)
-    set(test_name "${arg_NAME}_test_${short_test_file}")
+    set(test_name "${base_name}_test_${short_test_file}")
 
-    add_test(NAME ${test_name}
-      COMMAND $<TARGET_FILE:${arg_EXECUTABLE}> ${test_file}
+    blt_add_test(NAME ${test_name}
+      COMMAND ${arg_EXECUTABLE} ${test_file}
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+    if(${arg_PARALLEL})
+      set(test_name "${base_name}_test_${short_test_file}_2")
+      blt_add_test(NAME ${test_name}
+        COMMAND ${arg_EXECUTABLE} ${test_file}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        NUM_MPI_TASKS 2)
+
+      set(test_name "${base_name}_test_${short_test_file}_4")
+      blt_add_test(NAME ${test_name}
+        COMMAND ${arg_EXECUTABLE} ${test_file}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        NUM_MPI_TASKS 4)
+    endif()
 
     set_tests_properties(${test_name} PROPERTIES PASS_REGULAR_EXPRESSION "PASSED")
 

--- a/cmake/SAMRAIMacros.cmake
+++ b/cmake/SAMRAIMacros.cmake
@@ -2,16 +2,12 @@ macro (samrai_add_tests)
 
   set(singleValueArgs NAME EXECUTABLE PARALLEL)
   set(multiValueArgs INPUTS)
-  set(counter 0)
   set(base_name ${arg_NAME})
 
   cmake_parse_arguments(arg
       "${options}" "${singleValueArgs}" "${multiValueArgs}" ${ARGN} )
 
   foreach (test_file ${arg_INPUTS})
-
-    math(EXPR counter "${counter}+1")
-
 
     message(STATUS "Test: ${arg_NAME} with input ${test_file}")
 

--- a/source/test/MblkEuler/CMakeLists.txt
+++ b/source/test/MblkEuler/CMakeLists.txt
@@ -20,3 +20,12 @@ blt_add_executable(
     ${mblkeuler_depends_on})
 
 target_compile_definitions(mblkeuler PUBLIC TESTING=1)
+
+file (GLOB test_inputs ${CMAKE_CURRENT_SOURCE_DIR}/test_inputs/*.input)
+
+samrai_add_tests(
+  NAME mblkeuler
+  EXECUTABLE mblkeuler
+  INPUTS ${test_inputs}
+  PARALLEL TRUE)
+

--- a/source/test/applications/ConvDiff/CMakeLists.txt
+++ b/source/test/applications/ConvDiff/CMakeLists.txt
@@ -41,3 +41,12 @@ target_include_directories(
   PUBLIC ${PROJECT_SOURCE_DIR}/source/test/applications/ConvDiff)
 
 set_target_properties(convdiff PROPERTIES LINKER_LANGUAGE CXX)
+
+file (GLOB test_inputs ${CMAKE_CURRENT_SOURCE_DIR}/test_inputs/*.input)
+
+samrai_add_tests(
+  NAME convdiff
+  EXECUTABLE convdiff
+  INPUTS ${test_inputs}
+  PARALLEL TRUE)
+

--- a/source/test/applications/Euler/CMakeLists.txt
+++ b/source/test/applications/Euler/CMakeLists.txt
@@ -57,3 +57,12 @@ target_include_directories( euler
   PUBLIC ${PROJECT_SOURCE_DIR}/source/test/applications/Euler)
 
 set_target_properties(euler PROPERTIES LINKER_LANGUAGE CXX)
+
+file (GLOB test_inputs ${CMAKE_CURRENT_SOURCE_DIR}/test_inputs/*.input)
+
+samrai_add_tests(
+  NAME euler
+  EXECUTABLE euler
+  INPUTS ${test_inputs}
+  PARALLEL TRUE)
+

--- a/source/test/applications/LinAdv/CMakeLists.txt
+++ b/source/test/applications/LinAdv/CMakeLists.txt
@@ -47,3 +47,12 @@ target_include_directories( linadv
   PUBLIC ${PROJECT_SOURCE_DIR}/source/test/applications/LinAdv)
 
 set_target_properties(linadv PROPERTIES LINKER_LANGUAGE CXX)
+
+file (GLOB test_inputs ${CMAKE_CURRENT_SOURCE_DIR}/test_inputs/*.input)
+
+samrai_add_tests(
+  NAME linadv
+  EXECUTABLE linadv
+  INPUTS ${test_inputs}
+  PARALLEL TRUE)
+

--- a/source/test/mblktree/CMakeLists.txt
+++ b/source/test/mblktree/CMakeLists.txt
@@ -21,4 +21,4 @@ samrai_add_tests(
   NAME mblktree
   EXECUTABLE mblktree
   INPUTS ${test_inputs}
-  PARALLEL TRUE)
+  PARALLEL FALSE)

--- a/source/test/mblktree/main-mbtree.C
+++ b/source/test/mblktree/main-mbtree.C
@@ -85,7 +85,7 @@ int main(
    }
 
    int fail_count = 0;
-
+#ifdef HAVE_HDF5
    {
 
       /*
@@ -404,7 +404,7 @@ int main(
       tbox::plog << "\nShutting down..." << std::endl;
 
    }
-
+#endif
    /*
     * Shut down.
     */

--- a/source/test/performance/MeshGeneration/CMakeLists.txt
+++ b/source/test/performance/MeshGeneration/CMakeLists.txt
@@ -16,3 +16,12 @@ blt_add_executable(
   DEPENDS_ON ${meshgeneration_depends_on})
 
 target_compile_definitions(meshgeneration PUBLIC TESTING=1)
+
+file (GLOB test_inputs ${CMAKE_CURRENT_SOURCE_DIR}/test_inputs/*.input)
+
+samrai_add_tests(
+  NAME meshgeneration
+  EXECUTABLE meshgeneration
+  INPUTS ${test_inputs}
+  PARALLEL TRUE)
+

--- a/source/test/performance/TreeCommunication/CMakeLists.txt
+++ b/source/test/performance/TreeCommunication/CMakeLists.txt
@@ -8,3 +8,12 @@ blt_add_executable(
     SAMRAI_tbox)
 
 target_compile_definitions(treecommunication PUBLIC TESTING=1)
+
+file (GLOB test_inputs ${CMAKE_CURRENT_SOURCE_DIR}/test_inputs/*.input)
+
+samrai_add_tests(
+  NAME treecommunication
+  EXECUTABLE treecommunication
+  INPUTS ${test_inputs}
+  PARALLEL TRUE)
+

--- a/source/test/rank_group/main.C
+++ b/source/test/rank_group/main.C
@@ -203,7 +203,7 @@ int main(
       if (main_db->isInteger("min_size")) {
          main_db->getIntegerArray("min_size", &min_size[0], dimval);
       }
-      hier::IntVector max_size(dim, INT_MAX);
+      hier::IntVector max_size(dim, tbox::MathUtilities<int>::getMax());
       if (main_db->isInteger("max_size")) {
          main_db->getIntegerArray("max_size", &max_size[0], dimval);
       }


### PR DESCRIPTION
The biggest change is to the samrai_add_tests macro, creating tests of 1, 2, and 4 MPI ranks when PARALLEL is true.

Some things remaining to be done:

 - [ ] Make sure make clean and make distclean work -- including cleanup of output files produced by tests
 - [ ] A serial-only target for testing
 - [ ] Recommended host-configs or cmake command lines