### PR TITLE
Remove "using namespace std" from the code (mostly in tests)

### DIFF
--- a/config/config.guess
+++ b/config/config.guess
@@ -3,7 +3,7 @@
 #   Copyright (C) 1992, 1993, 1994, 1995, 1996, 1997, 1998, 1999,
 #   2000, 2001, 2002, 2003 Free Software Foundation, Inc.
 
-timestamp='2003-05-09'
+timestamp='2019-05-08'
 
 # This file is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -844,6 +844,9 @@ EOF
     ppc:Linux:*:*)
 	echo powerpc-unknown-linux-gnu
 	exit 0 ;;
+    ppc64le:Linux:*:*)
+	echo powerpc64-unknown-linux-gnu
+	exit ;;
     ppc64:Linux:*:*)
 	echo powerpc64-unknown-linux-gnu
 	exit 0 ;;

--- a/source/SAMRAI/algs/ImplicitIntegrator.C
+++ b/source/SAMRAI/algs/ImplicitIntegrator.C
@@ -22,8 +22,6 @@ namespace algs {
 
 const int ImplicitIntegrator::ALGS_IMPLICIT_INTEGRATOR_VERSION = 1;
 
-// using namespace std;
-
 /*
  *************************************************************************
  *

--- a/source/SAMRAI/appu/CartesianBoundaryUtilities3.C
+++ b/source/SAMRAI/appu/CartesianBoundaryUtilities3.C
@@ -99,8 +99,6 @@ void SAMRAI_F77_FUNC(getcartnodebdry3d, GETCARTNODEBDRY3D) (const int&, const in
 namespace SAMRAI {
 namespace appu {
 
-// using namespace std;
-
 bool CartesianBoundaryUtilities3::s_fortran_constants_stuffed = false;
 
 /*

--- a/source/SAMRAI/appu/VisMaterialsDataStrategy.C
+++ b/source/SAMRAI/appu/VisMaterialsDataStrategy.C
@@ -15,8 +15,6 @@
 namespace SAMRAI {
 namespace appu {
 
-// using namespace std;
-
 VisMaterialsDataStrategy::VisMaterialsDataStrategy()
 {
 }

--- a/source/SAMRAI/geom/CartesianCellComplexConservativeLinearRefine.C
+++ b/source/SAMRAI/geom/CartesianCellComplexConservativeLinearRefine.C
@@ -69,7 +69,6 @@ void SAMRAI_F77_FUNC(cartclinrefcellcplx3d, CARTCLINREFCELLCPLX3D) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianCellComplexConservativeLinearRefine::
 CartesianCellComplexConservativeLinearRefine():

--- a/source/SAMRAI/geom/CartesianCellComplexLinearRefine.C
+++ b/source/SAMRAI/geom/CartesianCellComplexLinearRefine.C
@@ -67,7 +67,6 @@ void SAMRAI_F77_FUNC(cartlinrefcellcplx3d, CARTLINREFCELLCPLX3D) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianCellComplexLinearRefine::CartesianCellComplexLinearRefine():
    hier::RefineOperator("LINEAR_REFINE")

--- a/source/SAMRAI/geom/CartesianCellComplexWeightedAverage.C
+++ b/source/SAMRAI/geom/CartesianCellComplexWeightedAverage.C
@@ -71,7 +71,6 @@ void SAMRAI_F77_FUNC(cartwgtavgcellcplx4d, CARTWGTAVGCELLCPLX4D) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianCellComplexWeightedAverage::CartesianCellComplexWeightedAverage():
    hier::CoarsenOperator("CONSERVATIVE_COARSEN")

--- a/source/SAMRAI/geom/CartesianCellDoubleConservativeLinearRefine.C
+++ b/source/SAMRAI/geom/CartesianCellDoubleConservativeLinearRefine.C
@@ -76,7 +76,6 @@ void SAMRAI_F77_FUNC(cartclinrefcelldoub3d, CARTCLINREFCELLDOUB3D) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianCellDoubleConservativeLinearRefine::
 CartesianCellDoubleConservativeLinearRefine():

--- a/source/SAMRAI/geom/CartesianCellDoubleLinearRefine.C
+++ b/source/SAMRAI/geom/CartesianCellDoubleLinearRefine.C
@@ -64,7 +64,6 @@ void SAMRAI_F77_FUNC(cartlinrefcelldoub3d, CARTLINREFCELLDOUB3D) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianCellDoubleLinearRefine::CartesianCellDoubleLinearRefine():
    hier::RefineOperator("LINEAR_REFINE")

--- a/source/SAMRAI/geom/CartesianCellFloatConservativeLinearRefine.C
+++ b/source/SAMRAI/geom/CartesianCellFloatConservativeLinearRefine.C
@@ -68,7 +68,6 @@ void SAMRAI_F77_FUNC(cartclinrefcellflot3d, CARTCLINREFCELLFLOT3D) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianCellFloatConservativeLinearRefine::
 CartesianCellFloatConservativeLinearRefine():

--- a/source/SAMRAI/geom/CartesianCellFloatLinearRefine.C
+++ b/source/SAMRAI/geom/CartesianCellFloatLinearRefine.C
@@ -64,7 +64,6 @@ void SAMRAI_F77_FUNC(cartlinrefcellflot3d, CARTLINREFCELLFLOT3D) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianCellFloatLinearRefine::CartesianCellFloatLinearRefine():
    hier::RefineOperator("LINEAR_REFINE")

--- a/source/SAMRAI/geom/CartesianCellFloatWeightedAverage.C
+++ b/source/SAMRAI/geom/CartesianCellFloatWeightedAverage.C
@@ -70,7 +70,6 @@ void SAMRAI_F77_FUNC(cartwgtavgcellflot4d, CARTWGTAVGCELLFLOT4D) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianCellFloatWeightedAverage::CartesianCellFloatWeightedAverage():
    hier::CoarsenOperator("CONSERVATIVE_COARSEN")

--- a/source/SAMRAI/geom/CartesianEdgeComplexWeightedAverage.C
+++ b/source/SAMRAI/geom/CartesianEdgeComplexWeightedAverage.C
@@ -86,7 +86,6 @@ void SAMRAI_F77_FUNC(cartwgtavgedgecplx3d2, CARTWGTAVGEDGECPLX3D2) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianEdgeComplexWeightedAverage::CartesianEdgeComplexWeightedAverage():
    hier::CoarsenOperator("CONSERVATIVE_COARSEN")

--- a/source/SAMRAI/geom/CartesianEdgeDoubleConservativeLinearRefine.C
+++ b/source/SAMRAI/geom/CartesianEdgeDoubleConservativeLinearRefine.C
@@ -102,7 +102,6 @@ void SAMRAI_F77_FUNC(cartclinrefedgedoub3d2, CARTCLINREFEDGEDOUB3D2) (const int&
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianEdgeDoubleConservativeLinearRefine::
 CartesianEdgeDoubleConservativeLinearRefine():

--- a/source/SAMRAI/geom/CartesianEdgeDoubleWeightedAverage.C
+++ b/source/SAMRAI/geom/CartesianEdgeDoubleWeightedAverage.C
@@ -85,7 +85,6 @@ void SAMRAI_F77_FUNC(cartwgtavgedgedoub3d2, CARTWGTAVGEDGEDOUB3D2) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianEdgeDoubleWeightedAverage::CartesianEdgeDoubleWeightedAverage():
    hier::CoarsenOperator("CONSERVATIVE_COARSEN")

--- a/source/SAMRAI/geom/CartesianEdgeFloatConservativeLinearRefine.C
+++ b/source/SAMRAI/geom/CartesianEdgeFloatConservativeLinearRefine.C
@@ -101,7 +101,6 @@ void SAMRAI_F77_FUNC(cartclinrefedgeflot3d2, CARTCLINREFEDGEFLOT3D2) (const int&
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianEdgeFloatConservativeLinearRefine::
 CartesianEdgeFloatConservativeLinearRefine():

--- a/source/SAMRAI/geom/CartesianEdgeFloatWeightedAverage.C
+++ b/source/SAMRAI/geom/CartesianEdgeFloatWeightedAverage.C
@@ -85,7 +85,6 @@ void SAMRAI_F77_FUNC(cartwgtavgedgeflot3d2, CARTWGTAVGEDGEFLOT3D2) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianEdgeFloatWeightedAverage::CartesianEdgeFloatWeightedAverage():
    hier::CoarsenOperator("CONSERVATIVE_COARSEN")

--- a/source/SAMRAI/geom/CartesianFaceComplexWeightedAverage.C
+++ b/source/SAMRAI/geom/CartesianFaceComplexWeightedAverage.C
@@ -123,7 +123,6 @@ void SAMRAI_F77_FUNC(cartwgtavgfacecplx4d3, CARTWGTAVGFACECPLX4D3) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianFaceComplexWeightedAverage::CartesianFaceComplexWeightedAverage():
    hier::CoarsenOperator("CONSERVATIVE_COARSEN")

--- a/source/SAMRAI/geom/CartesianFaceDoubleConservativeLinearRefine.C
+++ b/source/SAMRAI/geom/CartesianFaceDoubleConservativeLinearRefine.C
@@ -102,7 +102,6 @@ void SAMRAI_F77_FUNC(cartclinreffacedoub3d2, CARTCLINREFFACEDOUB3D2) (const int&
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianFaceDoubleConservativeLinearRefine::
 CartesianFaceDoubleConservativeLinearRefine():

--- a/source/SAMRAI/geom/CartesianFaceDoubleWeightedAverage.C
+++ b/source/SAMRAI/geom/CartesianFaceDoubleWeightedAverage.C
@@ -122,7 +122,6 @@ void SAMRAI_F77_FUNC(cartwgtavgfacedoub4d3, CARTWGTAVGFACEDOUB4D3) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianFaceDoubleWeightedAverage::CartesianFaceDoubleWeightedAverage():
    hier::CoarsenOperator("CONSERVATIVE_COARSEN")

--- a/source/SAMRAI/geom/CartesianFaceFloatWeightedAverage.C
+++ b/source/SAMRAI/geom/CartesianFaceFloatWeightedAverage.C
@@ -122,7 +122,6 @@ void SAMRAI_F77_FUNC(cartwgtavgfaceflot4d3, CARTWGTAVGFACEFLOT4D3) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianFaceFloatWeightedAverage::CartesianFaceFloatWeightedAverage():
    hier::CoarsenOperator("CONSERVATIVE_COARSEN")

--- a/source/SAMRAI/geom/CartesianNodeComplexLinearRefine.C
+++ b/source/SAMRAI/geom/CartesianNodeComplexLinearRefine.C
@@ -65,7 +65,6 @@ void SAMRAI_F77_FUNC(cartlinrefnodecplx3d, CARTLINREFNODECPLX3D) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianNodeComplexLinearRefine::CartesianNodeComplexLinearRefine():
    hier::RefineOperator("LINEAR_REFINE")

--- a/source/SAMRAI/geom/CartesianNodeDoubleLinearRefine.C
+++ b/source/SAMRAI/geom/CartesianNodeDoubleLinearRefine.C
@@ -64,7 +64,6 @@ void SAMRAI_F77_FUNC(cartlinrefnodedoub3d, CARTLINREFNODEDOUB3D) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianNodeDoubleLinearRefine::CartesianNodeDoubleLinearRefine():
    hier::RefineOperator("LINEAR_REFINE")

--- a/source/SAMRAI/geom/CartesianOuterfaceComplexWeightedAverage.C
+++ b/source/SAMRAI/geom/CartesianOuterfaceComplexWeightedAverage.C
@@ -92,7 +92,6 @@ void SAMRAI_F77_FUNC(cartwgtavgoutfacecplx3d2, CARTWGTAVGOUTFACECPLX3D2) (const 
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianOuterfaceComplexWeightedAverage::
 CartesianOuterfaceComplexWeightedAverage():

--- a/source/SAMRAI/geom/CartesianOuterfaceDoubleWeightedAverage.C
+++ b/source/SAMRAI/geom/CartesianOuterfaceDoubleWeightedAverage.C
@@ -91,7 +91,6 @@ void SAMRAI_F77_FUNC(cartwgtavgoutfacedoub3d2, CARTWGTAVGOUTFACEDOUB3D2) (const 
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianOuterfaceDoubleWeightedAverage::
 CartesianOuterfaceDoubleWeightedAverage():

--- a/source/SAMRAI/geom/CartesianOuterfaceFloatWeightedAverage.C
+++ b/source/SAMRAI/geom/CartesianOuterfaceFloatWeightedAverage.C
@@ -91,7 +91,6 @@ void SAMRAI_F77_FUNC(cartwgtavgoutfaceflot3d2, CARTWGTAVGOUTFACEFLOT3D2) (const 
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianOuterfaceFloatWeightedAverage::CartesianOuterfaceFloatWeightedAverage():
    hier::CoarsenOperator("CONSERVATIVE_COARSEN")

--- a/source/SAMRAI/geom/CartesianOutersideDoubleWeightedAverage.C
+++ b/source/SAMRAI/geom/CartesianOutersideDoubleWeightedAverage.C
@@ -91,7 +91,6 @@ void SAMRAI_F77_FUNC(cartwgtavgoutsidedoub3d2, CARTWGTAVGOUTSIDEDOUB3D2) (const 
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianOutersideDoubleWeightedAverage::
 CartesianOutersideDoubleWeightedAverage():

--- a/source/SAMRAI/geom/CartesianPatchGeometry.C
+++ b/source/SAMRAI/geom/CartesianPatchGeometry.C
@@ -13,7 +13,6 @@
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 /*
  *************************************************************************

--- a/source/SAMRAI/geom/CartesianSideComplexWeightedAverage.C
+++ b/source/SAMRAI/geom/CartesianSideComplexWeightedAverage.C
@@ -86,7 +86,6 @@ void SAMRAI_F77_FUNC(cartwgtavgsidecplx3d2, CARTWGTAVGSIDECPLX3D2) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianSideComplexWeightedAverage::CartesianSideComplexWeightedAverage():
    hier::CoarsenOperator("CONSERVATIVE_COARSEN")

--- a/source/SAMRAI/geom/CartesianSideDoubleWeightedAverage.C
+++ b/source/SAMRAI/geom/CartesianSideDoubleWeightedAverage.C
@@ -85,7 +85,6 @@ void SAMRAI_F77_FUNC(cartwgtavgsidedoub3d2, CARTWGTAVGSIDEDOUB3D2) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianSideDoubleWeightedAverage::CartesianSideDoubleWeightedAverage():
    hier::CoarsenOperator("CONSERVATIVE_COARSEN")

--- a/source/SAMRAI/geom/CartesianSideFloatConservativeLinearRefine.C
+++ b/source/SAMRAI/geom/CartesianSideFloatConservativeLinearRefine.C
@@ -101,7 +101,6 @@ void SAMRAI_F77_FUNC(cartclinrefsideflot3d2, CARTCLINREFSIDEFLOT3D2) (const int&
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianSideFloatConservativeLinearRefine::
 CartesianSideFloatConservativeLinearRefine():

--- a/source/SAMRAI/geom/CartesianSideFloatWeightedAverage.C
+++ b/source/SAMRAI/geom/CartesianSideFloatWeightedAverage.C
@@ -85,7 +85,6 @@ void SAMRAI_F77_FUNC(cartwgtavgsideflot3d2, CARTWGTAVGSIDEFLOT3D2) (const int&,
 namespace SAMRAI {
 namespace geom {
 
-// using namespace std;
 
 CartesianSideFloatWeightedAverage::CartesianSideFloatWeightedAverage():
    hier::CoarsenOperator("CONSERVATIVE_COARSEN")

--- a/source/SAMRAI/mesh/LoadBalanceStrategy.C
+++ b/source/SAMRAI/mesh/LoadBalanceStrategy.C
@@ -22,8 +22,6 @@
 namespace SAMRAI {
 namespace mesh {
 
-// using namespace std;
-
 int LoadBalanceStrategy::s_sequence_number = 0;
 
 /*

--- a/source/SAMRAI/mesh/SpatialKey.C
+++ b/source/SAMRAI/mesh/SpatialKey.C
@@ -26,8 +26,6 @@ namespace mesh {
 const int SpatialKey::BITS_PER_BYTE = 8;
 const int SpatialKey::BITS_PER_HEX_CHAR = 4;
 
-// using namespace std;
-
 /*
  ****************************************************************************
  *

--- a/source/SAMRAI/mesh/StandardTagAndInitStrategy.C
+++ b/source/SAMRAI/mesh/StandardTagAndInitStrategy.C
@@ -14,8 +14,6 @@
 namespace SAMRAI {
 namespace mesh {
 
-// using namespace std;
-
 StandardTagAndInitStrategy::StandardTagAndInitStrategy()
 {
 }

--- a/source/SAMRAI/mesh/StandardTagAndInitialize.C
+++ b/source/SAMRAI/mesh/StandardTagAndInitialize.C
@@ -67,8 +67,6 @@ void SAMRAI_F77_FUNC(coarsentags3d, COARSENTAGS3D) (const int&, const int&,
 namespace SAMRAI {
 namespace mesh {
 
-// using namespace std;
-
 /*
  *************************************************************************
  *

--- a/source/SAMRAI/solv/CartesianRobinBcHelper.C
+++ b/source/SAMRAI/solv/CartesianRobinBcHelper.C
@@ -76,8 +76,6 @@ void SAMRAI_F77_FUNC(settype3cells3d, SETTYPE3CELLS3D) (
 namespace SAMRAI {
 namespace solv {
 
-// using namespace std;
-
 /*
  ************************************************************************
  * Constructor

--- a/source/SAMRAI/solv/FACPreconditioner.C
+++ b/source/SAMRAI/solv/FACPreconditioner.C
@@ -18,8 +18,6 @@
 namespace SAMRAI {
 namespace solv {
 
-// using namespace std;
-
 /*
  *************************************************************************
  *

--- a/source/SAMRAI/solv/GhostCellRobinBcCoefs.C
+++ b/source/SAMRAI/solv/GhostCellRobinBcCoefs.C
@@ -23,8 +23,6 @@
 namespace SAMRAI {
 namespace solv {
 
-// using namespace std;
-
 /*
  ************************************************************************
  * Constructor

--- a/source/SAMRAI/tbox/Grammar.C
+++ b/source/SAMRAI/tbox/Grammar.C
@@ -187,10 +187,9 @@
 
 #include STL_SSTREAM_HEADER_FILE
 
-using namespace std;
 
 #if !defined(OSTRINGSTREAM_TYPE_IS_BROKEN) && defined(OSTRSTREAM_TYPE_IS_BROKEN)
-typedef ostringstream ostrstream;
+typedef std::ostringstream ostrstream;
 #endif
 
 #include "SAMRAI/tbox/Dimension.h"
@@ -206,8 +205,6 @@ typedef ostringstream ostrstream;
 #pragma report(disable, CPPC5334)
 #pragma report(disable, CPPC5328)
 #endif
-
-using namespace std;
 
 using namespace SAMRAI;
 using namespace tbox;
@@ -229,7 +226,7 @@ void yyerror(const char *const error)
 #define KEY_CHAR    (5)
 #define KEY_STRING  (6)
 
-static string type_names[] = {
+static std::string type_names[] = {
    "complex", "double", "int", "bool", "box", "char", "string"
 };
 
@@ -248,7 +245,7 @@ struct KeyData
    dcomplex        d_complex;	// complex if node is KEY_COMPLEX
    double          d_double;	// double if node is KEY_DOUBLE
    int             d_integer;	// integer if node is KEY_INTEGER
-   string          d_string;	// string if node is KEY_STRING
+   std::string     d_string;	// string if node is KEY_STRING
 };
 
 static void delete_list(KeyData*);
@@ -258,8 +255,8 @@ static void to_double(KeyData*);
 static void to_complex(KeyData*);
 static KeyData* binary_op(KeyData*, KeyData*, const int);
 static KeyData* compare_op(KeyData*, KeyData*, const int);
-static KeyData* eval_function(KeyData*, const string&);
-static KeyData* lookup_variable(const string&, const size_t, const bool);
+static KeyData* eval_function(KeyData*, const std::string&);
+static KeyData* lookup_variable(const std::string&, const size_t, const bool);
 
 
 
@@ -289,8 +286,8 @@ typedef union YYSTYPE
   double        u_double;
   int           u_integer;
   KeyData* u_keydata;
-  string*       u_keyword;
-  string*       u_string;
+  std::string*  u_keyword;
+  std::string*  u_string;
 }
 /* Line 193 of yacc.c.  */
 
@@ -1613,7 +1610,7 @@ yyreduce:
    }
 
       if (Parser::getParser()->getScope()->keyExists(*(yyvsp[(1) - (2)].u_keyword))) {
-	 string tmp("Redefinition of key ``");
+	 std::string tmp("Redefinition of key ``");
          tmp += *(yyvsp[(1) - (2)].u_keyword);
          tmp += "''";
          Parser::getParser()->warning(tmp);
@@ -1634,7 +1631,7 @@ yyreduce:
 
     {
       if (Parser::getParser()->getScope()->keyExists(*(yyvsp[(1) - (2)].u_keyword))) {
-	 string tmp("Redefinition of key ``");
+	 std::string tmp("Redefinition of key ``");
          tmp += *(yyvsp[(1) - (2)].u_keyword);
          tmp += "''";
          Parser::getParser()->warning(tmp);
@@ -1706,7 +1703,7 @@ yyreduce:
             break;
          }
          case KEY_STRING: {
-            std::vector<string> data(n);
+            std::vector<std::string> data(n);
             for (int i = n-1; i >= 0; i--) {
                data[i] = list->d_string;
                list = list->d_next;
@@ -1932,7 +1929,7 @@ yyreduce:
 
     {
       if (((yyvsp[(1) - (3)].u_keydata)->d_node_type == KEY_STRING) && ((yyvsp[(3) - (3)].u_keydata)->d_node_type == KEY_STRING)) {
-	 string tmp((yyvsp[(1) - (3)].u_keydata)->d_string);
+	 std::string tmp((yyvsp[(1) - (3)].u_keydata)->d_string);
 	 tmp += (yyvsp[(3) - (3)].u_keydata)->d_string;
          (yyvsp[(1) - (3)].u_keydata)->d_string = tmp;
          delete (yyvsp[(3) - (3)].u_keydata);
@@ -2649,7 +2646,7 @@ static KeyData* compare_op(KeyData* a, KeyData* b, const int op)
  */
 
 struct arith_functions {
-   string     d_name;
+   std::string     d_name;
    double   (*d_r2r_func)(double);
    dcomplex (*d_c2c_func)(const dcomplex&);
    double   (*d_c2r_func)(const dcomplex&);
@@ -2729,7 +2726,7 @@ void parser_static_table_initialize()
 
    af[5].d_name =    "conj";
    af[5].d_r2r_func = 0;
-   af[5].d_c2c_func = conj;
+   af[5].d_c2c_func = std::conj;
    af[5].d_c2r_func = 0;
 
 
@@ -2804,10 +2801,10 @@ void parser_static_table_initialize()
    af[19].d_c2r_func = 0;
 }
 
-static KeyData* eval_function(KeyData* arg, const string& func)
+static KeyData* eval_function(KeyData* arg, const std::string& func)
 {
    if (!IS_NUMBER(arg->d_node_type)) {
-      string tmp("Unknown function ");
+      std::string tmp("Unknown function ");
       tmp += func;
       tmp += "(";
       tmp += type_names[arg->d_node_type];
@@ -2850,7 +2847,7 @@ static KeyData* eval_function(KeyData* arg, const string& func)
          }
       }
 
-      string tmp("Unknown function ");
+      std::string tmp("Unknown function ");
       tmp += func;
       tmp += "(";
       tmp += type_names[arg->d_node_type];
@@ -2866,7 +2863,7 @@ static KeyData* eval_function(KeyData* arg, const string& func)
  */
 
 static KeyData* lookup_variable(
-   const string& key, const size_t index, const bool is_array)
+   const std::string& key, const size_t index, const bool is_array)
 {
    KeyData* result = new KeyData;
    result->d_node_type  = KEY_INTEGER;
@@ -2879,19 +2876,19 @@ static KeyData* lookup_variable(
    std::shared_ptr<Database> db(parser->getDatabaseWithKey(key));
 
    if (!db) {
-      string tmp("Variable ``");
+      std::string tmp("Variable ``");
       tmp += key;
       tmp += "'' not found in database";
       parser->error(tmp);
    } else if (!is_array && (db->getArraySize(key) > 1)) {
-      string tmp("Variable ``");
+      std::string tmp("Variable ``");
       tmp += key;
       tmp += "'' is not a scalar value";
       parser->error(tmp);
    } else if (index >= db->getArraySize(key)) {
       ostrstream oss;
       oss << index;
-      string tmp("Variable ``");
+      std::string tmp("Variable ``");
       tmp += key;
       tmp += "[";
       tmp += oss.str();

--- a/source/SAMRAI/tbox/Grammar.h
+++ b/source/SAMRAI/tbox/Grammar.h
@@ -120,8 +120,8 @@ typedef union YYSTYPE
   double        u_double;
   int           u_integer;
   KeyData* u_keydata;
-  string*       u_keyword;
-  string*       u_string;
+  std::string*       u_keyword;
+  std::string*       u_string;
 }
 /* Line 1529 of yacc.c.  */
 

--- a/source/SAMRAI/tbox/Grammar.y
+++ b/source/SAMRAI/tbox/Grammar.y
@@ -12,7 +12,6 @@
 
 #include STL_SSTREAM_HEADER_FILE
 
-using namespace std;
 
 #if !defined(OSTRINGSTREAM_TYPE_IS_BROKEN) && defined(OSTRSTREAM_TYPE_IS_BROKEN)
 typedef ostringstream ostrstream;
@@ -33,7 +32,6 @@ typedef ostringstream ostrstream;
 #pragma report(disable, CPPC5328)
 #endif
 
-using namespace std;
 
 using namespace SAMRAI;
 using namespace tbox;
@@ -55,7 +53,7 @@ void yyerror(const char *const error)
 #define KEY_CHAR    (5)
 #define KEY_STRING  (6)
 
-static string type_names[] = {
+static std::string type_names[] = {
    "complex", "double", "int", "bool", "box", "char", "string"
 };
 
@@ -74,7 +72,7 @@ struct KeyData
    dcomplex        d_complex;	// complex if node is KEY_COMPLEX
    double          d_double;	// double if node is KEY_DOUBLE
    int             d_integer;	// integer if node is KEY_INTEGER
-   string          d_string;	// string if node is KEY_STRING
+   std::string     d_string;	// string if node is KEY_STRING
 };
 
 static void delete_list(KeyData*);
@@ -84,8 +82,8 @@ static void to_double(KeyData*);
 static void to_complex(KeyData*);
 static KeyData* binary_op(KeyData*, KeyData*, const int);
 static KeyData* compare_op(KeyData*, KeyData*, const int);
-static KeyData* eval_function(KeyData*, const string&);
-static KeyData* lookup_variable(const string&, const int, const bool);
+static KeyData* eval_function(KeyData*, const std::string&);
+static KeyData* lookup_variable(const std::string&, const int, const bool);
 
 %}
 
@@ -95,8 +93,8 @@ static KeyData* lookup_variable(const string&, const int, const bool);
   double        u_double;
   int           u_integer;
   KeyData* u_keydata;
-  string*       u_keyword;
-  string*       u_string;
+  std::string*       u_keyword;
+  std::string*       u_string;
 }
 
 %token             T_AND
@@ -184,7 +182,7 @@ P_DEFINITION
    }
 
       if (Parser::getParser()->getScope()->keyExists(*$1)) {
-	 string tmp("Redefinition of key ``");
+	 std::string tmp("Redefinition of key ``");
          tmp += *$1;
          tmp += "''";
          Parser::getParser()->warning(tmp);
@@ -196,7 +194,7 @@ P_DEFINITION
    }
  | T_KEYWORD T_ASSIGN {
       if (Parser::getParser()->getScope()->keyExists(*$1)) {
-	 string tmp("Redefinition of key ``");
+	 std::string tmp("Redefinition of key ``");
          tmp += *$1;
          tmp += "''";
          Parser::getParser()->warning(tmp);
@@ -263,7 +261,7 @@ P_DEFINITION
             break;
          }
          case KEY_STRING: {
-            std::vector<string> data(n);
+            std::vector<std:string> data(n);
             for (int i = n-1; i >= 0; i--) {
                data[i] = list->d_string;
                list = list->d_next;
@@ -450,7 +448,7 @@ P_EXPRESSION
    }
  | P_EXPRESSION T_PLUS P_EXPRESSION {
       if (($1->d_node_type == KEY_STRING) && ($3->d_node_type == KEY_STRING)) {
-	 string tmp($1->d_string);
+	 std::string tmp($1->d_string);
 	 tmp += $3->d_string;
          $1->d_string = tmp;
          delete $3;
@@ -916,7 +914,7 @@ static KeyData* compare_op(KeyData* a, KeyData* b, const int op)
  */
 
 struct arith_functions {
-   string     d_name;
+   std::string     d_name;
    double   (*d_r2r_func)(double);
    dcomplex (*d_c2c_func)(const dcomplex&);
    double   (*d_c2r_func)(const dcomplex&);
@@ -1071,10 +1069,10 @@ void parser_static_table_initialize()
    af[19].d_c2r_func = 0;
 }
 
-static KeyData* eval_function(KeyData* arg, const string& func)
+static KeyData* eval_function(KeyData* arg, const std::string& func)
 {
    if (!IS_NUMBER(arg->d_node_type)) {
-      string tmp("Unknown function ");
+      std::string tmp("Unknown function ");
       tmp += func;
       tmp += "(";
       tmp += type_names[arg->d_node_type];
@@ -1117,7 +1115,7 @@ static KeyData* eval_function(KeyData* arg, const string& func)
          }
       }
 
-      string tmp("Unknown function ");
+      std::string tmp("Unknown function ");
       tmp += func;
       tmp += "(";
       tmp += type_names[arg->d_node_type];
@@ -1133,7 +1131,7 @@ static KeyData* eval_function(KeyData* arg, const string& func)
  */
 
 static KeyData* lookup_variable(
-   const string& key, const int index, const bool is_array)
+   const std::string& key, const int index, const bool is_array)
 {
    KeyData* result = new KeyData;
    result->d_node_type  = KEY_INTEGER;
@@ -1146,19 +1144,19 @@ static KeyData* lookup_variable(
    std::shared_ptr<Database> db(parser->getDatabaseWithKey(key));
 
    if (!db) {
-      string tmp("Variable ``");
+      std::string tmp("Variable ``");
       tmp += key;
       tmp += "'' not found in database";
       parser->error(tmp);
    } else if (!is_array && (db->getArraySize(key) > 1)) {
-      string tmp("Variable ``");
+      std::string tmp("Variable ``");
       tmp += key;
       tmp += "'' is not a scalar value";
       parser->error(tmp);
    } else if ((index < 0) || (index >= db->getArraySize(key))) {
       ostrstream oss;
       oss << index;
-      string tmp("Variable ``");
+      std::string tmp("Variable ``");
       tmp += key;
       tmp += "[";
       tmp += oss.str();

--- a/source/SAMRAI/tbox/SAMRAI_MPI.C
+++ b/source/SAMRAI/tbox/SAMRAI_MPI.C
@@ -19,10 +19,6 @@
 #endif
 
 #include <stdlib.h>
-#include <string.h>
-
-#include <string>
-using namespace std;
 
 #include "SAMRAI/tbox/SAMRAIManager.h"
 #include "SAMRAI/tbox/Utilities.h"

--- a/source/SAMRAI/tbox/Scanner.C
+++ b/source/SAMRAI/tbox/Scanner.C
@@ -501,7 +501,6 @@ char *yytext;
 
 #include <stdlib.h>
 #include <string>
-using namespace std;
 
 #define YY_NEVER_INTERACTIVE 1
 #define YY_NO_UNPUT 1
@@ -920,7 +919,7 @@ YY_RULE_SETUP
 
 {
    Parser::getParser()->advanceCursor(yytext);
-   SAMRAI_yylval.u_keyword = new string(yytext);
+   SAMRAI_yylval.u_keyword = new std::string(yytext);
    return(T_KEYWORD);
 }
 	YY_BREAK
@@ -938,8 +937,8 @@ YY_RULE_SETUP
 
 {
    Parser::getParser()->advanceCursor(yytext);
-   string s(yytext);
-   SAMRAI_yylval.u_string = new string(s.substr(1,s.length()-2));
+   std::string s(yytext);
+   SAMRAI_yylval.u_string = new std::string(s.substr(1,s.length()-2));
    return(T_STRING);
 }
 	YY_BREAK
@@ -963,11 +962,11 @@ case 35:
 YY_RULE_SETUP
 
 {
-   string s(yytext);
-   string::size_type start = s.find("\"")+1;
-   string::size_type end   = s.rfind("\"")-1;
+   std::string s(yytext);
+   std::string::size_type start = s.find("\"")+1;
+   std::string::size_type end   = s.rfind("\"")-1;
 
-   string filename(s, start, end-start+1);
+   std::string filename(s, start, end-start+1);
 
    if (s_include_stack_top >= MAXIMUM_INCLUDE_DEPTH) {
       Parser::getParser()->error("Too many nested #include statements");

--- a/source/SAMRAI/tbox/Scanner.l
+++ b/source/SAMRAI/tbox/Scanner.l
@@ -13,7 +13,6 @@
 
 #include <stdlib.h>
 #include <string>
-using namespace std;
 
 #define YY_NEVER_INTERACTIVE 1
 #define YY_NO_UNPUT 1
@@ -90,7 +89,7 @@ S_STRING  (\"([^\n"])*\")
 
 {S_KEYWORD} {
    Parser::getParser()->advanceCursor(yytext);
-   yylval.u_keyword = new string(yytext);
+   yylval.u_keyword = new std::string(yytext);
    return(T_KEYWORD);
 }
 
@@ -102,8 +101,8 @@ S_STRING  (\"([^\n"])*\")
 
 {S_STRING} {
    Parser::getParser()->advanceCursor(yytext);
-   string s(yytext);
-   yylval.u_string = new string(s.substr(1,s.length()-2));
+   std::string s(yytext);
+   yylval.u_string = new std::string(s.substr(1,s.length()-2));
    return(T_STRING);
 }
 
@@ -118,11 +117,11 @@ S_STRING  (\"([^\n"])*\")
 }
 
 "#include"[ \t]+\"[^\"\n]+\"[ \t]*\n {
-   string s(yytext);
-   string::size_type start = s.find("\"")+1;
-   string::size_type end   = s.rfind("\"")-1;
+   std::string s(yytext);
+   std::string::size_type start = s.find("\"")+1;
+   std::string::size_type end   = s.rfind("\"")-1;
 
-   string filename(s, start, end-start+1);
+   std::string filename(s, start, end-start+1);
 
    if (s_include_stack_top >= MAXIMUM_INCLUDE_DEPTH) {
       Parser::getParser()->error("Too many nested #include statements");

--- a/source/test/Connector/main.C
+++ b/source/test/Connector/main.C
@@ -24,7 +24,6 @@
 #include "SAMRAI/geom/GridGeometry.h"
 
 
-using namespace std;
 
 using namespace SAMRAI;
 using namespace hier;

--- a/source/test/FAC_adaptive/main.C
+++ b/source/test/FAC_adaptive/main.C
@@ -11,7 +11,6 @@
 
 #include IOMANIP_HEADER_FILE
 #include <fstream>
-// using namespace std;
 
 #include "AdaptivePoisson.h"
 #include "test/testlib/get-input-filename.h"

--- a/source/test/FAC_adaptive/setArrayData.C
+++ b/source/test/FAC_adaptive/setArrayData.C
@@ -14,7 +14,6 @@
 #include "SAMRAI/tbox/Utilities.h"
 #include <math.h>
 
-// using namespace std;
 
 /*!
  * \file

--- a/source/test/FAC_staticrefinement/main.C
+++ b/source/test/FAC_staticrefinement/main.C
@@ -11,7 +11,6 @@
 
 #include <string>
 #include <memory>
-using namespace std;
 
 #include "SAMRAI/mesh/BergerRigoutsos.h"
 #include "SAMRAI/geom/CartesianGridGeometry.h"
@@ -82,12 +81,12 @@ int main(
        *    executable <input file name>
        *
        */
-      string input_filename;
+      std::string input_filename;
 
       if (argc != 2) {
          TBOX_ERROR("USAGE:  " << argv[0] << " <input file> \n"
                                << "  options:\n"
-                               << "  none at this time" << endl);
+                               << "  none at this time" << std::endl);
       } else {
          input_filename = argv[1];
       }
@@ -118,13 +117,13 @@ int main(
 
       const tbox::Dimension dim(static_cast<unsigned short>(main_db->getInteger("dim")));
 
-      string base_name = "unnamed";
+      std::string base_name = "unnamed";
       base_name = main_db->getStringWithDefault("base_name", base_name);
 
       /*
        * Start logging.
        */
-      const string log_file_name = base_name + ".log";
+      const std::string log_file_name = base_name + ".log";
       bool log_all_nodes = false;
       log_all_nodes = main_db->getBoolWithDefault("log_all_nodes",
             log_all_nodes);
@@ -147,7 +146,7 @@ int main(
             dim,
             base_name + "CartesianGridGeometry",
             input_db->getDatabase("CartesianGridGeometry")));
-      tbox::plog << "Cartesian Geometry:" << endl;
+      tbox::plog << "Cartesian Geometry:" << std::endl;
       grid_geometry->printClassData(tbox::plog);
 
       std::shared_ptr<hier::PatchHierarchy> patch_hierarchy(
@@ -258,7 +257,7 @@ int main(
             tag_and_initializer,
             box_generator,
             load_balancer));
-      tbox::plog << "Gridding algorithm:" << endl;
+      tbox::plog << "Gridding algorithm:" << std::endl;
       gridding_algorithm->printClassData(tbox::plog);
 
       /*
@@ -268,13 +267,13 @@ int main(
       bool done = false;
       for (int lnum = 0;
            patch_hierarchy->levelCanBeRefined(lnum) && !done; lnum++) {
-         tbox::plog << "Adding finner levels with lnum = " << lnum << endl;
+         tbox::plog << "Adding finner levels with lnum = " << lnum << std::endl;
          gridding_algorithm->makeFinerLevel(
             0,
             true,
             0,
             0.0);
-         tbox::plog << "Just added finer levels with lnum = " << lnum << endl;
+         tbox::plog << "Just added finer levels with lnum = " << lnum << std::endl;
          done = !(patch_hierarchy->finerLevelExists(lnum));
       }
 
@@ -285,7 +284,7 @@ int main(
        * with the plotter.
        */
 #ifdef HAVE_HDF5
-      string vis_filename =
+      std::string vis_filename =
          main_db->getStringWithDefault("vis_filename", base_name);
       std::shared_ptr<appu::VisItDataWriter> visit_writer(
          std::make_shared<appu::VisItDataWriter>(dim,
@@ -300,8 +299,8 @@ int main(
        * to the log file.
        */
       tbox::plog << "\nCheck input data and variables before simulation:"
-                 << endl;
-      tbox::plog << "Input database..." << endl;
+                 << std::endl;
+      tbox::plog << "Input database..." << std::endl;
       input_db->printClassData(tbox::plog);
 
       /*
@@ -328,7 +327,7 @@ int main(
     * means application ran.  A better test would actually test the
     * results.
     */
-   tbox::pout << "\nPASSED:  FAC" << endl;
+   tbox::pout << "\nPASSED:  FAC" << std::endl;
 
    tbox::SAMRAIManager::shutdown();
    tbox::SAMRAIManager::finalize();

--- a/source/test/MblkEuler/MblkEuler.C
+++ b/source/test/MblkEuler/MblkEuler.C
@@ -25,7 +25,6 @@
 #endif
 #endif
 
-using namespace std;
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -94,7 +93,7 @@ using namespace std;
  */
 
 MblkEuler::MblkEuler(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> input_db,
    std::shared_ptr<hier::BaseGridGeometry>& grid_geom):
@@ -150,22 +149,22 @@ MblkEuler::MblkEuler(
    //
    // drop the region layout as a table
    //
-   tbox::plog << "region layout follows:" << endl;
+   tbox::plog << "region layout follows:" << std::endl;
 
    tbox::plog << "field";
    for (int ir = 0; ir < d_number_of_regions; ++ir)
       tbox::plog << "\t" << ir;
-   tbox::plog << endl;
+   tbox::plog << std::endl;
 
    for (int ii = 0; ii < d_number_of_regions * 10; ++ii)
       tbox::plog << "-";
-   tbox::plog << endl;
+   tbox::plog << std::endl;
 
    for (int istate = 0; istate < d_nState; ++istate) {
       tbox::plog << d_state_names[istate];
       for (int ir = 0; ir < d_number_of_regions; ++ir)
          tbox::plog << "\t" << d_state_ic[ir][istate];
-      tbox::plog << endl;
+      tbox::plog << std::endl;
    }
 }
 
@@ -238,11 +237,11 @@ void MblkEuler::registerModelVariables(
          d_object_name << ": registerModelVariables()"
                        << "\nVisIt data writer was"
                        << "\nregistered.  Consequently, no plot data will"
-                       << "\nbe written." << endl);
+                       << "\nbe written." << std::endl);
    }
 
    for (int n = 0; n < d_nState; ++n) {
-      string vname = d_state_names[n];
+      std::string vname = d_state_names[n];
       d_visit_writer->registerPlotQuantity(vname, "SCALAR",
          vardb->mapVariableAndContextToIndex(d_state,
             integrator->getPlotContext()),
@@ -655,9 +654,9 @@ double MblkEuler::computeStableDtOnPatch(
    const hier::Index ilast = patch.getBox().upper();
 
    tbox::plog << "--------------------- start stableDtOnPatch on patch ("
-              << level_number << ")" << endl;
-   tbox::plog << "level = " << level_number << endl;
-   tbox::plog << "box   = " << patch.getBox() << endl;
+              << level_number << ")" << std::endl;
+   tbox::plog << "level = " << level_number << std::endl;
+   tbox::plog << "box   = " << patch.getBox() << std::endl;
 
    //
    // get the cell data and their bounds
@@ -874,11 +873,11 @@ double MblkEuler::computeStableDtOnPatch(
    if (dt_fixed > 0.0)
       returned_dt = dt_fixed;
 
-   tbox::plog << "stabdt      = " << stabdt << endl;
-   tbox::plog << "dt_fixed    = " << dt_fixed << endl;
-   tbox::plog << "returned_dt = " << returned_dt << endl;
+   tbox::plog << "stabdt      = " << stabdt << std::endl;
+   tbox::plog << "dt_fixed    = " << dt_fixed << std::endl;
+   tbox::plog << "returned_dt = " << returned_dt << std::endl;
 
-   tbox::plog << "--------------------- end stableDtOnPatch on patch" << endl;
+   tbox::plog << "--------------------- end stableDtOnPatch on patch" << std::endl;
 
    return returned_dt;
 }
@@ -939,11 +938,11 @@ void MblkEuler::testPatchExtrema(
       }
    }
 
-   tbox::plog << endl << "extrema for the state follow " << pos
-              << " (min,max) = " << endl;
+   tbox::plog << std::endl << "extrema for the state follow " << pos
+              << " (min,max) = " << std::endl;
    for (int ii = 0; ii < d_nState; ++ii) {
       tbox::plog << d_state_names[ii] << " (min,max) = ";
-      tbox::plog << psi_min[ii] << " " << psi_max[ii] << endl;
+      tbox::plog << psi_min[ii] << " " << psi_max[ii] << std::endl;
    }
 
    delete[] psi_min;
@@ -998,11 +997,11 @@ void MblkEuler::computeFluxesOnPatch(
    TBOX_ASSERT(xyz->getGhostCellWidth() == d_nodeghosts);
 
    tbox::plog << "--------------------- start computeFluxesOnPatch on patch (";
-   tbox::plog << level_number << ")" << endl;
+   tbox::plog << level_number << ")" << std::endl;
    tbox::plog << "TIMESTEP for level = " << level_number << ", ";
    tbox::plog << "dt    = " << dt << ", stime  = " << time << ", ftime = "
-              << time + dt << endl;
-   tbox::plog << "box   = " << pbox << endl;
+              << time + dt << std::endl;
+   tbox::plog << "box   = " << pbox << std::endl;
 
    //
    // ------------------------------- the upwind bounds ----------------------------
@@ -1443,7 +1442,7 @@ void MblkEuler::computeFluxesOnPatch(
    } // end of field loop
 
    tbox::plog << "--------------------- end computeFluxesOnPatch on patch"
-              << endl;
+              << std::endl;
 }
 
 /*
@@ -1721,14 +1720,14 @@ void MblkEuler::preprocessRefine(
       fln = cln + 1;
       if (!fine.checkAllocated(xyz_id)) {
          TBOX_ERROR(d_object_name << ":preprocessRefine()"
-                                  << "\nfine xyz data not allocated" << endl);
+                                  << "\nfine xyz data not allocated" << std::endl);
       }
    }
    if (cln < 0) {
       cln = fln - 1;
       if (!coarse.checkAllocated(xyz_id)) {
          TBOX_ERROR(d_object_name << ":preprocessRefine()"
-                                  << "\ncoarse xyz data not allocated" << endl);
+                                  << "\ncoarse xyz data not allocated" << std::endl);
       }
    }
    setMappedGridOnPatch(coarse);
@@ -1794,16 +1793,16 @@ void MblkEuler::postprocessRefine(
    int clev = coarse.getPatchLevelNumber();
 
    tbox::plog << "--------------------- start postprocessRefineData ("
-              << flev << "," << clev << ")" << endl;
-   tbox::plog << "flevel     = " << flev << endl;
-   tbox::plog << "clevel     = " << clev << endl << endl;
-   tbox::plog << "fine_box         = " << fine_box << endl;
-   tbox::plog << "fine_patch_box   = " << fine.getBox() << endl;
-   tbox::plog << "fine_ghost_box   = " << fgbox << endl << endl;
+              << flev << "," << clev << ")" << std::endl;
+   tbox::plog << "flevel     = " << flev << std::endl;
+   tbox::plog << "clevel     = " << clev << std::endl << std::endl;
+   tbox::plog << "fine_box         = " << fine_box << std::endl;
+   tbox::plog << "fine_patch_box   = " << fine.getBox() << std::endl;
+   tbox::plog << "fine_ghost_box   = " << fgbox << std::endl << std::endl;
 
-   tbox::plog << "coarse_box       = " << coarse_box << endl;
-   tbox::plog << "coarse_patch_box = " << coarse.getBox() << endl;
-   tbox::plog << "coarse_ghost_box = " << coarse_box << endl;
+   tbox::plog << "coarse_box       = " << coarse_box << std::endl;
+   tbox::plog << "coarse_patch_box = " << coarse.getBox() << std::endl;
+   tbox::plog << "coarse_ghost_box = " << coarse_box << std::endl;
 
    //
    // setup work variables
@@ -1957,7 +1956,7 @@ void MblkEuler::postprocessRefine(
 
    } // end of state loop
 
-   tbox::plog << "--------------------- end postprocessRefine" << endl;
+   tbox::plog << "--------------------- end postprocessRefine" << std::endl;
 }
 
 /*
@@ -1985,14 +1984,14 @@ void MblkEuler::preprocessCoarsen(
       fln = cln + 1;
       if (!fine.checkAllocated(xyz_id)) {
          TBOX_ERROR(d_object_name << ":preprocessCoarsen()"
-                                  << "\nfine xyz data not allocated" << endl);
+                                  << "\nfine xyz data not allocated" << std::endl);
       }
    }
    if (cln < 0) {
       cln = fln - 1;
       if (!coarse.checkAllocated(xyz_id)) {
          TBOX_ERROR(d_object_name << ":preprocessCoarsen()"
-                                  << "\ncoarse xyz data not allocated" << endl);
+                                  << "\ncoarse xyz data not allocated" << std::endl);
       }
    }
    setMappedGridOnPatch(coarse);
@@ -2052,16 +2051,16 @@ void MblkEuler::postprocessCoarsen(
    int clev = coarse.getPatchLevelNumber();
 
    tbox::plog << "--------------------- start postprocessCoarsenData ("
-              << flev << "," << clev << ")" << endl;
-   tbox::plog << "flevel     = " << flev << endl;
-   tbox::plog << "clevel     = " << clev << endl;
-   tbox::plog << "fine       = " << fine.getBox() << endl;
-   tbox::plog << "coarse     = " << coarse.getBox() << endl;
-   tbox::plog << "fine_box   = " << fine_box << endl;
-   tbox::plog << "coarse_box = " << coarse_box << endl;
+              << flev << "," << clev << ")" << std::endl;
+   tbox::plog << "flevel     = " << flev << std::endl;
+   tbox::plog << "clevel     = " << clev << std::endl;
+   tbox::plog << "fine       = " << fine.getBox() << std::endl;
+   tbox::plog << "coarse     = " << coarse.getBox() << std::endl;
+   tbox::plog << "fine_box   = " << fine_box << std::endl;
+   tbox::plog << "coarse_box = " << coarse_box << std::endl;
 
-   tbox::plog << "filo = " << filo << ", fihi = " << fihi << endl;
-   tbox::plog << "cilo = " << cilo << ", cihi = " << cihi << endl;
+   tbox::plog << "filo = " << filo << ", fihi = " << fihi << std::endl;
+   tbox::plog << "cilo = " << cilo << ", cihi = " << cihi << std::endl;
 
    //
    // work variables
@@ -2171,7 +2170,7 @@ void MblkEuler::postprocessCoarsen(
       }
 
    }
-   tbox::plog << "--------------------- end postprocessCoarsen" << endl;
+   tbox::plog << "--------------------- end postprocessCoarsen" << std::endl;
 }
 
 // -------------------------------------------------------------------
@@ -2222,9 +2221,9 @@ void MblkEuler::tagGradientDetectorCells(
    int level = patch.getPatchLevelNumber();
 
    tbox::plog << "--------------------- start tagGradientCells (" << level
-              << ")" << endl;
-   tbox::plog << "level  = " << level << endl;
-   tbox::plog << "box    = " << patch.getBox() << endl;
+              << ")" << std::endl;
+   tbox::plog << "level  = " << level << std::endl;
+   tbox::plog << "box    = " << patch.getBox() << std::endl;
 
    std::shared_ptr<pdat::CellData<int> > tags(
       SAMRAI_SHARED_PTR_CAST<pdat::CellData<int>, hier::PatchData>(
@@ -2297,7 +2296,7 @@ void MblkEuler::tagGradientDetectorCells(
 
       TBOX_ASSERT(var);
 
-      string ref = d_refinement_criteria[ncrit];
+      std::string ref = d_refinement_criteria[ncrit];
 
       if (ref == "GRADIENT") {
          int nStateLocal = static_cast<int>(d_state_grad_names.size());
@@ -2494,7 +2493,7 @@ void MblkEuler::tagGradientDetectorCells(
       (*tags)(*ic, 0) = (*temp_tags)(*ic, 0);
    }
 
-   tbox::plog << "--------------------- end tagGradientCells" << endl;
+   tbox::plog << "--------------------- end tagGradientCells" << std::endl;
 
 }
 
@@ -2691,28 +2690,28 @@ void MblkEuler::registerVisItDataWriter(
  */
 
 void MblkEuler::printClassData(
-   ostream& os) const
+   std::ostream& os) const
 {
-   os << "\nMblkEuler::printClassData..." << endl;
-   os << "MblkEuler: this = " << (MblkEuler *)this << endl;
-   os << "d_object_name = " << d_object_name << endl;
-   os << "d_grid_geometry = " << endl;
+   os << "\nMblkEuler::printClassData..." << std::endl;
+   os << "MblkEuler: this = " << (MblkEuler *)this << std::endl;
+   os << "d_object_name = " << d_object_name << std::endl;
+   os << "d_grid_geometry = " << std::endl;
    for (hier::BlockId::block_t j = 0; j < d_grid_geometry->getNumberBlocks(); ++j) {
-//      os << (geom::GridGeometry*)d_grid_geometry[j] << endl;
+//      os << (geom::GridGeometry*)d_grid_geometry[j] << std::endl;
    }
 
    // ----------------------------------------------
 
-   os << "Parameters for numerical method ..." << endl;
+   os << "Parameters for numerical method ..." << std::endl;
    os << "   d_advection_velocity = ";
    for (tbox::Dimension::dir_t j = 0; j < d_dim.getValue(); ++j) os << d_advection_velocity[j] << " ";
-   os << endl;
+   os << std::endl;
 
-   os << "   d_nghosts    = " << d_nghosts << endl;
-   os << "   d_fluxghosts = " << d_fluxghosts << endl;
+   os << "   d_nghosts    = " << d_nghosts << std::endl;
+   os << "   d_fluxghosts = " << d_fluxghosts << std::endl;
 
-   os << "Problem description and initial data..." << endl;
-   os << "   d_data_problem = " << d_data_problem << endl;
+   os << "Problem description and initial data..." << std::endl;
+   os << "   d_data_problem = " << d_data_problem << std::endl;
 }
 
 /*
@@ -2783,7 +2782,7 @@ void MblkEuler::getFromInput(
          d_state_names = db->getStringVector("state_names");
          d_nState = static_cast<int>(d_state_names.size());
       } else {
-         TBOX_ERROR("missing 'state_names' input for sizing the state" << endl);
+         TBOX_ERROR("missing 'state_names' input for sizing the state" << std::endl);
       }
    } else {
       TBOX_ASSERT(d_advection_test);
@@ -2800,7 +2799,7 @@ void MblkEuler::getFromInput(
          TBOX_ERROR(
             d_object_name << ": "
                           << "`data_problem' value not found in input."
-                          << endl);
+                          << std::endl);
       }
 
       int problem_1d = 1;
@@ -2814,13 +2813,13 @@ void MblkEuler::getFromInput(
             db->getDoubleArray("center", d_center, d_dim.getValue());
          } else {
             TBOX_ERROR(
-               "`center' input required for REVOLUTION problem." << endl);
+               "`center' input required for REVOLUTION problem." << std::endl);
          }
 
          if (db->keyExists("axis")) {
             db->getDoubleArray("axis", d_axis, d_dim.getValue());
          } else {
-            TBOX_ERROR("`axis' input required for REVOLUTION problem." << endl);
+            TBOX_ERROR("`axis' input required for REVOLUTION problem." << std::endl);
          }
 
          // normalize the axis to a unit vector
@@ -2838,7 +2837,7 @@ void MblkEuler::getFromInput(
 
             char tmp[20];
             sprintf(tmp, "region_%d", i + 1);  //
-            string lkey = tmp;
+            std::string lkey = tmp;
             std::shared_ptr<tbox::Database> region_db(
                db->getDatabase(lkey));
 
@@ -2858,7 +2857,7 @@ void MblkEuler::getFromInput(
          if (db->keyExists("center")) {
             db->getDoubleArray("center", d_center, d_dim.getValue());
          } else {
-            TBOX_ERROR("`center' input required for SPHERE problem." << endl);
+            TBOX_ERROR("`center' input required for SPHERE problem." << std::endl);
          }
       }
 
@@ -2875,7 +2874,7 @@ void MblkEuler::getFromInput(
             d_phiy = db->getDoubleVector("phiy");
             d_phiz = db->getDoubleVector("phiz");
          } else {
-            TBOX_ERROR("missing input for RT_SHOCK_TUBE problem." << endl);
+            TBOX_ERROR("missing input for RT_SHOCK_TUBE problem." << std::endl);
          }
       }
 
@@ -2888,7 +2887,7 @@ void MblkEuler::getFromInput(
             d_number_of_regions = static_cast<int>(d_front_position.size()) - 1;
             TBOX_ASSERT(d_number_of_regions > 0);
          } else {
-            TBOX_ERROR("Missing`front_position' input required" << endl);
+            TBOX_ERROR("Missing`front_position' input required" << std::endl);
          }
       }
 
@@ -2925,7 +2924,7 @@ void MblkEuler::getFromInput(
             }
          } else {
             TBOX_ERROR(
-               "missing 'state_data' input for initial conditions" << endl);
+               "missing 'state_data' input for initial conditions" << std::endl);
          }
       } else {
          TBOX_ASSERT(d_advection_test);
@@ -2939,7 +2938,7 @@ void MblkEuler::getFromInput(
    if (db->keyExists("Refinement_data")) {
       std::shared_ptr<tbox::Database> refine_db = db->getDatabase(
             "Refinement_data");
-      std::vector<string> refinement_keys = refine_db->getAllKeys();
+      std::vector<std::string> refinement_keys = refine_db->getAllKeys();
       int num_keys = static_cast<int>(refinement_keys.size());
 
       if (refine_db->keyExists("refine_criteria")) {
@@ -2948,15 +2947,15 @@ void MblkEuler::getFromInput(
          TBOX_WARNING(
             d_object_name << ": "
                           << "No key `refine_criteria' found in data for"
-                          << " RefinementData. No refinement will occur." << endl);
+                          << " RefinementData. No refinement will occur." << std::endl);
       }
 
-      std::vector<string> ref_keys_defined(num_keys);
+      std::vector<std::string> ref_keys_defined(num_keys);
       int def_key_cnt = 0;
       std::shared_ptr<tbox::Database> error_db;
       for (int i = 0; i < num_keys; ++i) {
 
-         string error_key = refinement_keys[i];
+         std::string error_key = refinement_keys[i];
          error_db.reset();
 
          if (!(error_key == "refine_criteria")) {
@@ -2969,7 +2968,7 @@ void MblkEuler::getFromInput(
                TBOX_ERROR(
                   "Unknown refinement criteria: " << error_key
                                                   << " in input."
-                                                  << endl);
+                                                  << std::endl);
 
             } else {
                error_db = refine_db->getDatabase(error_key);
@@ -2989,7 +2988,7 @@ void MblkEuler::getFromInput(
                d_state_grad_id.resize(nStateLocal);
 
                for (int id = 0; id < nStateLocal; ++id) {
-                  string grad_name = d_state_grad_names[id];
+                  std::string grad_name = d_state_grad_names[id];
 
                   // ... the index needed
                   d_state_grad_id[id] = -1;
@@ -3008,7 +3007,7 @@ void MblkEuler::getFromInput(
                   } else {
                      TBOX_ERROR(
                         "No tolerance array " << grad_name
-                                              << "found for gradient detector" << endl);
+                                              << "found for gradient detector" << std::endl);
                   }
 
                }
@@ -3035,7 +3034,7 @@ void MblkEuler::getFromInput(
     */
    if ((d_grid_geometry->getNumberBlocks() > 1) && (num_per_dirs > 0)) {
       TBOX_ERROR(d_object_name << ": cannot have periodic BCs when there"
-                               << "\nare multiple blocks." << endl);
+                               << "\nare multiple blocks." << std::endl);
    }
 }
 

--- a/source/test/MblkEuler/MblkEuler.h
+++ b/source/test/MblkEuler/MblkEuler.h
@@ -22,7 +22,6 @@
 
 #include <string>
 #include <vector>
-using namespace std;
 #define included_String
 
 #include "MblkGeometry.h"
@@ -43,7 +42,7 @@ public:
    // the constructor and destructor
    //
    MblkEuler(
-      const string& object_name,
+      const std::string& object_name,
       const tbox::Dimension& dim,
       std::shared_ptr<tbox::Database> input_db,
       std::shared_ptr<hier::BaseGridGeometry>& grid_geom);
@@ -233,7 +232,7 @@ public:
     */
    void
    printClassData(
-      ostream& os) const;
+      std::ostream& os) const;
 
 private:
    /*
@@ -264,7 +263,7 @@ private:
     * The object name is used for error/warning reporting and also as a
     * string label for restart database entries.
     */
-   string d_object_name;
+   std::string d_object_name;
 
    const tbox::Dimension d_dim;
 
@@ -354,7 +353,7 @@ private:
    //
    // Indicator for problem type and initial conditions
    //
-   string d_data_problem;
+   std::string d_data_problem;
 
    //
    // region initialization inputs
@@ -366,7 +365,7 @@ private:
    // array of initial conditions and their names [region][state]
    //
    std::vector<std::vector<double> > d_state_ic;
-   std::vector<string> d_state_names;
+   std::vector<std::string> d_state_names;
 
    //
    // This class stores geometry information used for constructing the
@@ -388,11 +387,11 @@ private:
    // ====================== Refinement Data (private) =======================
    //
 
-   std::vector<string> d_refinement_criteria;
+   std::vector<std::string> d_refinement_criteria;
 
    /// history variable gradient tagging tolerance
    std::vector<std::vector<double> > d_state_grad_tol;
-   std::vector<string> d_state_grad_names;
+   std::vector<std::string> d_state_grad_names;
    std::vector<int> d_state_grad_id;
 
    //

--- a/source/test/MblkEuler/main.C
+++ b/source/test/MblkEuler/main.C
@@ -14,7 +14,6 @@
 #include <stdlib.h>
 #include <string>
 #include <fstream>
-using namespace std;
 
 #ifndef _MSC_VER
 #include <unistd.h>
@@ -73,8 +72,8 @@ int main(
    tbox::SAMRAIManager::startup();
    const tbox::SAMRAI_MPI& mpi(tbox::SAMRAI_MPI::getSAMRAIWorld());
 
-   string input_filename;
-   string restart_read_dirname;
+   std::string input_filename;
+   std::string restart_read_dirname;
    int restore_num = 0;
 
    bool is_from_restart = false;
@@ -84,7 +83,7 @@ int main(
                  << "<restart dir> <restore number> [options]\n"
                  << "  options:\n"
                  << "  none at this time"
-                 << endl;
+                 << std::endl;
       tbox::SAMRAI_MPI::abort();
       return -1;
    } else {
@@ -100,7 +99,7 @@ int main(
    //
    // fire up the log file
    //
-   string log_file_name = "MblkEuler.log";
+   std::string log_file_name = "MblkEuler.log";
    bool log_all_nodes = false;
    if (log_all_nodes) {
       tbox::PIO::logAllNodes(log_file_name);
@@ -116,9 +115,9 @@ int main(
    tbox::plog << "Compiled without OpenMP.\n";
 #endif
 
-   tbox::plog << "input_filename       = " << input_filename << endl;
-   tbox::plog << "restart_read_dirname = " << restart_read_dirname << endl;
-   tbox::plog << "restore_num          = " << restore_num << endl;
+   tbox::plog << "input_filename       = " << input_filename << std::endl;
+   tbox::plog << "restart_read_dirname = " << restart_read_dirname << std::endl;
+   tbox::plog << "restore_num          = " << restore_num << std::endl;
 
    //
    // Create input database and parse all data in input file.
@@ -128,7 +127,7 @@ int main(
       new tbox::InputDatabase("input_db"));
    tbox::InputManager::getManager()->parseInputFile(input_filename, input_db);
 
-   tbox::plog << "---- done parsing input file" << endl << endl;
+   tbox::plog << "---- done parsing input file" << std::endl << std::endl;
 
    //
    // Retrieve "GlobalInputs" section of the input database and set
@@ -138,7 +137,7 @@ int main(
       std::shared_ptr<tbox::Database> global_db(
          input_db->getDatabase("GlobalInputs"));
 //      if (global_db->keyExists("tag_clustering_method")) {
-//       string tag_clustering_method =
+//       std::string tag_clustering_method =
 //          global_db->getString("tag_clustering_method");
 //       mesh::BergerRigoutsos::setClusteringOption(tag_clustering_method);
 //     }
@@ -167,8 +166,8 @@ int main(
       viz_dump_interval = main_db->getInteger("viz_dump_interval");
    }
 
-   string viz_dump_dirname = "";
-   string visit_dump_dirname = "";
+   std::string viz_dump_dirname = "";
+   std::string visit_dump_dirname = "";
    int visit_number_procs_per_file = 1;
 
    if (viz_dump_interval > 0) {
@@ -180,7 +179,7 @@ int main(
          TBOX_ERROR("main(): "
             << "\nviz_dump_dirname is null ... "
             << "\nThis must be specified for use with VisIt"
-            << endl);
+            << std::endl);
       }
       if (main_db->keyExists("visit_number_procs_per_file")) {
          visit_number_procs_per_file =
@@ -195,7 +194,7 @@ int main(
       restart_interval = main_db->getInteger("restart_interval");
    }
 
-   string restart_write_dirname;
+   std::string restart_write_dirname;
    if (restart_interval > 0) {
       if (main_db->keyExists("restart_write_dirname")) {
          restart_write_dirname = main_db->getString("restart_write_dirname");
@@ -207,7 +206,7 @@ int main(
 
    bool use_refined_timestepping = true;
    if (main_db->keyExists("timestepping")) {
-      string timestepping_method = main_db->getString("timestepping");
+      std::string timestepping_method = main_db->getString("timestepping");
       if (timestepping_method == "SYNCHRONIZED") {
          use_refined_timestepping = false;
       }
@@ -338,13 +337,13 @@ int main(
    // print the input database and variable database contents
    // to the log file.
    //
-   tbox::plog << "\nCheck input data and variables before simulation:" << endl;
-   tbox::plog << "Input database..." << endl;
+   tbox::plog << "\nCheck input data and variables before simulation:" << std::endl;
+   tbox::plog << "Input database..." << std::endl;
    input_db->printClassData(tbox::plog);
-   tbox::plog << "\nVariable database..." << endl;
+   tbox::plog << "\nVariable database..." << std::endl;
    hier::VariableDatabase::getDatabase()->printClassData(tbox::plog);
 
-   tbox::plog << "\nPrinting a summary of model input... " << endl;
+   tbox::plog << "\nPrinting a summary of model input... " << std::endl;
    euler_model->printClassData(tbox::plog);
 
 #ifdef HAVE_HDF5
@@ -375,10 +374,10 @@ int main(
       iteration_num = time_integrator->getIntegratorStep() + 1;
 
       if (old_log_style) {
-         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << endl;
+         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
          tbox::pout << "At begining of timestep # " << iteration_num - 1
-                    << endl;
-         tbox::pout << "Simulation time is " << loop_time << endl;
+                    << std::endl;
+         tbox::pout << "Simulation time is " << loop_time << std::endl;
       }
 
       //
@@ -399,13 +398,13 @@ int main(
             loop_time,
             dt_new);
 
-         tbox::pout << my_line << endl;
+         tbox::pout << my_line << std::endl;
       }
 
       if (old_log_style) {
-         tbox::pout << "At end of timestep # " << iteration_num - 1 << endl;
-         tbox::pout << "Simulation time is " << loop_time << endl;
-         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << endl;
+         tbox::pout << "At end of timestep # " << iteration_num - 1 << std::endl;
+         tbox::pout << "Simulation time is " << loop_time << std::endl;
+         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
       }
 
       //
@@ -461,7 +460,7 @@ int main(
    input_db.reset();
    main_db.reset();
 
-   tbox::pout << "\nPASSED:  MblkEuler" << endl;
+   tbox::pout << "\nPASSED:  MblkEuler" << std::endl;
 
    tbox::SAMRAIManager::shutdown();
    tbox::SAMRAIManager::finalize();

--- a/source/test/MblkLinAdv/MblkLinAdv.C
+++ b/source/test/MblkLinAdv/MblkLinAdv.C
@@ -27,7 +27,6 @@
 
 #include <vector>
 
-using namespace std;
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -125,7 +124,7 @@ using namespace std;
  */
 
 MblkLinAdv::MblkLinAdv(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> input_db,
    std::shared_ptr<hier::BaseGridGeometry>& grid_geom):
@@ -250,7 +249,7 @@ MblkLinAdv::MblkLinAdv(
          d_object_name << ": "
                        << "Unknown d_data_problem string = "
                        << d_data_problem
-                       << " encountered in constructor" << endl);
+                       << " encountered in constructor" << std::endl);
    }
 
    /*
@@ -418,7 +417,7 @@ void MblkLinAdv::registerModelVariables(
          d_object_name << ": registerModelVariables()"
                        << "\nVisIt data writer was"
                        << "\nregistered.  Consequently, no plot data will"
-                       << "\nbe written." << endl);
+                       << "\nbe written." << std::endl);
    }
 #endif
 
@@ -1179,14 +1178,14 @@ void MblkLinAdv::preprocessRefine(
       fln = cln + 1;
       if (!fine.checkAllocated(xyz_id)) {
          TBOX_ERROR(d_object_name << ":preprocessRefine()"
-                                  << "\nfine xyz data not allocated" << endl);
+                                  << "\nfine xyz data not allocated" << std::endl);
       }
    }
    if (cln < 0) {
       cln = fln - 1;
       if (!coarse.checkAllocated(xyz_id)) {
          TBOX_ERROR(d_object_name << ":preprocessRefine()"
-                                  << "\ncoarse xyz data not allocated" << endl);
+                                  << "\ncoarse xyz data not allocated" << std::endl);
       }
    }
    hier::BlockId::block_t block_number =
@@ -1243,16 +1242,16 @@ void MblkLinAdv::postprocessRefine(
    int clev = coarse.getPatchLevelNumber();
 
    tbox::plog << "--------------------- start postprocessRefineData ("
-              << flev << "," << clev << ")" << endl;
-   tbox::plog << "flevel     = " << flev << endl;
-   tbox::plog << "clevel     = " << clev << endl;
-   tbox::plog << "fine       = " << fine.getBox() << endl;
-   tbox::plog << "coarse     = " << coarse.getBox() << endl;
-   tbox::plog << "fine_box   = " << fine_box << endl;
-   tbox::plog << "coarse_box = " << coarse_box << endl;
+              << flev << "," << clev << ")" << std::endl;
+   tbox::plog << "flevel     = " << flev << std::endl;
+   tbox::plog << "clevel     = " << clev << std::endl;
+   tbox::plog << "fine       = " << fine.getBox() << std::endl;
+   tbox::plog << "coarse     = " << coarse.getBox() << std::endl;
+   tbox::plog << "fine_box   = " << fine_box << std::endl;
+   tbox::plog << "coarse_box = " << coarse_box << std::endl;
 
-   tbox::plog << "filo = " << filo << ", fihi = " << fihi << endl;
-   tbox::plog << "cilo = " << cilo << ", cihi = " << cihi << endl;
+   tbox::plog << "filo = " << filo << ", fihi = " << fihi << std::endl;
+   tbox::plog << "cilo = " << cilo << ", cihi = " << cihi << std::endl;
 
    //
    // setup work variables
@@ -1412,7 +1411,7 @@ void MblkLinAdv::postprocessRefine(
 
    } // end of history loop
 
-   tbox::plog << "--------------------- end postprocessRefine" << endl;
+   tbox::plog << "--------------------- end postprocessRefine" << std::endl;
 
 }
 
@@ -1441,14 +1440,14 @@ void MblkLinAdv::preprocessCoarsen(
       fln = cln + 1;
       if (!fine.checkAllocated(xyz_id)) {
          TBOX_ERROR(d_object_name << ":preprocessCoarsen()"
-                                  << "\nfine xyz data not allocated" << endl);
+                                  << "\nfine xyz data not allocated" << std::endl);
       }
    }
    if (cln < 0) {
       cln = fln - 1;
       if (!coarse.checkAllocated(xyz_id)) {
          TBOX_ERROR(d_object_name << ":preprocessCoarsen()"
-                                  << "\ncoarse xyz data not allocated" << endl);
+                                  << "\ncoarse xyz data not allocated" << std::endl);
       }
    }
    hier::BlockId::block_t block_number =
@@ -1506,16 +1505,16 @@ void MblkLinAdv::postprocessCoarsen(
    int clev = coarse.getPatchLevelNumber();
 
    tbox::plog << "--------------------- start postprocessCoarsenData ("
-              << flev << "," << clev << ")" << endl;
-   tbox::plog << "flevel     = " << flev << endl;
-   tbox::plog << "clevel     = " << clev << endl;
-   tbox::plog << "fine       = " << fine.getBox() << endl;
-   tbox::plog << "coarse     = " << coarse.getBox() << endl;
-   tbox::plog << "fine_box   = " << fine_box << endl;
-   tbox::plog << "coarse_box = " << coarse_box << endl;
+              << flev << "," << clev << ")" << std::endl;
+   tbox::plog << "flevel     = " << flev << std::endl;
+   tbox::plog << "clevel     = " << clev << std::endl;
+   tbox::plog << "fine       = " << fine.getBox() << std::endl;
+   tbox::plog << "coarse     = " << coarse.getBox() << std::endl;
+   tbox::plog << "fine_box   = " << fine_box << std::endl;
+   tbox::plog << "coarse_box = " << coarse_box << std::endl;
 
-   tbox::plog << "filo = " << filo << ", fihi = " << fihi << endl;
-   tbox::plog << "cilo = " << cilo << ", cihi = " << cihi << endl;
+   tbox::plog << "filo = " << filo << ", fihi = " << fihi << std::endl;
+   tbox::plog << "cilo = " << cilo << ", cihi = " << cihi << std::endl;
 
    //
    // work variables
@@ -1625,7 +1624,7 @@ void MblkLinAdv::postprocessCoarsen(
       }
 
    }
-   tbox::plog << "--------------------- end postprocessCoarsen" << endl;
+   tbox::plog << "--------------------- end postprocessCoarsen" << std::endl;
 }
 
 // -------------------------------------------------------------------
@@ -1678,9 +1677,9 @@ void MblkLinAdv::tagGradientDetectorCells(
    int level = patch.getPatchLevelNumber();
 
    tbox::plog << "--------------------- start tagGradientCells (" << level
-              << ")" << endl;
-   tbox::plog << "level  = " << level << endl;
-   tbox::plog << "box    = " << patch.getBox() << endl;
+              << ")" << std::endl;
+   tbox::plog << "level  = " << level << std::endl;
+   tbox::plog << "box    = " << patch.getBox() << std::endl;
 
    std::shared_ptr<pdat::CellData<int> > tags(
       SAMRAI_SHARED_PTR_CAST<pdat::CellData<int>, hier::PatchData>(
@@ -1758,7 +1757,7 @@ void MblkLinAdv::tagGradientDetectorCells(
    for (int ncrit = 0;
         ncrit < static_cast<int>(d_refinement_criteria.size()); ++ncrit) {
 
-      string ref = d_refinement_criteria[ncrit];
+      std::string ref = d_refinement_criteria[ncrit];
       int size = 0;
       double tol = 0.;
 
@@ -1953,7 +1952,7 @@ void MblkLinAdv::tagGradientDetectorCells(
       (*tags)(*ic, 0) = (*temp_tags)(*ic, 0);
    }
 
-   tbox::plog << "--------------------- end tagGradientCells" << endl;
+   tbox::plog << "--------------------- end tagGradientCells" << std::endl;
 
 }
 
@@ -2006,7 +2005,7 @@ void MblkLinAdv::setMappedGridOnPatch(
    int num_domain_boxes = domain_boxes.size();
 
    if (num_domain_boxes > 1) {
-      TBOX_ERROR("Sorry, cannot handle non-rectangular domains..." << endl);
+      TBOX_ERROR("Sorry, cannot handle non-rectangular domains..." << std::endl);
    }
 
    int xyz_id = hier::VariableDatabase::getDatabase()->
@@ -2046,167 +2045,167 @@ void MblkLinAdv::registerVisItDataWriter(
  */
 
 void MblkLinAdv::printClassData(
-   ostream& os) const
+   std::ostream& os) const
 {
    int j, k;
 
-   os << "\nMblkLinAdv::printClassData..." << endl;
-   os << "MblkLinAdv: this = " << (MblkLinAdv *)this << endl;
-   os << "d_object_name = " << d_object_name << endl;
-   os << "d_grid_geometry = " << endl;
+   os << "\nMblkLinAdv::printClassData..." << std::endl;
+   os << "MblkLinAdv: this = " << (MblkLinAdv *)this << std::endl;
+   os << "d_object_name = " << d_object_name << std::endl;
+   os << "d_grid_geometry = " << std::endl;
 //   for (j=0; j < d_grid_geometry.getSize(); ++j) {
-//      os << (*((std::shared_ptr<geom::GridGeometry >)(d_grid_geometry[j]))) << endl;
+//      os << (*((std::shared_ptr<geom::GridGeometry >)(d_grid_geometry[j]))) << std::endl;
 //   }
 
-   os << "Parameters for numerical method ..." << endl;
+   os << "Parameters for numerical method ..." << std::endl;
    os << "   d_advection_velocity = ";
    for (j = 0; j < d_dim.getValue(); ++j) os << d_advection_velocity[j] << " ";
-   os << endl;
-   os << "   d_godunov_order = " << d_godunov_order << endl;
-   os << "   d_corner_transport = " << d_corner_transport << endl;
-   os << "   d_nghosts = " << d_nghosts << endl;
-   os << "   d_fluxghosts = " << d_fluxghosts << endl;
+   os << std::endl;
+   os << "   d_godunov_order = " << d_godunov_order << std::endl;
+   os << "   d_corner_transport = " << d_corner_transport << std::endl;
+   os << "   d_nghosts = " << d_nghosts << std::endl;
+   os << "   d_fluxghosts = " << d_fluxghosts << std::endl;
 
-   os << "Problem description and initial data..." << endl;
-   os << "   d_data_problem = " << d_data_problem << endl;
-   os << "   d_data_problem_int = " << d_data_problem << endl;
+   os << "Problem description and initial data..." << std::endl;
+   os << "   d_data_problem = " << d_data_problem << std::endl;
+   os << "   d_data_problem_int = " << d_data_problem << std::endl;
 
-   os << "       d_radius = " << d_radius << endl;
+   os << "       d_radius = " << d_radius << std::endl;
    os << "       d_center = ";
    for (j = 0; j < d_dim.getValue(); ++j) os << d_center[j] << " ";
-   os << endl;
-   os << "       d_uval_inside = " << d_uval_inside << endl;
-   os << "       d_uval_outside = " << d_uval_outside << endl;
+   os << std::endl;
+   os << "       d_uval_inside = " << d_uval_inside << std::endl;
+   os << "       d_uval_outside = " << d_uval_outside << std::endl;
 
-   os << "       d_number_of_intervals = " << d_number_of_intervals << endl;
+   os << "       d_number_of_intervals = " << d_number_of_intervals << std::endl;
    os << "       d_front_position = ";
    for (k = 0; k < d_number_of_intervals - 1; ++k) {
       os << d_front_position[k] << "  ";
    }
-   os << endl;
-   os << "       d_interval_uval = " << endl;
+   os << std::endl;
+   os << "       d_interval_uval = " << std::endl;
    for (k = 0; k < d_number_of_intervals; ++k) {
-      os << "            " << d_interval_uval[k] << endl;
+      os << "            " << d_interval_uval[k] << std::endl;
    }
-   os << "   Boundary condition data " << endl;
+   os << "   Boundary condition data " << std::endl;
 
    if (d_dim == tbox::Dimension(2)) {
       for (j = 0; j < static_cast<int>(d_scalar_bdry_edge_conds.size()); ++j) {
          os << "       d_scalar_bdry_edge_conds[" << j << "] = "
-            << d_scalar_bdry_edge_conds[j] << endl;
+            << d_scalar_bdry_edge_conds[j] << std::endl;
          if (d_scalar_bdry_edge_conds[j] == BdryCond::DIRICHLET) {
             os << "         d_bdry_edge_uval[" << j << "] = "
-               << d_bdry_edge_uval[j] << endl;
+               << d_bdry_edge_uval[j] << std::endl;
          }
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_scalar_bdry_node_conds.size()); ++j) {
          os << "       d_scalar_bdry_node_conds[" << j << "] = "
-            << d_scalar_bdry_node_conds[j] << endl;
+            << d_scalar_bdry_node_conds[j] << std::endl;
          os << "       d_node_bdry_edge[" << j << "] = "
-            << d_node_bdry_edge[j] << endl;
+            << d_node_bdry_edge[j] << std::endl;
       }
    } else if (d_dim == tbox::Dimension(3)) {
       for (j = 0; j < static_cast<int>(d_scalar_bdry_face_conds.size()); ++j) {
          os << "       d_scalar_bdry_face_conds[" << j << "] = "
-            << d_scalar_bdry_face_conds[j] << endl;
+            << d_scalar_bdry_face_conds[j] << std::endl;
          if (d_scalar_bdry_face_conds[j] == BdryCond::DIRICHLET) {
             os << "         d_bdry_face_uval[" << j << "] = "
-               << d_bdry_face_uval[j] << endl;
+               << d_bdry_face_uval[j] << std::endl;
          }
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_scalar_bdry_edge_conds.size()); ++j) {
          os << "       d_scalar_bdry_edge_conds[" << j << "] = "
-            << d_scalar_bdry_edge_conds[j] << endl;
+            << d_scalar_bdry_edge_conds[j] << std::endl;
          os << "       d_edge_bdry_face[" << j << "] = "
-            << d_edge_bdry_face[j] << endl;
+            << d_edge_bdry_face[j] << std::endl;
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_scalar_bdry_node_conds.size()); ++j) {
          os << "       d_scalar_bdry_node_conds[" << j << "] = "
-            << d_scalar_bdry_node_conds[j] << endl;
+            << d_scalar_bdry_node_conds[j] << std::endl;
          os << "       d_node_bdry_face[" << j << "] = "
-            << d_node_bdry_face[j] << endl;
+            << d_node_bdry_face[j] << std::endl;
       }
    }
 
-   os << "   Refinement criteria parameters " << endl;
+   os << "   Refinement criteria parameters " << std::endl;
 
    for (j = 0; j < static_cast<int>(d_refinement_criteria.size()); ++j) {
       os << "       d_refinement_criteria[" << j << "] = "
-         << d_refinement_criteria[j] << endl;
+         << d_refinement_criteria[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_dev_tol.size()); ++j) {
       os << "       d_dev_tol[" << j << "] = "
-         << d_dev_tol[j] << endl;
+         << d_dev_tol[j] << std::endl;
    }
    for (j = 0; j < static_cast<int>(d_dev.size()); ++j) {
       os << "       d_dev[" << j << "] = "
-         << d_dev[j] << endl;
+         << d_dev[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_dev_time_max.size()); ++j) {
       os << "       d_dev_time_max[" << j << "] = "
-         << d_dev_time_max[j] << endl;
+         << d_dev_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_dev_time_min.size()); ++j) {
       os << "       d_dev_time_min[" << j << "] = "
-         << d_dev_time_min[j] << endl;
+         << d_dev_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_grad_tol.size()); ++j) {
       os << "       d_grad_tol[" << j << "] = "
-         << d_grad_tol[j] << endl;
+         << d_grad_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_grad_time_max.size()); ++j) {
       os << "       d_grad_time_max[" << j << "] = "
-         << d_grad_time_max[j] << endl;
+         << d_grad_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_grad_time_min.size()); ++j) {
       os << "       d_grad_time_min[" << j << "] = "
-         << d_grad_time_min[j] << endl;
+         << d_grad_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_shock_onset.size()); ++j) {
       os << "       d_shock_onset[" << j << "] = "
-         << d_shock_onset[j] << endl;
+         << d_shock_onset[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_shock_tol.size()); ++j) {
       os << "       d_shock_tol[" << j << "] = "
-         << d_shock_tol[j] << endl;
+         << d_shock_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_shock_time_max.size()); ++j) {
       os << "       d_shock_time_max[" << j << "] = "
-         << d_shock_time_max[j] << endl;
+         << d_shock_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_shock_time_min.size()); ++j) {
       os << "       d_shock_time_min[" << j << "] = "
-         << d_shock_time_min[j] << endl;
+         << d_shock_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_rich_tol.size()); ++j) {
       os << "       d_rich_tol[" << j << "] = "
-         << d_rich_tol[j] << endl;
+         << d_rich_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_rich_time_max.size()); ++j) {
       os << "       d_rich_time_max[" << j << "] = "
-         << d_rich_time_max[j] << endl;
+         << d_rich_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_rich_time_min.size()); ++j) {
       os << "       d_rich_time_min[" << j << "] = "
-         << d_rich_time_min[j] << endl;
+         << d_rich_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
 
 }
 
@@ -2257,7 +2256,7 @@ void MblkLinAdv::getFromInput(
           (d_godunov_order != 4)) {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "`godunov_order' in input must be 1, 2, or 4." << endl);
+                          << "`godunov_order' in input must be 1, 2, or 4." << std::endl);
       }
    } else {
       d_godunov_order = db->getIntegerWithDefault("d_godunov_order",
@@ -2271,7 +2270,7 @@ void MblkLinAdv::getFromInput(
          TBOX_ERROR(
             d_object_name << ": "
                           << "`corner_transport' in input must be either string"
-                          << " 'CORNER_TRANSPORT_1' or 'CORNER_TRANSPORT_2'." << endl);
+                          << " 'CORNER_TRANSPORT_1' or 'CORNER_TRANSPORT_2'." << std::endl);
       }
    } else {
       d_corner_transport = db->getStringWithDefault("corner_transport",
@@ -2281,7 +2280,7 @@ void MblkLinAdv::getFromInput(
    if (db->keyExists("Refinement_data")) {
       std::shared_ptr<tbox::Database> refine_db(
          db->getDatabase("Refinement_data"));
-      std::vector<string> refinement_keys = refine_db->getAllKeys();
+      std::vector<std::string> refinement_keys = refine_db->getAllKeys();
       int num_keys = static_cast<int>(refinement_keys.size());
 
       if (refine_db->keyExists("refine_criteria")) {
@@ -2290,15 +2289,15 @@ void MblkLinAdv::getFromInput(
          TBOX_WARNING(
             d_object_name << ": "
                           << "No key `refine_criteria' found in data for"
-                          << " RefinementData. No refinement will occur." << endl);
+                          << " RefinementData. No refinement will occur." << std::endl);
       }
 
-      std::vector<string> ref_keys_defined(num_keys);
+      std::vector<std::string> ref_keys_defined(num_keys);
       int def_key_cnt = 0;
       std::shared_ptr<tbox::Database> error_db;
       for (int i = 0; i < num_keys; ++i) {
 
-         string error_key = refinement_keys[i];
+         std::string error_key = refinement_keys[i];
          error_db.reset();
 
          if (!(error_key == "refine_criteria")) {
@@ -2311,7 +2310,7 @@ void MblkLinAdv::getFromInput(
                   d_object_name << ": "
                                 << "Unknown refinement criteria: "
                                 << error_key
-                                << "\nin input." << endl);
+                                << "\nin input." << std::endl);
             } else {
                error_db = refine_db->getDatabase(error_key);
                ref_keys_defined[def_key_cnt] = error_key;
@@ -2326,7 +2325,7 @@ void MblkLinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `dev_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("uval_dev")) {
@@ -2335,7 +2334,7 @@ void MblkLinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `uval_dev' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -2362,7 +2361,7 @@ void MblkLinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `grad_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -2389,7 +2388,7 @@ void MblkLinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `shock_onset' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("shock_tol")) {
@@ -2398,7 +2397,7 @@ void MblkLinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `shock_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -2425,7 +2424,7 @@ void MblkLinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `rich_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -2458,13 +2457,13 @@ void MblkLinAdv::getFromInput(
          TBOX_ERROR(
             d_object_name << ": "
                           << "`data_problem' value not found in input."
-                          << endl);
+                          << std::endl);
       }
 
       if (!db->keyExists("Initial_data")) {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "No `Initial_data' database found in input." << endl);
+                          << "No `Initial_data' database found in input." << std::endl);
       }
       std::shared_ptr<tbox::Database> init_data_db(
          db->getDatabase("Initial_data"));
@@ -2478,28 +2477,28 @@ void MblkLinAdv::getFromInput(
          } else {
             TBOX_ERROR(
                d_object_name << ": "
-                             << "`radius' input required for SPHERE problem." << endl);
+                             << "`radius' input required for SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("center")) {
             init_data_db->getDoubleArray("center", d_center, d_dim.getValue());
          } else {
             TBOX_ERROR(
                d_object_name << ": "
-                             << "`center' input required for SPHERE problem." << endl);
+                             << "`center' input required for SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("uval_inside")) {
             d_uval_inside = init_data_db->getDouble("uval_inside");
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`uval_inside' input required for "
-                                     << "SPHERE problem." << endl);
+                                     << "SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("uval_outside")) {
             d_uval_outside = init_data_db->getDouble("uval_outside");
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`uval_outside' input required for "
-                                     << "SPHERE problem." << endl);
+                                     << "SPHERE problem." << std::endl);
          }
 
          found_problem_data = true;
@@ -2519,7 +2518,7 @@ void MblkLinAdv::getFromInput(
                TBOX_ERROR(
                   d_object_name << ": `PIECEWISE_CONSTANT_Y' "
                                 << "problem invalid in 1 dimension."
-                                << endl);
+                                << std::endl);
             }
          }
 
@@ -2527,18 +2526,18 @@ void MblkLinAdv::getFromInput(
             if (d_dim < tbox::Dimension(3)) {
                TBOX_ERROR(
                   d_object_name << ": `PIECEWISE_CONSTANT_Z' "
-                                << "problem invalid in 1 or 2 dimensions." << endl);
+                                << "problem invalid in 1 or 2 dimensions." << std::endl);
             }
          }
 
-         std::vector<string> init_data_keys = init_data_db->getAllKeys();
+         std::vector<std::string> init_data_keys = init_data_db->getAllKeys();
 
          if (init_data_db->keyExists("front_position")) {
             d_front_position = init_data_db->getDoubleVector("front_position");
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`front_position' input required for "
-                                     << d_data_problem << " problem." << endl);
+                                     << d_data_problem << " problem." << std::endl);
          }
 
          d_number_of_intervals =
@@ -2565,7 +2564,7 @@ void MblkLinAdv::getFromInput(
                } else {
                   TBOX_ERROR(d_object_name << ": "
                                            << "`uval' data missing in input for key = "
-                                           << init_data_keys[nkey] << endl);
+                                           << init_data_keys[nkey] << std::endl);
                }
                ++i;
 
@@ -2588,7 +2587,7 @@ void MblkLinAdv::getFromInput(
             } else {
                TBOX_ERROR(
                   d_object_name << ": "
-                                << "`frequency' input required for SINE problem." << endl);
+                                << "`frequency' input required for SINE problem." << std::endl);
             }
          }
 
@@ -2597,7 +2596,7 @@ void MblkLinAdv::getFromInput(
                d_object_name << ": "
                              << "Insufficient interval data given in input"
                              << " for PIECEWISE_CONSTANT_*problem."
-                             << endl);
+                             << std::endl);
          }
 
          found_problem_data = true;
@@ -2606,7 +2605,7 @@ void MblkLinAdv::getFromInput(
       if (!found_problem_data) {
          TBOX_ERROR(d_object_name << ": "
                                   << "`Initial_data' database found in input."
-                                  << " But bad data supplied." << endl);
+                                  << " But bad data supplied." << std::endl);
       }
 
    } // if !is_from_restart read in problem data
@@ -2623,7 +2622,7 @@ void MblkLinAdv::getFromInput(
     */
    if ((d_grid_geometry->getNumberBlocks() > 1) && (num_per_dirs > 0)) {
       TBOX_ERROR(d_object_name << ": cannot have periodic BCs when there"
-                               << "\nare multiple blocks." << endl);
+                               << "\nare multiple blocks." << std::endl);
    }
 
    if (db->keyExists("Boundary_data")) {
@@ -2649,7 +2648,7 @@ void MblkLinAdv::getFromInput(
    } else {
       TBOX_ERROR(
          d_object_name << ": "
-                       << "Key data `Boundary_data' not found in input. " << endl);
+                       << "Key data `Boundary_data' not found in input. " << std::endl);
    }
 
 }
@@ -2781,14 +2780,14 @@ void MblkLinAdv::getFromRestart()
    if (!(d_nghosts == CELLG)) {
       TBOX_ERROR(
          d_object_name << ": "
-                       << "Key data `d_nghosts' in restart file != CELLG." << endl);
+                       << "Key data `d_nghosts' in restart file != CELLG." << std::endl);
    }
    int* tmp_fluxghosts = d_fluxghosts;
    db->getIntegerArray("d_fluxghosts", tmp_fluxghosts, d_dim);
    if (!(d_fluxghosts == FLUXG)) {
       TBOX_ERROR(
          d_object_name << ": "
-                       << "Key data `d_fluxghosts' in restart file != FLUXG." << endl);
+                       << "Key data `d_fluxghosts' in restart file != FLUXG." << std::endl);
    }
 #endif
 
@@ -2865,7 +2864,7 @@ void MblkLinAdv::getFromRestart()
 
 void MblkLinAdv::readDirichletBoundaryDataEntry(
    const std::shared_ptr<tbox::Database>& db,
-   string& db_name,
+   std::string& db_name,
    int bdry_location_index)
 {
    TBOX_ASSERT(db);
@@ -2886,7 +2885,7 @@ void MblkLinAdv::readDirichletBoundaryDataEntry(
 
 void MblkLinAdv::readStateDataEntry(
    std::shared_ptr<tbox::Database> db,
-   const string& db_name,
+   const std::string& db_name,
    int array_indx,
    std::vector<double>& uval)
 {
@@ -2900,14 +2899,14 @@ void MblkLinAdv::readStateDataEntry(
    } else {
       TBOX_ERROR(d_object_name << ": "
                                << "`uval' entry missing from " << db_name
-                               << " input database. " << endl);
+                               << " input database. " << std::endl);
    }
 
 }
 
 void MblkLinAdv::readNeumannBoundaryDataEntry(
    const std::shared_ptr<tbox::Database>& db,
-   string& db_name,
+   std::string& db_name,
    int bdry_location_index)
 {
    NULL_USE(db);
@@ -3014,7 +3013,7 @@ void MblkLinAdv::checkBoundaryData(
                     << "     " << num_bad_values
                     << " bad UVAL values found for\n"
                     << "     boundary type " << btype << " at location "
-                    << bloc << endl;
+                    << bloc << std::endl;
       }
 #endif
 

--- a/source/test/MblkLinAdv/MblkLinAdv.h
+++ b/source/test/MblkLinAdv/MblkLinAdv.h
@@ -27,7 +27,6 @@
 
 #include <string>
 #include <vector>
-using namespace std;
 #define included_String
 
 // Local classes used for this application
@@ -75,7 +74,7 @@ public:
     * database (potentially overriding those found in the restart file).
     */
    MblkLinAdv(
-      const string& object_name,
+      const std::string& object_name,
       const tbox::Dimension& dim,
       std::shared_ptr<tbox::Database> input_db,
       std::shared_ptr<hier::BaseGridGeometry>& grid_geom);
@@ -268,7 +267,7 @@ public:
    void
    readDirichletBoundaryDataEntry(
       const std::shared_ptr<tbox::Database>& db,
-      string& db_name,
+      std::string& db_name,
       int bdry_location_index);
 
    /**
@@ -279,7 +278,7 @@ public:
    void
    readNeumannBoundaryDataEntry(
       const std::shared_ptr<tbox::Database>& db,
-      string& db_name,
+      std::string& db_name,
       int bdry_location_index);
 
    hier::IntVector
@@ -303,7 +302,7 @@ public:
     */
    void
    printClassData(
-      ostream& os) const;
+      std::ostream& os) const;
 
 private:
    /*
@@ -326,7 +325,7 @@ private:
    void
    readStateDataEntry(
       std::shared_ptr<tbox::Database> db,
-      const string& db_name,
+      const std::string& db_name,
       int array_indx,
       std::vector<double>& uval);
 
@@ -358,7 +357,7 @@ private:
     * The object name is used for error/warning reporting and also as a
     * string label for restart database entries.
     */
-   string d_object_name;
+   std::string d_object_name;
 
    const tbox::Dimension d_dim;
 
@@ -421,7 +420,7 @@ private:
     *
     */
    int d_godunov_order;
-   string d_corner_transport;
+   std::string d_corner_transport;
    hier::IntVector d_nghosts;
    hier::IntVector d_fluxghosts;
    hier::IntVector d_nodeghosts;
@@ -429,7 +428,7 @@ private:
    /*
     * Indicator for problem type and initial conditions
     */
-   string d_data_problem;
+   std::string d_data_problem;
    int d_data_problem_int;
 
    /*
@@ -483,7 +482,7 @@ private:
     * Refinement criteria parameters for gradient detector and
     * Richardson extrapolation.
     */
-   std::vector<string> d_refinement_criteria;
+   std::vector<std::string> d_refinement_criteria;
    std::vector<double> d_dev_tol;
    std::vector<double> d_dev;
    std::vector<double> d_dev_time_max;

--- a/source/test/MblkLinAdv/SkeletonOutersideDoubleWeightedAverage.C
+++ b/source/test/MblkLinAdv/SkeletonOutersideDoubleWeightedAverage.C
@@ -216,7 +216,7 @@ void SkeletonOutersideDoubleWeightedAverage::coarsen(
                cdata->getPointer(2, i, d));
          } else {
             TBOX_ERROR("SkeletonOutersideDoubleWeightedAverage error...\n"
-               << "dimension > 3 not supported." << endl);
+               << "dimension > 3 not supported." << std::endl);
          }
       }
    }

--- a/source/test/MblkLinAdv/SkeletonOutersideDoubleWeightedAverage.h
+++ b/source/test/MblkLinAdv/SkeletonOutersideDoubleWeightedAverage.h
@@ -23,7 +23,6 @@
 #include "SAMRAI/hier/CoarsenOperator.h"
 
 
-using namespace std;
 using namespace SAMRAI;
 
 /**

--- a/source/test/MblkLinAdv/main.C
+++ b/source/test/MblkLinAdv/main.C
@@ -14,7 +14,6 @@
 #include <cstdlib>
 #include <string>
 #include <fstream>
-using namespace std;
 
 #ifndef _MSC_VER
 #include <unistd.h>
@@ -180,8 +179,8 @@ int main(
       tbox::SAMRAIManager::startup();
       const tbox::SAMRAI_MPI& mpi(tbox::SAMRAI_MPI::getSAMRAIWorld());
 
-      string input_filename;
-      string restart_read_dirname;
+      std::string input_filename;
+      std::string restart_read_dirname;
       int restore_num = 0;
 
       bool is_from_restart = false;
@@ -191,7 +190,7 @@ int main(
                     << "<restart dir> <restore number> [options]\n"
                     << "  options:\n"
                     << "  none at this time"
-                    << endl;
+                    << std::endl;
          tbox::SAMRAI_MPI::abort();
          return -1;
       } else {
@@ -204,9 +203,9 @@ int main(
          }
       }
 
-      tbox::plog << "input_filename = " << input_filename << endl;
-      tbox::plog << "restart_read_dirname = " << restart_read_dirname << endl;
-      tbox::plog << "restore_num = " << restore_num << endl;
+      tbox::plog << "input_filename = " << input_filename << std::endl;
+      tbox::plog << "restart_read_dirname = " << restart_read_dirname << std::endl;
+      tbox::plog << "restore_num = " << restore_num << std::endl;
 
       /*
        * Create input database and parse all data in input file.
@@ -225,7 +224,7 @@ int main(
          std::shared_ptr<tbox::Database> global_db(
             input_db->getDatabase("GlobalInputs"));
 //         if (global_db->keyExists("tag_clustering_method")) {
-//            string tag_clustering_method =
+//            std::string tag_clustering_method =
 //               global_db->getString("tag_clustering_method");
 //            mesh::BergerRigoutsos::setClusteringOption(tag_clustering_method);
 //         }
@@ -248,7 +247,7 @@ int main(
 
       const tbox::Dimension dim(static_cast<unsigned short>(main_db->getInteger("dim")));
 
-      string log_file_name = "MblkLinAdv.log";
+      std::string log_file_name = "MblkLinAdv.log";
       if (main_db->keyExists("log_file_name")) {
          log_file_name = main_db->getString("log_file_name");
       }
@@ -275,8 +274,8 @@ int main(
          viz_dump_interval = main_db->getInteger("viz_dump_interval");
       }
 
-      string viz_dump_dirname = "";
-      string visit_dump_dirname = "";
+      std::string viz_dump_dirname = "";
+      std::string visit_dump_dirname = "";
       int visit_number_procs_per_file = 1;
       if (viz_dump_interval > 0) {
          if (main_db->keyExists("viz_dump_dirname")) {
@@ -287,7 +286,7 @@ int main(
             TBOX_ERROR("main(): "
                << "\nviz_dump_dirname is null ... "
                << "\nThis must be specified for use with VisIt"
-               << endl);
+               << std::endl);
          }
          if (main_db->keyExists("visit_number_procs_per_file")) {
             visit_number_procs_per_file =
@@ -301,7 +300,7 @@ int main(
          restart_interval = main_db->getInteger("restart_interval");
       }
 
-      string restart_write_dirname;
+      std::string restart_write_dirname;
       if (restart_interval > 0) {
          if (main_db->keyExists("restart_write_dirname")) {
             restart_write_dirname = main_db->getString("restart_write_dirname");
@@ -313,7 +312,7 @@ int main(
 
       bool use_refined_timestepping = true;
       if (main_db->keyExists("timestepping")) {
-         string timestepping_method = main_db->getString("timestepping");
+         std::string timestepping_method = main_db->getString("timestepping");
          if (timestepping_method == "SYNCHRONIZED") {
             use_refined_timestepping = false;
          }
@@ -469,13 +468,13 @@ int main(
        */
 
       tbox::plog << "\nCheck input data and variables before simulation:"
-                 << endl;
-      tbox::plog << "Input database..." << endl;
+                 << std::endl;
+      tbox::plog << "Input database..." << std::endl;
       input_db->printClassData(tbox::plog);
-      tbox::plog << "\nVariable database..." << endl;
+      tbox::plog << "\nVariable database..." << std::endl;
       hier::VariableDatabase::getDatabase()->printClassData(tbox::plog);
 
-      tbox::plog << "\nCheck Linear Advection data... " << endl;
+      tbox::plog << "\nCheck Linear Advection data... " << std::endl;
       linear_advection_model->printClassData(tbox::plog);
 
       if (viz_dump_data) {
@@ -513,19 +512,19 @@ int main(
 
          iteration_num = time_integrator->getIntegratorStep() + 1;
 
-         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << endl;
+         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
          tbox::pout << "At begining of timestep # " << iteration_num - 1
-                    << endl;
-         tbox::pout << "Simulation time is " << loop_time << endl;
+                    << std::endl;
+         tbox::pout << "Simulation time is " << loop_time << std::endl;
 
          double dt_new = time_integrator->advanceHierarchy(dt_now);
 
          loop_time += dt_now;
          dt_now = dt_new;
 
-         tbox::pout << "At end of timestep # " << iteration_num - 1 << endl;
-         tbox::pout << "Simulation time is " << loop_time << endl;
-         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << endl;
+         tbox::pout << "At end of timestep # " << iteration_num - 1 << std::endl;
+         tbox::pout << "Simulation time is " << loop_time << std::endl;
+         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
 
          /*
           * At specified intervals, write restart and visualization files.
@@ -604,7 +603,7 @@ int main(
    tbox::SAMRAIManager::finalize();
    tbox::SAMRAI_MPI::finalize();
 
-   tbox::pout << "\nPASSED:  MblkLinAdv" << endl;
+   tbox::pout << "\nPASSED:  MblkLinAdv" << std::endl;
 
    return 0;
 }

--- a/source/test/OverlapConnectorAlgorithm/main.C
+++ b/source/test/OverlapConnectorAlgorithm/main.C
@@ -23,7 +23,6 @@
 #include "SAMRAI/geom/GridGeometry.h"
 
 
-using namespace std;
 
 using namespace SAMRAI;
 using namespace hier;

--- a/source/test/applications/ConvDiff/ConvDiff.C
+++ b/source/test/applications/ConvDiff/ConvDiff.C
@@ -27,8 +27,6 @@
 #endif
 #endif
 
-using namespace std;
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
@@ -86,7 +84,7 @@ using namespace std;
  */
 
 ConvDiff::ConvDiff(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> input_db,
    std::shared_ptr<geom::CartesianGridGeometry> grid_geom):
@@ -204,7 +202,7 @@ ConvDiff::ConvDiff(
          d_object_name << ": "
                        << "Unknown d_data_problem string = "
                        << d_data_problem
-                       << " encountered in constructor" << endl);
+                       << " encountered in constructor" << std::endl);
    }
 
    /*
@@ -336,13 +334,13 @@ void ConvDiff::registerModelVariables(
    int prim_var_id = vardb->mapVariableAndContextToIndex(
          d_primitive_vars, getInteriorContext());
 
-   string dump_name = "Primitive Var #";
+   std::string dump_name = "Primitive Var #";
    const int size = static_cast<int>(dump_name.length()) + 16;
    char* buffer = new char[size];
 
    for (int n = 0; n < NEQU; ++n) {
       sprintf(buffer, "%s%01d", dump_name.c_str(), n);
-      string variable_name(buffer);
+      std::string variable_name(buffer);
 #ifdef HAVE_HDF5
       if (d_visit_writer) {
          d_visit_writer->
@@ -354,7 +352,7 @@ void ConvDiff::registerModelVariables(
             d_object_name << ": registerModelVariables()\n"
                           << "VisIt data writer was not registered.\n"
                           << "Consequently, no plot data will\n"
-                          << "be written." << endl);
+                          << "be written." << std::endl);
       }
 #endif
 
@@ -428,8 +426,8 @@ void ConvDiff::initializeDataOnPatch(
             NEQU);
       }
 
-      // tbox::plog << "Level:" << patch.getPatchLevelNumber() << "\n" << endl;
-      // tbox::plog << "Patch:" << endl;
+      // tbox::plog << "Level:" << patch.getPatchLevelNumber() << "\n" << std::endl;
+      // tbox::plog << "Patch:" << std::endl;
       // primitive_vars->print(pbox,tbox::plog);
    }
 }
@@ -528,9 +526,9 @@ void ConvDiff::singleStep(
    TBOX_ASSERT(patch_geom);
    const double* dx = patch_geom->getDx();
 
-//      tbox::plog << "----primitive_var_current" << endl;
+//      tbox::plog << "----primitive_var_current" << std::endl;
 //      prim_var_current->print(prim_var_current->getGhostBox(),tbox::plog);
-//      tbox::plog << "----primitive_var_scratch" << endl;
+//      tbox::plog << "----primitive_var_scratch" << std::endl;
 //      prim_var_scratch->print(prim_var_scratch->getGhostBox(),tbox::plog);
 //
 // Evaluate Right hand side F(prim_var_scratch)
@@ -561,7 +559,7 @@ void ConvDiff::singleStep(
          NEQU);
    }
 
-//    tbox::plog << "Function Evaluation" << endl;
+//    tbox::plog << "Function Evaluation" << std::endl;
 //    function_eval->print(function_eval->getBox());
 //
 // Take RK step
@@ -591,7 +589,7 @@ void ConvDiff::singleStep(
          function_eval->getPointer(),
          NEQU);
    }
-//        tbox::plog << "----prim_var_scratch after RK step" << endl;
+//        tbox::plog << "----prim_var_scratch after RK step" << std::endl;
 //        prim_var_scratch->print(prim_var_scratch->getGhostBox(),tbox::plog);
 
 }
@@ -796,80 +794,80 @@ void ConvDiff::registerVisItDataWriter(
  */
 
 void ConvDiff::printClassData(
-   ostream& os) const
+   std::ostream& os) const
 {
    fflush(stdout);
    int j;
 
-   os << "ptr ConvDiff = " << (ConvDiff *)this << endl;
+   os << "ptr ConvDiff = " << (ConvDiff *)this << std::endl;
    os << "ptr grid geometry = "
-      << d_grid_geometry.get() << endl;
+      << d_grid_geometry.get() << std::endl;
 
-   os << "Coefficients..." << endl;
+   os << "Coefficients..." << std::endl;
    for (j = 0; j < d_dim.getValue(); ++j) os << "d_convection_coeff[" << j << "] = "
-                                             << d_convection_coeff[j] << endl;
-   os << "d_diffusion_coeff = " << d_diffusion_coeff << endl;
-   os << "d_source_coeff = " << d_source_coeff << endl;
+                                             << d_convection_coeff[j] << std::endl;
+   os << "d_diffusion_coeff = " << d_diffusion_coeff << std::endl;
+   os << "d_source_coeff = " << d_source_coeff << std::endl;
 
-   os << "Problem description and initial data..." << endl;
-   os << "   d_data_problem = " << d_data_problem << endl;
+   os << "Problem description and initial data..." << std::endl;
+   os << "   d_data_problem = " << d_data_problem << std::endl;
 
-   os << "       d_radius = " << d_radius << endl;
+   os << "       d_radius = " << d_radius << std::endl;
    os << "       d_center = ";
    for (j = 0; j < d_dim.getValue(); ++j) os << d_center[j] << " ";
-   os << endl;
+   os << std::endl;
    os << "       d_val_inside = ";
    for (j = 0; j < NEQU; ++j) os << d_val_inside[j] << " ";
-   os << endl;
+   os << std::endl;
    os << "       d_val_outside = ";
    for (j = 0; j < NEQU; ++j) os << d_val_outside[j] << " ";
-   os << endl;
+   os << std::endl;
 
-   os << "Boundary Condition data..." << endl;
+   os << "Boundary Condition data..." << std::endl;
    if (d_dim == tbox::Dimension(2)) {
       for (j = 0; j < static_cast<int>(d_scalar_bdry_edge_conds.size()); ++j) {
          os << "       d_scalar_bdry_edge_conds[" << j << "] = "
-            << d_scalar_bdry_edge_conds[j] << endl;
+            << d_scalar_bdry_edge_conds[j] << std::endl;
          if (d_scalar_bdry_edge_conds[j] == BdryCond::DIRICHLET) {
             os << "         d_bdry_edge_val[" << j << "] = "
-               << d_bdry_edge_val[j] << endl;
+               << d_bdry_edge_val[j] << std::endl;
          }
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_scalar_bdry_node_conds.size()); ++j) {
          os << "       d_scalar_bdry_node_conds[" << j << "] = "
-            << d_scalar_bdry_node_conds[j] << endl;
+            << d_scalar_bdry_node_conds[j] << std::endl;
          os << "       d_node_bdry_edge[" << j << "] = "
-            << d_node_bdry_edge[j] << endl;
+            << d_node_bdry_edge[j] << std::endl;
       }
    } else if (d_dim == tbox::Dimension(3)) {
       for (j = 0; j < static_cast<int>(d_scalar_bdry_face_conds.size()); ++j) {
          os << "       d_scalar_bdry_face_conds[" << j << "] = "
-            << d_scalar_bdry_face_conds[j] << endl;
+            << d_scalar_bdry_face_conds[j] << std::endl;
          if (d_scalar_bdry_face_conds[j] == BdryCond::DIRICHLET) {
             os << "         d_bdry_face_val[" << j << "] = "
-               << d_bdry_face_val[j] << endl;
+               << d_bdry_face_val[j] << std::endl;
          }
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_scalar_bdry_edge_conds.size()); ++j) {
          os << "       d_scalar_bdry_edge_conds[" << j << "] = "
-            << d_scalar_bdry_edge_conds[j] << endl;
+            << d_scalar_bdry_edge_conds[j] << std::endl;
          os << "       d_edge_bdry_face[" << j << "] = "
-            << d_edge_bdry_face[j] << endl;
+            << d_edge_bdry_face[j] << std::endl;
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_scalar_bdry_node_conds.size()); ++j) {
          os << "       d_scalar_bdry_node_conds[" << j << "] = "
-            << d_scalar_bdry_node_conds[j] << endl;
+            << d_scalar_bdry_node_conds[j] << std::endl;
          os << "       d_node_bdry_face[" << j << "] = "
-            << d_node_bdry_face[j] << endl;
+            << d_node_bdry_face[j] << std::endl;
       }
    }
 
-   os << "         d_nghosts = " << d_nghosts << endl;
-   os << "         d_zero_ghosts = " << d_zero_ghosts << endl;
-   os << "         d_cfl = " << d_cfl << endl;
+   os << "         d_nghosts = " << d_nghosts << std::endl;
+   os << "         d_zero_ghosts = " << d_zero_ghosts << std::endl;
+   os << "         d_cfl = " << d_cfl << std::endl;
 
 }
 
@@ -926,13 +924,13 @@ void ConvDiff::getFromInput(
          TBOX_ERROR(
             d_object_name << ": "
                           << "`data_problem' value not found in input."
-                          << endl);
+                          << std::endl);
       }
 
       if (!input_db->keyExists("Initial_data")) {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "No `Initial_data' database found in input." << endl);
+                          << "No `Initial_data' database found in input." << std::endl);
       }
       std::shared_ptr<tbox::Database> init_data_db(
          input_db->getDatabase("Initial_data"));
@@ -946,28 +944,28 @@ void ConvDiff::getFromInput(
          } else {
             TBOX_ERROR(
                d_object_name << ": "
-                             << "`radius' input required for SPHERE problem." << endl);
+                             << "`radius' input required for SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("center")) {
             init_data_db->getDoubleArray("center", d_center, d_dim.getValue());
          } else {
             TBOX_ERROR(
                d_object_name << ": "
-                             << "`center' input required for SPHERE problem." << endl);
+                             << "`center' input required for SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("val_inside")) {
             init_data_db->getDoubleArray("val_inside", d_val_inside, NEQU);
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "val_inside' input required for "
-                                     << "SPHERE problem." << endl);
+                                     << "SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("val_outside")) {
             init_data_db->getDoubleArray("val_outside", d_val_outside, NEQU);
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`val_outside' input required for "
-                                     << "SPHERE problem." << endl);
+                                     << "SPHERE problem." << std::endl);
          }
 
          found_problem_data = true;
@@ -978,7 +976,7 @@ void ConvDiff::getFromInput(
          TBOX_ERROR(
             d_object_name << ": "
                           << "Bad data in `Initial_data' database."
-                          << endl);
+                          << std::endl);
       }
 
       const hier::IntVector& one_vec(hier::IntVector::getOne(d_dim));
@@ -1011,7 +1009,7 @@ void ConvDiff::getFromInput(
          TBOX_WARNING(
             d_object_name << ": "
                           << "Key data `Boundary_data' not found in input. "
-                          << "Using default FLOW boundary conditions." << endl);
+                          << "Using default FLOW boundary conditions." << std::endl);
       }
    }
 }
@@ -1125,7 +1123,7 @@ void ConvDiff::getFromRestart()
 
 void ConvDiff::readDirichletBoundaryDataEntry(
    const std::shared_ptr<tbox::Database>& db,
-   string& db_name,
+   std::string& db_name,
    int bdry_location_index)
 {
    TBOX_ASSERT(db);
@@ -1146,7 +1144,7 @@ void ConvDiff::readDirichletBoundaryDataEntry(
 
 void ConvDiff::readNeumannBoundaryDataEntry(
    const std::shared_ptr<tbox::Database>& db,
-   string& db_name,
+   std::string& db_name,
    int bdry_location_index)
 {
    TBOX_ASSERT(db);
@@ -1167,7 +1165,7 @@ void ConvDiff::readNeumannBoundaryDataEntry(
 
 void ConvDiff::readStateDataEntry(
    std::shared_ptr<tbox::Database> db,
-   const string& db_name,
+   const std::string& db_name,
    int array_indx,
    std::vector<double>& val)
 {
@@ -1181,7 +1179,7 @@ void ConvDiff::readStateDataEntry(
    } else {
       TBOX_ERROR(d_object_name << ": "
                                << "`val' entry missing from " << db_name
-                               << " input database. " << endl);
+                               << " input database. " << std::endl);
    }
 
 }
@@ -1290,7 +1288,7 @@ void ConvDiff::checkBoundaryData(
                     << "     " << num_bad_values
                     << " bad VAL values found for\n"
                     << "     boundary type " << btype << " at location "
-                    << bloc << endl;
+                    << bloc << std::endl;
       }
 #endif
 

--- a/source/test/applications/ConvDiff/ConvDiff.h
+++ b/source/test/applications/ConvDiff/ConvDiff.h
@@ -26,7 +26,6 @@
 #include "SAMRAI/hier/Patch.h"
 #include "SAMRAI/tbox/Serializable.h"
 #include <string>
-using namespace std;
 #define included_String
 #include "SAMRAI/hier/VariableContext.h"
 #include "SAMRAI/appu/VisItDataWriter.h"
@@ -77,7 +76,7 @@ public:
     * potentially overriding those in the restart file.
     */
    ConvDiff(
-      const string& object_name,
+      const std::string& object_name,
       const tbox::Dimension& dim,
       std::shared_ptr<tbox::Database> input_db,
       std::shared_ptr<geom::CartesianGridGeometry> grid_geom);
@@ -261,20 +260,20 @@ public:
     * This routine is a concrete implementation of the virtual function
     * in the base class BoundaryUtilityStrategy.  It reads DIRICHLET
     * boundary state values from the given database with the
-    * given name string idenifier.  The integer location index
+    * given name std::string idenifier.  The integer location index
     * indicates the face (in 3D) or edge (in 2D) to which the boundary
     * condition applies.
     */
    void
    readDirichletBoundaryDataEntry(
       const std::shared_ptr<tbox::Database>& db,
-      string& db_name,
+      std::string& db_name,
       int bdry_location_index);
 
    void
    readNeumannBoundaryDataEntry(
       const std::shared_ptr<tbox::Database>& db,
-      string& db_name,
+      std::string& db_name,
       int bdry_location_index);
 
    /**
@@ -293,7 +292,7 @@ public:
     */
    void
    printClassData(
-      ostream& os) const;
+      std::ostream& os) const;
 
 private:
    /*
@@ -316,7 +315,7 @@ private:
    void
    readStateDataEntry(
       std::shared_ptr<tbox::Database> db,
-      const string& db_name,
+      const std::string& db_name,
       int array_indx,
       std::vector<double>& uval);
 
@@ -334,7 +333,7 @@ private:
     * Object name used for error/warning reporting and as a label
     * for restart database entries.
     */
-   string d_object_name;
+   std::string d_object_name;
 
    /*
     * Dimension of problem.
@@ -386,7 +385,7 @@ private:
    /*
     * Indicator for problem type and initial conditions
     */
-   string d_data_problem;
+   std::string d_data_problem;
    int d_data_problem_int;
 
    /*

--- a/source/test/applications/ConvDiff/MainRestartData.C
+++ b/source/test/applications/ConvDiff/MainRestartData.C
@@ -22,7 +22,7 @@
  */
 
 MainRestartData::MainRestartData(
-   const string& object_name,
+   const std::string& object_name,
    std::shared_ptr<tbox::Database> input_db):
    d_object_name(object_name)
 {
@@ -143,7 +143,7 @@ void MainRestartData::getFromInput(
       d_max_timesteps = input_db->getInteger("max_timesteps");
    } else {
       if (!is_from_restart) {
-         TBOX_ERROR("max_timesteps not entered in input file" << endl);
+         TBOX_ERROR("max_timesteps not entered in input file" << std::endl);
       }
    }
 

--- a/source/test/applications/ConvDiff/MainRestartData.h
+++ b/source/test/applications/ConvDiff/MainRestartData.h
@@ -21,7 +21,6 @@
 
 #include <memory>
 
-using namespace std;
 using namespace SAMRAI;
 
 /**
@@ -63,7 +62,7 @@ public:
     * The constructor for the serializable base class does nothing interesting.
     */
    MainRestartData(
-      const string& object_name,
+      const std::string& object_name,
       std::shared_ptr<tbox::Database> input_db);
 
    /**
@@ -165,7 +164,7 @@ private:
    double d_loop_time;
    int d_iteration_number;
 
-   string d_object_name;
+   std::string d_object_name;
 };
 
 #endif

--- a/source/test/applications/ConvDiff/main.C
+++ b/source/test/applications/ConvDiff/main.C
@@ -14,7 +14,6 @@
 #include <stdlib.h>
 #include <string>
 #include <fstream>
-using namespace std;
 
 #ifndef _MSC_VER
 #include <unistd.h>
@@ -159,8 +158,8 @@ int main(
        *               <restart number>
        */
 
-      string input_filename;
-      string restart_read_dirname;
+      std::string input_filename;
+      std::string restart_read_dirname;
       int restore_num = 0;
       bool is_from_restart = false;
 
@@ -169,7 +168,7 @@ int main(
                     << "<restart dir> <restore number> [options]\n"
                     << "  options:\n"
                     << "  none at this time"
-                    << endl;
+                    << std::endl;
          tbox::SAMRAI_MPI::abort();
          return -1;
       } else {
@@ -182,9 +181,9 @@ int main(
          }
       }
 
-      tbox::plog << "input_filename = " << input_filename << endl;
-      tbox::plog << "restart_read_dirname = " << restart_read_dirname << endl;
-      tbox::plog << "restore_num = " << restore_num << endl;
+      tbox::plog << "input_filename = " << input_filename << std::endl;
+      tbox::plog << "restart_read_dirname = " << restart_read_dirname << std::endl;
+      tbox::plog << "restore_num = " << restore_num << std::endl;
 
       /*
        * Create input database and parse all data in input file.
@@ -380,10 +379,10 @@ int main(
        */
 
       tbox::plog << "\nCheck input data and variables before simulation:"
-                 << endl;
-      tbox::plog << "Input database..." << endl;
+                 << std::endl;
+      tbox::plog << "Input database..." << std::endl;
       input_db->printClassData(tbox::plog);
-      tbox::plog << "\nVariable database..." << endl;
+      tbox::plog << "\nVariable database..." << std::endl;
       hier::VariableDatabase::getDatabase()->printClassData(tbox::plog);
       mol_integrator->initializeIntegrator(gridding_algorithm);
 
@@ -413,7 +412,7 @@ int main(
          tag_buffer_array[il] = main_restart_data->getTagBuffer();
          tbox::pout << "il = " << il << " tag_buffer = "
                     << tag_buffer_array[il]
-                    << endl;
+                    << std::endl;
       }
 
       std::vector<double> regrid_start_time(
@@ -513,10 +512,10 @@ int main(
          iteration_num = main_restart_data->getIterationNumber();
          ++iteration_num;
 
-         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << endl;
+         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
          tbox::pout << "At begining of timestep # " << iteration_num - 1
-                    << endl;
-         tbox::pout << "Simulation time is " << loop_time << endl;
+                    << std::endl;
+         tbox::pout << "Simulation time is " << loop_time << std::endl;
 
          double dt = mol_integrator->getTimestep(patch_hierarchy, loop_time);
 
@@ -524,9 +523,9 @@ int main(
 
          loop_time += dt;
 
-         tbox::pout << "At end of timestep # " << iteration_num - 1 << endl;
-         tbox::pout << "Simulation time is " << loop_time << endl;
-         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << endl;
+         tbox::pout << "At end of timestep # " << iteration_num - 1 << std::endl;
+         tbox::pout << "Simulation time is " << loop_time << std::endl;
+         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
 
          /*
           * Write restart file at specified intervals.  Set current state
@@ -562,10 +561,10 @@ int main(
          if ((iteration_num % main_restart_data->getRegridStep()) == 0 &&
              patch_hierarchy->getMaxNumberOfLevels() > 1) {
             tbox::plog << "\n\n############################################"
-                       << endl;
-            tbox::plog << "                 REGRIDDING" << endl;
+                       << std::endl;
+            tbox::plog << "                 REGRIDDING" << std::endl;
             tbox::plog << "Finest level before regrid: "
-                       << patch_hierarchy->getFinestLevelNumber() << endl;
+                       << patch_hierarchy->getFinestLevelNumber() << std::endl;
 
             gridding_algorithm->regridAllFinerLevels(0,
                tag_buffer_array,
@@ -574,9 +573,9 @@ int main(
                regrid_start_time);
 
             tbox::plog << "Finest level after regrid: "
-                       << patch_hierarchy->getFinestLevelNumber() << endl;
+                       << patch_hierarchy->getFinestLevelNumber() << std::endl;
             tbox::plog << "############################################\n\n"
-                       << endl;
+                       << std::endl;
          }
 
 #if (TESTING == 1)
@@ -628,7 +627,7 @@ int main(
    }
 
    if (num_failures == 0) {
-      tbox::pout << "\nPASSED:  ConvDiff" << endl;
+      tbox::pout << "\nPASSED:  ConvDiff" << std::endl;
    }
 
    tbox::SAMRAIManager::shutdown();

--- a/source/test/applications/Euler/Euler.C
+++ b/source/test/applications/Euler/Euler.C
@@ -26,7 +26,6 @@
 #endif
 #endif
 
-using namespace std;
 
 #include <cstdlib>
 #include <cstdio>
@@ -122,7 +121,7 @@ std::shared_ptr<tbox::Timer> Euler::t_taggradient;
  */
 
 Euler::Euler(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> input_db,
    std::shared_ptr<geom::CartesianGridGeometry> grid_geom):
@@ -289,7 +288,7 @@ Euler::Euler(
          d_object_name << ": "
                        << "Unknown d_riemann_solve string = "
                        << d_riemann_solve
-                       << " encountered in constructor" << endl);
+                       << " encountered in constructor" << std::endl);
    }
 
    if (d_data_problem == "PIECEWISE_CONSTANT_X") {
@@ -307,7 +306,7 @@ Euler::Euler(
          d_object_name << ": "
                        << "Unknown d_data_problem string = "
                        << d_data_problem
-                       << " encountered in constructor" << endl);
+                       << " encountered in constructor" << std::endl);
    }
 
    /*
@@ -499,7 +498,7 @@ void Euler::registerModelVariables(
       TBOX_WARNING(d_object_name << ": registerModelVariables()\n"
                                  << "VisIt data writer was not registered\n"
                                  << "Consequently, no plot data will\n"
-                                 << "be written." << endl);
+                                 << "be written." << std::endl);
    }
 #endif
 
@@ -546,7 +545,7 @@ void Euler::setupLoadBalancer(
          TBOX_WARNING(
             d_object_name << ": "
                           << "  Unknown load balancer used in gridding algorithm."
-                          << "  Ignoring request for nonuniform load balancing." << endl);
+                          << "  Ignoring request for nonuniform load balancing." << std::endl);
          d_use_nonuniform_workload = false;
       }
    } else {
@@ -2434,7 +2433,7 @@ void Euler::tagGradientDetectorCells(
    for (int ncrit = 0;
         ncrit < static_cast<int>(d_refinement_criteria.size()); ++ncrit) {
 
-      string ref = d_refinement_criteria[ncrit];
+      std::string ref = d_refinement_criteria[ncrit];
       std::shared_ptr<pdat::CellData<double> > var;
       int size = 0;
       double tol = 0.;
@@ -2717,7 +2716,7 @@ void Euler::tagRichardsonExtrapolationCells(
    for (int ncrit = 0;
         ncrit < static_cast<int>(d_refinement_criteria.size()); ++ncrit) {
 
-      string ref = d_refinement_criteria[ncrit];
+      std::string ref = d_refinement_criteria[ncrit];
       std::shared_ptr<pdat::CellData<double> > coarsened_fine_var;
       std::shared_ptr<pdat::CellData<double> > advanced_coarse_var;
       int size = 0;
@@ -2909,7 +2908,7 @@ bool Euler::packDerivedDataIntoDoubleBuffer(
    double* dbuffer,
    const hier::Patch& patch,
    const hier::Box& region,
-   const string& variable_name,
+   const std::string& variable_name,
    int depth_id,
    double simulation_time) const
 {
@@ -3062,7 +3061,7 @@ void Euler::writeData1dPencil(
    const std::shared_ptr<hier::Patch> patch,
    const hier::Box& pencil_box,
    const tbox::Dimension::dir_t idir,
-   ostream& file)
+   std::ostream& file)
 {
 
    const hier::Box& patchbox = patch->getBox();
@@ -3130,7 +3129,7 @@ void Euler::writeData1dPencil(
          file << vel << " ";
          file << eint << " ";
 
-         file << endl;
+         file << std::endl;
       }
 
    }
@@ -3146,292 +3145,292 @@ void Euler::writeData1dPencil(
  */
 
 void Euler::printClassData(
-   ostream& os) const
+   std::ostream& os) const
 {
    int j, k;
 
-   os << "\nEuler::printClassData..." << endl;
-   os << "Euler: this = " << (Euler *)this << endl;
-   os << "d_object_name = " << d_object_name << endl;
+   os << "\nEuler::printClassData..." << std::endl;
+   os << "Euler: this = " << (Euler *)this << std::endl;
+   os << "d_object_name = " << d_object_name << std::endl;
    os << "d_grid_geometry = "
-      << d_grid_geometry.get() << endl;
+      << d_grid_geometry.get() << std::endl;
 
-   os << "Parameters for physical problem ..." << endl;
-   os << "   d_gamma = " << d_gamma << endl;
+   os << "Parameters for physical problem ..." << std::endl;
+   os << "   d_gamma = " << d_gamma << std::endl;
 
-   os << "Numerical method description and ghost sizes..." << endl;
-   os << "   d_riemann_solve = " << d_riemann_solve << endl;
-   os << "   d_riemann_solve_int = " << d_riemann_solve_int << endl;
-   os << "   d_godunov_order = " << d_godunov_order << endl;
-   os << "   d_corner_transport = " << d_corner_transport << endl;
-   os << "   d_nghosts = " << d_nghosts << endl;
-   os << "   d_fluxghosts = " << d_fluxghosts << endl;
+   os << "Numerical method description and ghost sizes..." << std::endl;
+   os << "   d_riemann_solve = " << d_riemann_solve << std::endl;
+   os << "   d_riemann_solve_int = " << d_riemann_solve_int << std::endl;
+   os << "   d_godunov_order = " << d_godunov_order << std::endl;
+   os << "   d_corner_transport = " << d_corner_transport << std::endl;
+   os << "   d_nghosts = " << d_nghosts << std::endl;
+   os << "   d_fluxghosts = " << d_fluxghosts << std::endl;
 
-   os << "Problem description and initial data..." << endl;
-   os << "   d_data_problem = " << d_data_problem << endl;
-   os << "   d_data_problem_int = " << d_data_problem_int << endl;
+   os << "Problem description and initial data..." << std::endl;
+   os << "   d_data_problem = " << d_data_problem << std::endl;
+   os << "   d_data_problem_int = " << d_data_problem_int << std::endl;
 
-   os << "       d_radius = " << d_radius << endl;
+   os << "       d_radius = " << d_radius << std::endl;
    os << "       d_center = ";
    for (j = 0; j < d_dim.getValue(); ++j) os << d_center[j] << " ";
-   os << endl;
-   os << "       d_density_inside = " << d_density_inside << endl;
+   os << std::endl;
+   os << "       d_density_inside = " << d_density_inside << std::endl;
    os << "       d_velocity_inside = ";
    for (j = 0; j < d_dim.getValue(); ++j) os << d_velocity_inside[j] << " ";
-   os << endl;
-   os << "       d_pressure_inside = " << d_pressure_inside << endl;
-   os << "       d_density_outside = " << d_density_outside << endl;
+   os << std::endl;
+   os << "       d_pressure_inside = " << d_pressure_inside << std::endl;
+   os << "       d_density_outside = " << d_density_outside << std::endl;
    os << "       d_velocity_outside = ";
    for (j = 0; j < d_dim.getValue(); ++j) os << d_velocity_outside[j] << " ";
-   os << endl;
-   os << "       d_pressure_outside = " << d_pressure_outside << endl;
+   os << std::endl;
+   os << "       d_pressure_outside = " << d_pressure_outside << std::endl;
 
-   os << "       d_number_of_intervals = " << d_number_of_intervals << endl;
+   os << "       d_number_of_intervals = " << d_number_of_intervals << std::endl;
    os << "       d_front_position = ";
    for (k = 0; k < d_number_of_intervals - 1; ++k) {
       os << d_front_position[k] << "  ";
    }
-   os << endl;
-   os << "       d_interval_density = " << endl;
+   os << std::endl;
+   os << "       d_interval_density = " << std::endl;
    for (k = 0; k < d_number_of_intervals; ++k) {
-      os << "            " << d_interval_density[k] << endl;
+      os << "            " << d_interval_density[k] << std::endl;
    }
-   os << "       d_interval_velocity = " << endl;
+   os << "       d_interval_velocity = " << std::endl;
    for (k = 0; k < d_number_of_intervals; ++k) {
       os << "            ";
       for (j = 0; j < d_dim.getValue(); ++j) {
          os << d_interval_velocity[k * d_dim.getValue() + j] << "  ";
       }
-      os << endl;
+      os << std::endl;
    }
-   os << "       d_interval_pressure = " << endl;
+   os << "       d_interval_pressure = " << std::endl;
    for (k = 0; k < d_number_of_intervals; ++k) {
-      os << "            " << d_interval_pressure[k] << endl;
+      os << "            " << d_interval_pressure[k] << std::endl;
    }
 
-   os << "   Boundary condition data " << endl;
+   os << "   Boundary condition data " << std::endl;
 
    if (d_dim == tbox::Dimension(2)) {
       for (j = 0; j < static_cast<int>(d_master_bdry_edge_conds.size()); ++j) {
          os << "\n       d_master_bdry_edge_conds[" << j << "] = "
-            << d_master_bdry_edge_conds[j] << endl;
+            << d_master_bdry_edge_conds[j] << std::endl;
          os << "       d_scalar_bdry_edge_conds[" << j << "] = "
-            << d_scalar_bdry_edge_conds[j] << endl;
+            << d_scalar_bdry_edge_conds[j] << std::endl;
          os << "       d_vector_bdry_edge_conds[" << j << "] = "
-            << d_vector_bdry_edge_conds[j] << endl;
+            << d_vector_bdry_edge_conds[j] << std::endl;
          if (d_master_bdry_edge_conds[j] == BdryCond::DIRICHLET) {
             os << "         d_bdry_edge_density[" << j << "] = "
-               << d_bdry_edge_density[j] << endl;
+               << d_bdry_edge_density[j] << std::endl;
             os << "         d_bdry_edge_velocity[" << j << "] = "
                << d_bdry_edge_velocity[j * d_dim.getValue() + 0] << " , "
-               << d_bdry_edge_velocity[j * d_dim.getValue() + 1] << endl;
+               << d_bdry_edge_velocity[j * d_dim.getValue() + 1] << std::endl;
             os << "         d_bdry_edge_pressure[" << j << "] = "
-               << d_bdry_edge_pressure[j] << endl;
+               << d_bdry_edge_pressure[j] << std::endl;
          }
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_master_bdry_node_conds.size()); ++j) {
          os << "\n       d_master_bdry_node_conds[" << j << "] = "
-            << d_master_bdry_node_conds[j] << endl;
+            << d_master_bdry_node_conds[j] << std::endl;
          os << "       d_scalar_bdry_node_conds[" << j << "] = "
-            << d_scalar_bdry_node_conds[j] << endl;
+            << d_scalar_bdry_node_conds[j] << std::endl;
          os << "       d_vector_bdry_node_conds[" << j << "] = "
-            << d_vector_bdry_node_conds[j] << endl;
+            << d_vector_bdry_node_conds[j] << std::endl;
          os << "       d_node_bdry_edge[" << j << "] = "
-            << d_node_bdry_edge[j] << endl;
+            << d_node_bdry_edge[j] << std::endl;
       }
    }
    if (d_dim == tbox::Dimension(3)) {
       for (j = 0; j < static_cast<int>(d_master_bdry_face_conds.size()); ++j) {
          os << "\n       d_master_bdry_face_conds[" << j << "] = "
-            << d_master_bdry_face_conds[j] << endl;
+            << d_master_bdry_face_conds[j] << std::endl;
          os << "       d_scalar_bdry_face_conds[" << j << "] = "
-            << d_scalar_bdry_face_conds[j] << endl;
+            << d_scalar_bdry_face_conds[j] << std::endl;
          os << "       d_vector_bdry_face_conds[" << j << "] = "
-            << d_vector_bdry_face_conds[j] << endl;
+            << d_vector_bdry_face_conds[j] << std::endl;
          if (d_master_bdry_face_conds[j] == BdryCond::DIRICHLET) {
             os << "         d_bdry_face_density[" << j << "] = "
-               << d_bdry_face_density[j] << endl;
+               << d_bdry_face_density[j] << std::endl;
             os << "         d_bdry_face_velocity[" << j << "] = "
                << d_bdry_face_velocity[j * d_dim.getValue() + 0] << " , "
                << d_bdry_face_velocity[j * d_dim.getValue() + 1] << " , "
-               << d_bdry_face_velocity[j * d_dim.getValue() + 2] << endl;
+               << d_bdry_face_velocity[j * d_dim.getValue() + 2] << std::endl;
             os << "         d_bdry_face_pressure[" << j << "] = "
-               << d_bdry_face_pressure[j] << endl;
+               << d_bdry_face_pressure[j] << std::endl;
          }
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_master_bdry_edge_conds.size()); ++j) {
          os << "\n       d_master_bdry_edge_conds[" << j << "] = "
-            << d_master_bdry_edge_conds[j] << endl;
+            << d_master_bdry_edge_conds[j] << std::endl;
          os << "       d_scalar_bdry_edge_conds[" << j << "] = "
-            << d_scalar_bdry_edge_conds[j] << endl;
+            << d_scalar_bdry_edge_conds[j] << std::endl;
          os << "       d_vector_bdry_edge_conds[" << j << "] = "
-            << d_vector_bdry_edge_conds[j] << endl;
+            << d_vector_bdry_edge_conds[j] << std::endl;
          os << "       d_edge_bdry_face[" << j << "] = "
-            << d_edge_bdry_face[j] << endl;
+            << d_edge_bdry_face[j] << std::endl;
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_master_bdry_node_conds.size()); ++j) {
          os << "\n       d_master_bdry_node_conds[" << j << "] = "
-            << d_master_bdry_node_conds[j] << endl;
+            << d_master_bdry_node_conds[j] << std::endl;
          os << "       d_scalar_bdry_node_conds[" << j << "] = "
-            << d_scalar_bdry_node_conds[j] << endl;
+            << d_scalar_bdry_node_conds[j] << std::endl;
          os << "       d_vector_bdry_node_conds[" << j << "] = "
-            << d_vector_bdry_node_conds[j] << endl;
+            << d_vector_bdry_node_conds[j] << std::endl;
          os << "       d_node_bdry_face[" << j << "] = "
-            << d_node_bdry_face[j] << endl;
+            << d_node_bdry_face[j] << std::endl;
       }
    }
 
-   os << "   Refinement criteria parameters " << endl;
+   os << "   Refinement criteria parameters " << std::endl;
 
    for (j = 0; j < static_cast<int>(d_refinement_criteria.size()); ++j) {
       os << "       d_refinement_criteria[" << j << "] = "
-         << d_refinement_criteria[j] << endl;
+         << d_refinement_criteria[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_dev_tol.size()); ++j) {
       os << "       d_density_dev_tol[" << j << "] = "
-         << d_density_dev_tol[j] << endl;
+         << d_density_dev_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_dev.size()); ++j) {
       os << "       d_density_dev[" << j << "] = "
-         << d_density_dev[j] << endl;
+         << d_density_dev[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_dev_time_max.size()); ++j) {
       os << "       d_density_dev_time_max[" << j << "] = "
-         << d_density_dev_time_max[j] << endl;
+         << d_density_dev_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_dev_time_min.size()); ++j) {
       os << "       d_density_dev_time_min[" << j << "] = "
-         << d_density_dev_time_min[j] << endl;
+         << d_density_dev_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_grad_tol.size()); ++j) {
       os << "       d_density_grad_tol[" << j << "] = "
-         << d_density_grad_tol[j] << endl;
+         << d_density_grad_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_grad_time_max.size()); ++j) {
       os << "       d_density_grad_time_max[" << j << "] = "
-         << d_density_grad_time_max[j] << endl;
+         << d_density_grad_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_grad_time_min.size()); ++j) {
       os << "       d_density_grad_time_min[" << j << "] = "
-         << d_density_grad_time_min[j] << endl;
+         << d_density_grad_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_shock_onset.size()); ++j) {
       os << "       d_density_shock_onset[" << j << "] = "
-         << d_density_shock_onset[j] << endl;
+         << d_density_shock_onset[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_shock_tol.size()); ++j) {
       os << "       d_density_shock_tol[" << j << "] = "
-         << d_density_shock_tol[j] << endl;
+         << d_density_shock_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_shock_time_max.size()); ++j) {
       os << "       d_density_shock_time_max[" << j << "] = "
-         << d_density_shock_time_max[j] << endl;
+         << d_density_shock_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_shock_time_min.size()); ++j) {
       os << "       d_density_shock_time_min[" << j << "] = "
-         << d_density_shock_time_min[j] << endl;
+         << d_density_shock_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_rich_tol.size()); ++j) {
       os << "       d_density_rich_tol[" << j << "] = "
-         << d_density_rich_tol[j] << endl;
+         << d_density_rich_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_rich_time_max.size()); ++j) {
       os << "       d_density_rich_time_max[" << j << "] = "
-         << d_density_rich_time_max[j] << endl;
+         << d_density_rich_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_rich_time_min.size()); ++j) {
       os << "       d_density_rich_time_min[" << j << "] = "
-         << d_density_rich_time_min[j] << endl;
+         << d_density_rich_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
 
    for (j = 0; j < static_cast<int>(d_pressure_dev_tol.size()); ++j) {
       os << "       d_pressure_dev_tol[" << j << "] = "
-         << d_pressure_dev_tol[j] << endl;
+         << d_pressure_dev_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_dev.size()); ++j) {
       os << "       d_pressure_dev[" << j << "] = "
-         << d_pressure_dev[j] << endl;
+         << d_pressure_dev[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_dev_time_max.size()); ++j) {
       os << "       d_pressure_dev_time_max[" << j << "] = "
-         << d_pressure_dev_time_max[j] << endl;
+         << d_pressure_dev_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_dev_time_min.size()); ++j) {
       os << "       d_pressure_dev_time_min[" << j << "] = "
-         << d_pressure_dev_time_min[j] << endl;
+         << d_pressure_dev_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_grad_tol.size()); ++j) {
       os << "       d_pressure_grad_tol[" << j << "] = "
-         << d_pressure_grad_tol[j] << endl;
+         << d_pressure_grad_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_grad_time_max.size()); ++j) {
       os << "       d_pressure_grad_time_max[" << j << "] = "
-         << d_pressure_grad_time_max[j] << endl;
+         << d_pressure_grad_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_grad_time_min.size()); ++j) {
       os << "       d_pressure_grad_time_min[" << j << "] = "
-         << d_pressure_grad_time_min[j] << endl;
+         << d_pressure_grad_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_shock_onset.size()); ++j) {
       os << "       d_pressure_shock_onset[" << j << "] = "
-         << d_pressure_shock_onset[j] << endl;
+         << d_pressure_shock_onset[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_shock_tol.size()); ++j) {
       os << "       d_pressure_shock_tol[" << j << "] = "
-         << d_pressure_shock_tol[j] << endl;
+         << d_pressure_shock_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_shock_time_max.size()); ++j) {
       os << "       d_pressure_shock_time_max[" << j << "] = "
-         << d_pressure_shock_time_max[j] << endl;
+         << d_pressure_shock_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_shock_time_min.size()); ++j) {
       os << "       d_pressure_shock_time_min[" << j << "] = "
-         << d_pressure_shock_time_min[j] << endl;
+         << d_pressure_shock_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_rich_tol.size()); ++j) {
       os << "       d_pressure_rich_tol[" << j << "] = "
-         << d_pressure_rich_tol[j] << endl;
+         << d_pressure_rich_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_rich_time_max.size()); ++j) {
       os << "       d_pressure_rich_time_max[" << j << "] = "
-         << d_pressure_rich_time_max[j] << endl;
+         << d_pressure_rich_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_rich_time_min.size()); ++j) {
       os << "       d_pressure_rich_time_min[" << j << "] = "
-         << d_pressure_rich_time_min[j] << endl;
+         << d_pressure_rich_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
 
 }
 
@@ -3478,7 +3477,7 @@ void Euler::getFromInput(
             d_object_name << ": "
                           << "`riemann_solve' in input must be either string "
                           << "'APPROX_RIEM_SOLVE', 'EXACT_RIEM_SOLVE', "
-                          << "'HLLC_RIEM_SOLVE'." << endl);
+                          << "'HLLC_RIEM_SOLVE'." << std::endl);
 
       }
    } else {
@@ -3493,7 +3492,7 @@ void Euler::getFromInput(
           (d_godunov_order != 4)) {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "`godunov_order' in input must be 1, 2, or 4." << endl);
+                          << "`godunov_order' in input must be 1, 2, or 4." << std::endl);
 
       }
    } else {
@@ -3508,7 +3507,7 @@ void Euler::getFromInput(
          TBOX_ERROR(
             d_object_name << ": "
                           << "`corner_transport' in input must be either string"
-                          << " 'CORNER_TRANSPORT_1' or 'CORNER_TRANSPORT_2'." << endl);
+                          << " 'CORNER_TRANSPORT_1' or 'CORNER_TRANSPORT_2'." << std::endl);
       }
    } else {
       d_corner_transport = input_db->getStringWithDefault("corner_transport",
@@ -3518,7 +3517,7 @@ void Euler::getFromInput(
    if (input_db->keyExists("Refinement_data")) {
       std::shared_ptr<tbox::Database> refine_db(
          input_db->getDatabase("Refinement_data"));
-      std::vector<string> refinement_keys = refine_db->getAllKeys();
+      std::vector<std::string> refinement_keys = refine_db->getAllKeys();
       int num_keys = static_cast<int>(refinement_keys.size());
 
       if (refine_db->keyExists("refine_criteria")) {
@@ -3527,15 +3526,15 @@ void Euler::getFromInput(
          TBOX_WARNING(
             d_object_name << ": "
                           << "No key `refine_criteria' found in data for"
-                          << " RefinementData. No refinement will occur." << endl);
+                          << " RefinementData. No refinement will occur." << std::endl);
       }
 
-      std::vector<string> ref_keys_defined(num_keys);
+      std::vector<std::string> ref_keys_defined(num_keys);
       int def_key_cnt = 0;
       std::shared_ptr<tbox::Database> error_db;
       for (int i = 0; i < num_keys; ++i) {
 
-         string error_key = refinement_keys[i];
+         std::string error_key = refinement_keys[i];
          error_db.reset();
 
          if (!(error_key == "refine_criteria")) {
@@ -3552,7 +3551,7 @@ void Euler::getFromInput(
                   d_object_name << ": "
                                 << "Unknown refinement criteria: "
                                 << error_key
-                                << "\nin input." << endl);
+                                << "\nin input." << std::endl);
             } else {
                error_db = refine_db->getDatabase(error_key);
                ref_keys_defined[def_key_cnt] = error_key;
@@ -3567,7 +3566,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `dev_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("density_dev")) {
@@ -3576,7 +3575,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `density_dev' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -3606,7 +3605,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `grad_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -3637,7 +3636,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `shock_onset' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("shock_tol")) {
@@ -3646,7 +3645,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `shock_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -3676,7 +3675,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `rich_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -3706,7 +3705,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `dev_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("pressure_dev")) {
@@ -3715,7 +3714,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `pressure_dev' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -3745,7 +3744,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `grad_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -3776,7 +3775,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `shock_onset' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("shock_tol")) {
@@ -3786,7 +3785,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `shock_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -3816,7 +3815,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `rich_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -3847,17 +3846,17 @@ void Euler::getFromInput(
        */
       for (int k0 = 0;
            k0 < static_cast<int>(d_refinement_criteria.size()); ++k0) {
-         string use_key = d_refinement_criteria[k0];
+         std::string use_key = d_refinement_criteria[k0];
          bool key_found = false;
          for (int k1 = 0; k1 < def_key_cnt; ++k1) {
-            string def_key = ref_keys_defined[k1];
+            std::string def_key = ref_keys_defined[k1];
             if (def_key == use_key) key_found = true;
          }
 
          if (!key_found) {
             TBOX_ERROR(d_object_name << ": "
                                      << "No input found for specified refine criteria: "
-                                     << d_refinement_criteria[k0] << endl);
+                                     << d_refinement_criteria[k0] << std::endl);
          }
       }
 
@@ -3871,13 +3870,13 @@ void Euler::getFromInput(
          TBOX_ERROR(
             d_object_name << ": "
                           << "`data_problem' value not found in input."
-                          << endl);
+                          << std::endl);
       }
 
       if (!input_db->keyExists("Initial_data")) {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "No `Initial_data' database found in input." << endl);
+                          << "No `Initial_data' database found in input." << std::endl);
       }
       std::shared_ptr<tbox::Database> init_data_db(
          input_db->getDatabase("Initial_data"));
@@ -3891,21 +3890,21 @@ void Euler::getFromInput(
          } else {
             TBOX_ERROR(
                d_object_name << ": "
-                             << "`radius' input required for SPHERE problem." << endl);
+                             << "`radius' input required for SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("center")) {
             init_data_db->getDoubleArray("center", d_center, d_dim.getValue());
          } else {
             TBOX_ERROR(
                d_object_name << ": "
-                             << "`center' input required for SPHERE problem." << endl);
+                             << "`center' input required for SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("density_inside")) {
             d_density_inside = init_data_db->getDouble("density_inside");
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`density_inside' input required for "
-                                     << "SPHERE problem." << endl);
+                                     << "SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("velocity_inside")) {
             init_data_db->getDoubleArray("velocity_inside",
@@ -3913,21 +3912,21 @@ void Euler::getFromInput(
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`velocity_inside' input required for "
-                                     << "SPHERE problem." << endl);
+                                     << "SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("pressure_inside")) {
             d_pressure_inside = init_data_db->getDouble("pressure_inside");
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`pressure_inside' input required for "
-                                     << "SPHERE problem." << endl);
+                                     << "SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("density_outside")) {
             d_density_outside = init_data_db->getDouble("density_outside");
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`density_outside' input required for "
-                                     << "SPHERE problem." << endl);
+                                     << "SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("velocity_outside")) {
             init_data_db->getDoubleArray("velocity_outside",
@@ -3936,7 +3935,7 @@ void Euler::getFromInput(
             TBOX_ERROR(
                d_object_name << ": "
                              << "`velocity_outside' input required for "
-                             << "SPHERE problem." << endl);
+                             << "SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("pressure_outside")) {
             d_pressure_outside = init_data_db->getDouble("pressure_outside");
@@ -3944,7 +3943,7 @@ void Euler::getFromInput(
             TBOX_ERROR(
                d_object_name << ": "
                              << "`pressure_outside' input required for "
-                             << "SPHERE problem." << endl);
+                             << "SPHERE problem." << std::endl);
          }
 
          found_problem_data = true;
@@ -3967,19 +3966,19 @@ void Euler::getFromInput(
                TBOX_ERROR(
                   d_object_name << ": `PIECEWISE_CONSTANT_Z' "
                                 << "problem invalid in 2 dimensions."
-                                << endl);
+                                << std::endl);
             }
             idir = 2;
          }
 
-         std::vector<string> init_data_keys = init_data_db->getAllKeys();
+         std::vector<std::string> init_data_keys = init_data_db->getAllKeys();
 
          if (init_data_db->keyExists("front_position")) {
             d_front_position = init_data_db->getDoubleVector("front_position");
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`front_position' input required for "
-                                     << "PIECEWISE_CONSTANT_* problem." << endl);
+                                     << "PIECEWISE_CONSTANT_* problem." << std::endl);
          }
 
          d_number_of_intervals =
@@ -4028,7 +4027,7 @@ void Euler::getFromInput(
             TBOX_ERROR(
                d_object_name << ": "
                              << "Insufficient interval data given in input"
-                             << " for PIECEWISE_CONSTANT_* or STEP problem." << endl);
+                             << " for PIECEWISE_CONSTANT_* or STEP problem." << std::endl);
          }
 
          found_problem_data = true;
@@ -4038,7 +4037,7 @@ void Euler::getFromInput(
       if (!found_problem_data) {
          TBOX_ERROR(d_object_name << ": "
                                   << "`Initial_data' database found in input."
-                                  << " But bad data supplied." << endl);
+                                  << " But bad data supplied." << std::endl);
       }
 
    } // if !is_from_restart read in problem data
@@ -4076,7 +4075,7 @@ void Euler::getFromInput(
       } else {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "Key data `Boundary_data' not found in input. " << endl);
+                          << "Key data `Boundary_data' not found in input. " << std::endl);
       }
 
    }
@@ -4262,7 +4261,7 @@ void Euler::getFromRestart()
 
    if (!root_db->isDatabase(d_object_name)) {
       TBOX_ERROR("Restart database corresponding to "
-         << d_object_name << " not found in restart file." << endl);
+         << d_object_name << " not found in restart file." << std::endl);
    }
    std::shared_ptr<tbox::Database> db(root_db->getDatabase(d_object_name));
 
@@ -4270,7 +4269,7 @@ void Euler::getFromRestart()
    if (ver != EULER_VERSION) {
       TBOX_ERROR(
          d_object_name << ": "
-                       << "Restart file version different than class version." << endl);
+                       << "Restart file version different than class version." << std::endl);
    }
 
    d_gamma = db->getDouble("d_gamma");
@@ -4285,7 +4284,7 @@ void Euler::getFromRestart()
       if (d_nghosts(i) != CELLG) {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "Key data `d_nghosts' in restart file != CELLG." << endl);
+                          << "Key data `d_nghosts' in restart file != CELLG." << std::endl);
       }
    }
    int* tmp_fluxghosts = &d_fluxghosts[0];
@@ -4294,7 +4293,7 @@ void Euler::getFromRestart()
       if (d_fluxghosts(i) != FLUXG) {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "Key data `d_fluxghosts' in restart file != FLUXG." << endl);
+                          << "Key data `d_fluxghosts' in restart file != FLUXG." << std::endl);
       }
    }
 
@@ -4443,7 +4442,7 @@ void Euler::getFromRestart()
 
 void Euler::readDirichletBoundaryDataEntry(
    const std::shared_ptr<tbox::Database>& db,
-   string& db_name,
+   std::string& db_name,
    int bdry_location_index)
 {
    TBOX_ASSERT(db);
@@ -4469,7 +4468,7 @@ void Euler::readDirichletBoundaryDataEntry(
 
 void Euler::readNeumannBoundaryDataEntry(
    const std::shared_ptr<tbox::Database>& db,
-   string& db_name,
+   std::string& db_name,
    int bdry_location_index)
 {
    NULL_USE(db);
@@ -4479,7 +4478,7 @@ void Euler::readNeumannBoundaryDataEntry(
 
 void Euler::readStateDataEntry(
    std::shared_ptr<tbox::Database> db,
-   const string& db_name,
+   const std::string& db_name,
    int array_indx,
    std::vector<double>& density,
    std::vector<double>& velocity,
@@ -4497,7 +4496,7 @@ void Euler::readStateDataEntry(
    } else {
       TBOX_ERROR(d_object_name << ": "
                                << "`density' entry missing from " << db_name
-                               << " input database. " << endl);
+                               << " input database. " << std::endl);
    }
    if (db->keyExists("velocity")) {
       std::vector<double> tmp_vel = db->getDoubleVector("velocity");
@@ -4505,7 +4504,7 @@ void Euler::readStateDataEntry(
          TBOX_ERROR(d_object_name << ": "
                                   << "Insufficient number `velocity' values"
                                   << " given in " << db_name
-                                  << " input database." << endl);
+                                  << " input database." << std::endl);
       }
       for (int iv = 0; iv < d_dim.getValue(); ++iv) {
          velocity[array_indx * d_dim.getValue() + iv] = tmp_vel[iv];
@@ -4513,14 +4512,14 @@ void Euler::readStateDataEntry(
    } else {
       TBOX_ERROR(d_object_name << ": "
                                << "`velocity' entry missing from " << db_name
-                               << " input database. " << endl);
+                               << " input database. " << std::endl);
    }
    if (db->keyExists("pressure")) {
       pressure[array_indx] = db->getDouble("pressure");
    } else {
       TBOX_ERROR(d_object_name << ": "
                                << "`pressure' entry missing from " << db_name
-                               << " input database. " << endl);
+                               << " input database. " << std::endl);
    }
 
 }
@@ -4650,7 +4649,7 @@ void Euler::checkBoundaryData(
                     << "     " << num_bad_values
                     << " bad DENSITY values found for\n"
                     << "     boundary type " << btype << " at location "
-                    << bloc << endl;
+                    << bloc << std::endl;
       }
 #endif
 
@@ -4684,7 +4683,7 @@ void Euler::checkBoundaryData(
                     << "     " << num_bad_values
                     << " bad PRESSURE values found for\n"
                     << "     boundary type " << btype << " at location "
-                    << bloc << endl;
+                    << bloc << std::endl;
       }
 #endif
 
@@ -4751,7 +4750,7 @@ void Euler::checkBoundaryData(
                        << " bad VELOCITY values found in direction " << idir
                        << " for\n"
                        << "     boundary type " << btype << " at location "
-                       << bloc << endl;
+                       << bloc << std::endl;
          }
 #endif
       }

--- a/source/test/applications/Euler/Euler.h
+++ b/source/test/applications/Euler/Euler.h
@@ -36,7 +36,6 @@
 #include <vector>
 #include <memory>
 
-using namespace std;
 
 /**
  * The Euler class provides routines for a sample application code that
@@ -75,7 +74,7 @@ public:
     * database (potentially overriding those found in the restart file).
     */
    Euler(
-      const string& object_name,
+      const std::string& object_name,
       const tbox::Dimension& dim,
       std::shared_ptr<tbox::Database> input_db,
       std::shared_ptr<geom::CartesianGridGeometry> grid_geom);
@@ -327,7 +326,7 @@ public:
    void
    readDirichletBoundaryDataEntry(
       const std::shared_ptr<tbox::Database>& db,
-      string& db_name,
+      std::string& db_name,
       int bdry_location_index);
 
    /**
@@ -338,7 +337,7 @@ public:
    void
    readNeumannBoundaryDataEntry(
       const std::shared_ptr<tbox::Database>& db,
-      string& db_name,
+      std::string& db_name,
       int bdry_location_index);
 
    /**
@@ -374,7 +373,7 @@ public:
       double* buffer,
       const hier::Patch& patch,
       const hier::Box& region,
-      const string& variable_name,
+      const std::string& variable_name,
       int depth_id,
       double simulation_time) const;
 
@@ -398,7 +397,7 @@ public:
     */
    void
    printClassData(
-      ostream& os) const;
+      std::ostream& os) const;
 
    /*
     * Dump data in intersection of 1-dimensional "pencil box" to file
@@ -411,7 +410,7 @@ public:
       const std::shared_ptr<hier::Patch> patch,
       const hier::Box& pencil_box,
       const tbox::Dimension::dir_t idir,
-      ostream& file);
+      std::ostream& file);
 
 private:
    /*
@@ -433,7 +432,7 @@ private:
    void
    readStateDataEntry(
       std::shared_ptr<tbox::Database> db,
-      const string& db_name,
+      const std::string& db_name,
       int array_indx,
       std::vector<double>& density,
       std::vector<double>& velocity,
@@ -468,7 +467,7 @@ private:
     * The object name is used for error/warning reporting and also as a
     * string label for restart database entries.
     */
-   string d_object_name;
+   std::string d_object_name;
 
    /*
     * We cache pointers to the grid geometry and Vis data writers
@@ -529,17 +528,17 @@ private:
     *    d_fluxghosts .......... number of ghost cells for fluxes
     *
     */
-   string d_riemann_solve;
+   std::string d_riemann_solve;
    int d_riemann_solve_int;
    int d_godunov_order;
-   string d_corner_transport;
+   std::string d_corner_transport;
    hier::IntVector d_nghosts;
    hier::IntVector d_fluxghosts;
 
    /*
     * Indicator for problem type and initial conditions
     */
-   string d_data_problem;
+   std::string d_data_problem;
    int d_data_problem_int;
 
    /*
@@ -606,7 +605,7 @@ private:
     * Refinement criteria parameters for gradient detector and
     * Richardson extrapolation.
     */
-   std::vector<string> d_refinement_criteria;
+   std::vector<std::string> d_refinement_criteria;
    std::vector<double> d_density_dev_tol;
    std::vector<double> d_density_dev;
    std::vector<double> d_density_dev_time_max;

--- a/source/test/applications/Euler/main.C
+++ b/source/test/applications/Euler/main.C
@@ -51,7 +51,6 @@
 #include <string>
 #include <fstream>
 #include <memory>
-using namespace std;
 
 #ifndef _MSC_VER
 #include <unistd.h>
@@ -176,8 +175,8 @@ using namespace SAMRAI;
 
 static void
 dumpMatlabData1dPencil(
-   const string& dirname,
-   const string& filename,
+   const std::string& dirname,
+   const std::string& filename,
    const int ext,
    const double plot_time,
    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
@@ -204,8 +203,8 @@ int main(
 
    {
 
-      string input_filename;
-      string restart_read_dirname;
+      std::string input_filename;
+      std::string restart_read_dirname;
       int restore_num = 0;
 
       bool is_from_restart = false;
@@ -215,7 +214,7 @@ int main(
                     << "<restart dir> <restore number> [options]\n"
                     << "  options:\n"
                     << "  none at this time"
-                    << endl;
+                    << std::endl;
          tbox::SAMRAI_MPI::abort();
          return -1;
       } else {
@@ -228,9 +227,9 @@ int main(
          }
       }
 
-      tbox::plog << "input_filename = " << input_filename << endl;
-      tbox::plog << "restart_read_dirname = " << restart_read_dirname << endl;
-      tbox::plog << "restore_num = " << restore_num << endl;
+      tbox::plog << "input_filename = " << input_filename << std::endl;
+      tbox::plog << "restart_read_dirname = " << restart_read_dirname << std::endl;
+      tbox::plog << "restore_num = " << restore_num << std::endl;
 
       /*
        * Create input database and parse all data in input file.
@@ -252,7 +251,7 @@ int main(
 #ifdef SGS
          // TODO change to what?
          if (global_db->keyExists("tag_clustering_method")) {
-            string tag_clustering_method =
+            std::string tag_clustering_method =
                global_db->getString("tag_clustering_method");
             mesh::BergerRigoutsos::setClusteringOption(tag_clustering_method);
          }
@@ -317,8 +316,8 @@ int main(
          }
       }
 
-      string matlab_dump_filename;
-      string matlab_dump_dirname;
+      std::string matlab_dump_filename;
+      std::string matlab_dump_dirname;
       int matlab_dump_interval = 0;
       tbox::Dimension::dir_t matlab_pencil_direction = 0;
       std::vector<int> matlab_pencil_index(dim.getValue() - 1);
@@ -365,7 +364,7 @@ int main(
 
       bool use_refined_timestepping = true;
       if (main_db->keyExists("timestepping")) {
-         string timestepping_method = main_db->getString("timestepping");
+         std::string timestepping_method = main_db->getString("timestepping");
          if (timestepping_method == "SYNCHRONIZED") {
             use_refined_timestepping = false;
          }
@@ -532,14 +531,14 @@ int main(
 
 #if 1
       tbox::plog << "\nCheck input data and variables before simulation:"
-                 << endl;
-      tbox::plog << "Input database..." << endl;
+                 << std::endl;
+      tbox::plog << "Input database..." << std::endl;
       input_db->printClassData(tbox::plog);
-      tbox::plog << "\nVariable database..." << endl;
+      tbox::plog << "\nVariable database..." << std::endl;
       hier::VariableDatabase::getDatabase()->printClassData(tbox::plog);
 
 #endif
-      tbox::plog << "\nCheck Euler data... " << endl;
+      tbox::plog << "\nCheck Euler data... " << std::endl;
       euler_model->printClassData(tbox::plog);
 
       /*
@@ -599,20 +598,20 @@ int main(
 
          int iteration_num = time_integrator->getIntegratorStep() + 1;
 
-         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << endl;
+         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
          tbox::pout << "At begining of timestep # " << iteration_num - 1
-                    << endl;
-         tbox::pout << "Simulation time is " << loop_time << endl;
-         tbox::pout << "Current dt is " << dt_now << endl;
+                    << std::endl;
+         tbox::pout << "Simulation time is " << loop_time << std::endl;
+         tbox::pout << "Current dt is " << dt_now << std::endl;
 
          double dt_new = time_integrator->advanceHierarchy(dt_now);
 
          loop_time += dt_now;
          dt_now = dt_new;
 
-         tbox::pout << "At end of timestep # " << iteration_num - 1 << endl;
-         tbox::pout << "Simulation time is " << loop_time << endl;
-         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << endl;
+         tbox::pout << "At end of timestep # " << iteration_num - 1 << std::endl;
+         tbox::pout << "Simulation time is " << loop_time << std::endl;
+         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
 
          /*
           * At specified intervals, write restart files.
@@ -674,7 +673,7 @@ int main(
          tbox::plog << "Step " << num_buf
                     << " P" << mpi.getRank()
                     << ": " << tbox::SAMRAI_MPI::getIncomingBytes()
-                    << " bytes in" << endl;
+                    << " bytes in" << std::endl;
 #endif
 
       }
@@ -708,7 +707,7 @@ int main(
    }
 
    if (num_failures == 0) {
-      tbox::pout << "\nPASSED:  Euler" << endl;
+      tbox::pout << "\nPASSED:  Euler" << std::endl;
    }
 
    tbox::SAMRAIManager::shutdown();
@@ -719,8 +718,8 @@ int main(
 }
 
 static void dumpMatlabData1dPencil(
-   const string& dirname,
-   const string& filename,
+   const std::string& dirname,
+   const std::string& filename,
    const int ext,
    const double plot_time,
    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
@@ -795,7 +794,7 @@ static void dumpMatlabData1dPencil(
     * Create matlab filename and open the output stream.
     */
 
-   string dump_filename = filename;
+   std::string dump_filename = filename;
    if (!dirname.empty()) {
       tbox::Utilities::recursiveMkdir(dirname);
       dump_filename = dirname;
@@ -817,8 +816,8 @@ static void dumpMatlabData1dPencil(
     * Open a new output file having name name of buffer character array.
     */
 
-   ofstream outfile(buffer, ios::out);
-   outfile.setf(ios::scientific);
+   std::ofstream outfile(buffer, std::ios::out);
+   outfile.setf(std::ios::scientific);
    outfile.precision(10);
 
    delete[] buffer;
@@ -829,7 +828,7 @@ static void dumpMatlabData1dPencil(
    for (int i = 0; i < 6 + 1; ++i) {
       outfile << plot_time << "  ";
    }
-   outfile << endl;
+   outfile << std::endl;
 
    euler_model->setDataContext(
       hier::VariableDatabase::getDatabase()->getContext("CURRENT"));

--- a/source/test/applications/LinAdv/LinAdv.C
+++ b/source/test/applications/LinAdv/LinAdv.C
@@ -25,7 +25,6 @@
 #endif
 #endif
 
-using namespace std;
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -113,7 +112,7 @@ using namespace std;
  */
 
 LinAdv::LinAdv(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> input_db,
    std::shared_ptr<geom::CartesianGridGeometry> grid_geom):
@@ -234,7 +233,7 @@ LinAdv::LinAdv(
          d_object_name << ": "
                        << "Unknown d_data_problem string = "
                        << d_data_problem
-                       << " encountered in constructor" << endl);
+                       << " encountered in constructor" << std::endl);
    }
 
    /*
@@ -373,7 +372,7 @@ void LinAdv::registerModelVariables(
       TBOX_WARNING(d_object_name << ": registerModelVariables()"
                                  << "\nVisIt data writer was not registered.\n"
                                  << "Consequently, no plot data will"
-                                 << "\nbe written." << endl);
+                                 << "\nbe written." << std::endl);
    }
 #endif
 
@@ -420,7 +419,7 @@ void LinAdv::setupLoadBalancer(
          TBOX_WARNING(
             d_object_name << ": "
                           << "  Unknown load balancer used in gridding algorithm."
-                          << "  Ignoring request for nonuniform load balancing." << endl);
+                          << "  Ignoring request for nonuniform load balancing." << std::endl);
          d_use_nonuniform_workload = false;
       }
    } else {
@@ -853,7 +852,7 @@ void LinAdv::computeFluxesOnPatch(
             double delta = (*flux)(fm) - (*flux)(fp);
             if (fabs(delta) > 1.e-10) {
                tbox::perr << "\nLinAdv Time Refinement Test FAILED: \n"
-                          << " found non-zero net fluxes" << endl;
+                          << " found non-zero net fluxes" << std::endl;
             }
          }
       }
@@ -1145,7 +1144,7 @@ void LinAdv::compute3DFluxesWithCornerTransport1(
       traced_right.getPointer(1),
       traced_right.getPointer(2));
 
-//     tbox::plog << "flux values: option1...." << endl;
+//     tbox::plog << "flux values: option1...." << std::endl;
 //     flux->print(pbox, tbox::plog);
 
 }
@@ -1370,7 +1369,7 @@ void LinAdv::compute3DFluxesWithCornerTransport2(
       traced_right.getPointer(1),
       traced_right.getPointer(2));
 
-//     tbox::plog << "flux values: option2...." << endl;
+//     tbox::plog << "flux values: option2...." << std::endl;
 //     flux->print(pbox, tbox::plog);
 }
 
@@ -1702,7 +1701,7 @@ void LinAdv::tagRichardsonExtrapolationCells(
    for (int ncrit = 0;
         ncrit < static_cast<int>(d_refinement_criteria.size()); ++ncrit) {
 
-      string ref = d_refinement_criteria[ncrit];
+      std::string ref = d_refinement_criteria[ncrit];
       int size;
       double tol;
       bool time_allowed;
@@ -1911,7 +1910,7 @@ void LinAdv::tagGradientDetectorCells(
    for (int ncrit = 0;
         ncrit < static_cast<int>(d_refinement_criteria.size()); ++ncrit) {
 
-      string ref = d_refinement_criteria[ncrit];
+      std::string ref = d_refinement_criteria[ncrit];
       std::shared_ptr<pdat::CellData<double> > var(
          SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
             patch.getPatchData(d_uval, getDataContext())));
@@ -2138,167 +2137,167 @@ void LinAdv::registerVisItDataWriter(
  */
 
 void LinAdv::printClassData(
-   ostream& os) const
+   std::ostream& os) const
 {
    int j, k;
 
-   os << "\nLinAdv::printClassData..." << endl;
-   os << "LinAdv: this = " << (LinAdv *)this << endl;
-   os << "d_object_name = " << d_object_name << endl;
+   os << "\nLinAdv::printClassData..." << std::endl;
+   os << "LinAdv: this = " << (LinAdv *)this << std::endl;
+   os << "d_object_name = " << d_object_name << std::endl;
    os << "d_grid_geometry = "
-      << d_grid_geometry.get() << endl;
+      << d_grid_geometry.get() << std::endl;
 
-   os << "Parameters for numerical method ..." << endl;
+   os << "Parameters for numerical method ..." << std::endl;
    os << "   d_advection_velocity = ";
    for (j = 0; j < d_dim.getValue(); ++j) os << d_advection_velocity[j] << " ";
-   os << endl;
-   os << "   d_source = " << d_source << endl;
-   os << "   d_godunov_order = " << d_godunov_order << endl;
-   os << "   d_corner_transport = " << d_corner_transport << endl;
-   os << "   d_nghosts = " << d_nghosts << endl;
-   os << "   d_fluxghosts = " << d_fluxghosts << endl;
+   os << std::endl;
+   os << "   d_source = " << d_source << std::endl;
+   os << "   d_godunov_order = " << d_godunov_order << std::endl;
+   os << "   d_corner_transport = " << d_corner_transport << std::endl;
+   os << "   d_nghosts = " << d_nghosts << std::endl;
+   os << "   d_fluxghosts = " << d_fluxghosts << std::endl;
 
-   os << "Problem description and initial data..." << endl;
-   os << "   d_data_problem = " << d_data_problem << endl;
-   os << "   d_data_problem_int = " << d_data_problem << endl;
+   os << "Problem description and initial data..." << std::endl;
+   os << "   d_data_problem = " << d_data_problem << std::endl;
+   os << "   d_data_problem_int = " << d_data_problem << std::endl;
 
-   os << "       d_radius = " << d_radius << endl;
+   os << "       d_radius = " << d_radius << std::endl;
    os << "       d_center = ";
    for (j = 0; j < d_dim.getValue(); ++j) os << d_center[j] << " ";
-   os << endl;
-   os << "       d_uval_inside = " << d_uval_inside << endl;
-   os << "       d_uval_outside = " << d_uval_outside << endl;
+   os << std::endl;
+   os << "       d_uval_inside = " << d_uval_inside << std::endl;
+   os << "       d_uval_outside = " << d_uval_outside << std::endl;
 
-   os << "       d_number_of_intervals = " << d_number_of_intervals << endl;
+   os << "       d_number_of_intervals = " << d_number_of_intervals << std::endl;
    os << "       d_front_position = ";
    for (k = 0; k < d_number_of_intervals - 1; ++k) {
       os << d_front_position[k] << "  ";
    }
-   os << endl;
-   os << "       d_interval_uval = " << endl;
+   os << std::endl;
+   os << "       d_interval_uval = " << std::endl;
    for (k = 0; k < d_number_of_intervals; ++k) {
-      os << "            " << d_interval_uval[k] << endl;
+      os << "            " << d_interval_uval[k] << std::endl;
    }
-   os << "   Boundary condition data " << endl;
+   os << "   Boundary condition data " << std::endl;
 
    if (d_dim == tbox::Dimension(2)) {
       for (j = 0; j < static_cast<int>(d_scalar_bdry_edge_conds.size()); ++j) {
          os << "       d_scalar_bdry_edge_conds[" << j << "] = "
-            << d_scalar_bdry_edge_conds[j] << endl;
+            << d_scalar_bdry_edge_conds[j] << std::endl;
          if (d_scalar_bdry_edge_conds[j] == BdryCond::DIRICHLET) {
             os << "         d_bdry_edge_uval[" << j << "] = "
-               << d_bdry_edge_uval[j] << endl;
+               << d_bdry_edge_uval[j] << std::endl;
          }
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_scalar_bdry_node_conds.size()); ++j) {
          os << "       d_scalar_bdry_node_conds[" << j << "] = "
-            << d_scalar_bdry_node_conds[j] << endl;
+            << d_scalar_bdry_node_conds[j] << std::endl;
          os << "       d_node_bdry_edge[" << j << "] = "
-            << d_node_bdry_edge[j] << endl;
+            << d_node_bdry_edge[j] << std::endl;
       }
    }
    if (d_dim == tbox::Dimension(3)) {
       for (j = 0; j < static_cast<int>(d_scalar_bdry_face_conds.size()); ++j) {
          os << "       d_scalar_bdry_face_conds[" << j << "] = "
-            << d_scalar_bdry_face_conds[j] << endl;
+            << d_scalar_bdry_face_conds[j] << std::endl;
          if (d_scalar_bdry_face_conds[j] == BdryCond::DIRICHLET) {
             os << "         d_bdry_face_uval[" << j << "] = "
-               << d_bdry_face_uval[j] << endl;
+               << d_bdry_face_uval[j] << std::endl;
          }
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_scalar_bdry_edge_conds.size()); ++j) {
          os << "       d_scalar_bdry_edge_conds[" << j << "] = "
-            << d_scalar_bdry_edge_conds[j] << endl;
+            << d_scalar_bdry_edge_conds[j] << std::endl;
          os << "       d_edge_bdry_face[" << j << "] = "
-            << d_edge_bdry_face[j] << endl;
+            << d_edge_bdry_face[j] << std::endl;
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_scalar_bdry_node_conds.size()); ++j) {
          os << "       d_scalar_bdry_node_conds[" << j << "] = "
-            << d_scalar_bdry_node_conds[j] << endl;
+            << d_scalar_bdry_node_conds[j] << std::endl;
          os << "       d_node_bdry_face[" << j << "] = "
-            << d_node_bdry_face[j] << endl;
+            << d_node_bdry_face[j] << std::endl;
       }
    }
 
-   os << "   Refinement criteria parameters " << endl;
+   os << "   Refinement criteria parameters " << std::endl;
 
    for (j = 0; j < static_cast<int>(d_refinement_criteria.size()); ++j) {
       os << "       d_refinement_criteria[" << j << "] = "
-         << d_refinement_criteria[j] << endl;
+         << d_refinement_criteria[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_dev_tol.size()); ++j) {
       os << "       d_dev_tol[" << j << "] = "
-         << d_dev_tol[j] << endl;
+         << d_dev_tol[j] << std::endl;
    }
    for (j = 0; j < static_cast<int>(d_dev.size()); ++j) {
       os << "       d_dev[" << j << "] = "
-         << d_dev[j] << endl;
+         << d_dev[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_dev_time_max.size()); ++j) {
       os << "       d_dev_time_max[" << j << "] = "
-         << d_dev_time_max[j] << endl;
+         << d_dev_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_dev_time_min.size()); ++j) {
       os << "       d_dev_time_min[" << j << "] = "
-         << d_dev_time_min[j] << endl;
+         << d_dev_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_grad_tol.size()); ++j) {
       os << "       d_grad_tol[" << j << "] = "
-         << d_grad_tol[j] << endl;
+         << d_grad_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_grad_time_max.size()); ++j) {
       os << "       d_grad_time_max[" << j << "] = "
-         << d_grad_time_max[j] << endl;
+         << d_grad_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_grad_time_min.size()); ++j) {
       os << "       d_grad_time_min[" << j << "] = "
-         << d_grad_time_min[j] << endl;
+         << d_grad_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_shock_onset.size()); ++j) {
       os << "       d_shock_onset[" << j << "] = "
-         << d_shock_onset[j] << endl;
+         << d_shock_onset[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_shock_tol.size()); ++j) {
       os << "       d_shock_tol[" << j << "] = "
-         << d_shock_tol[j] << endl;
+         << d_shock_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_shock_time_max.size()); ++j) {
       os << "       d_shock_time_max[" << j << "] = "
-         << d_shock_time_max[j] << endl;
+         << d_shock_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_shock_time_min.size()); ++j) {
       os << "       d_shock_time_min[" << j << "] = "
-         << d_shock_time_min[j] << endl;
+         << d_shock_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_rich_tol.size()); ++j) {
       os << "       d_rich_tol[" << j << "] = "
-         << d_rich_tol[j] << endl;
+         << d_rich_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_rich_time_max.size()); ++j) {
       os << "       d_rich_time_max[" << j << "] = "
-         << d_rich_time_max[j] << endl;
+         << d_rich_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_rich_time_min.size()); ++j) {
       os << "       d_rich_time_min[" << j << "] = "
-         << d_rich_time_min[j] << endl;
+         << d_rich_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
 
 }
 
@@ -2354,7 +2353,7 @@ void LinAdv::getFromInput(
           (d_godunov_order != 4)) {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "`godunov_order' in input must be 1, 2, or 4." << endl);
+                          << "`godunov_order' in input must be 1, 2, or 4." << std::endl);
       }
    } else {
       d_godunov_order = input_db->getIntegerWithDefault("d_godunov_order",
@@ -2368,7 +2367,7 @@ void LinAdv::getFromInput(
          TBOX_ERROR(
             d_object_name << ": "
                           << "`corner_transport' in input must be either string"
-                          << " 'CORNER_TRANSPORT_1' or 'CORNER_TRANSPORT_2'." << endl);
+                          << " 'CORNER_TRANSPORT_1' or 'CORNER_TRANSPORT_2'." << std::endl);
       }
    } else {
       d_corner_transport = input_db->getStringWithDefault("corner_transport",
@@ -2378,7 +2377,7 @@ void LinAdv::getFromInput(
    if (input_db->keyExists("Refinement_data")) {
       std::shared_ptr<tbox::Database> refine_db(
          input_db->getDatabase("Refinement_data"));
-      std::vector<string> refinement_keys = refine_db->getAllKeys();
+      std::vector<std::string> refinement_keys = refine_db->getAllKeys();
       int num_keys = static_cast<int>(refinement_keys.size());
 
       if (refine_db->keyExists("refine_criteria")) {
@@ -2387,15 +2386,15 @@ void LinAdv::getFromInput(
          TBOX_WARNING(
             d_object_name << ": "
                           << "No key `refine_criteria' found in data for"
-                          << " RefinementData. No refinement will occur." << endl);
+                          << " RefinementData. No refinement will occur." << std::endl);
       }
 
-      std::vector<string> ref_keys_defined(num_keys);
+      std::vector<std::string> ref_keys_defined(num_keys);
       int def_key_cnt = 0;
       std::shared_ptr<tbox::Database> error_db;
       for (int i = 0; i < num_keys; ++i) {
 
-         string error_key = refinement_keys[i];
+         std::string error_key = refinement_keys[i];
          error_db.reset();
 
          if (!(error_key == "refine_criteria")) {
@@ -2409,7 +2408,7 @@ void LinAdv::getFromInput(
                   d_object_name << ": "
                                 << "Unknown refinement criteria: "
                                 << error_key
-                                << "\nin input." << endl);
+                                << "\nin input." << std::endl);
             } else {
                error_db = refine_db->getDatabase(error_key);
                ref_keys_defined[def_key_cnt] = error_key;
@@ -2428,7 +2427,7 @@ void LinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `dev_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("uval_dev")) {
@@ -2437,7 +2436,7 @@ void LinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `uval_dev' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -2464,7 +2463,7 @@ void LinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `grad_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -2491,7 +2490,7 @@ void LinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `shock_onset' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("shock_tol")) {
@@ -2500,7 +2499,7 @@ void LinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `shock_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -2527,7 +2526,7 @@ void LinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `rich_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -2555,17 +2554,17 @@ void LinAdv::getFromInput(
        */
       for (int k0 = 0;
            k0 < static_cast<int>(d_refinement_criteria.size()); ++k0) {
-         string use_key = d_refinement_criteria[k0];
+         std::string use_key = d_refinement_criteria[k0];
          bool key_found = false;
          for (int k1 = 0; k1 < def_key_cnt; ++k1) {
-            string def_key = ref_keys_defined[k1];
+            std::string def_key = ref_keys_defined[k1];
             if (def_key == use_key) key_found = true;
          }
 
          if (!key_found) {
             TBOX_ERROR(d_object_name << ": "
                                      << "No input found for specified refine criteria: "
-                                     << d_refinement_criteria[k0] << endl);
+                                     << d_refinement_criteria[k0] << std::endl);
          }
       }
 
@@ -2584,13 +2583,13 @@ void LinAdv::getFromInput(
          TBOX_ERROR(
             d_object_name << ": "
                           << "`data_problem' value not found in input."
-                          << endl);
+                          << std::endl);
       }
 
       if (!input_db->keyExists("Initial_data")) {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "No `Initial_data' database found in input." << endl);
+                          << "No `Initial_data' database found in input." << std::endl);
       }
       std::shared_ptr<tbox::Database> init_data_db(
          input_db->getDatabase("Initial_data"));
@@ -2604,28 +2603,28 @@ void LinAdv::getFromInput(
          } else {
             TBOX_ERROR(
                d_object_name << ": "
-                             << "`radius' input required for SPHERE problem." << endl);
+                             << "`radius' input required for SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("center")) {
             d_center = init_data_db->getDoubleVector("center");
          } else {
             TBOX_ERROR(
                d_object_name << ": "
-                             << "`center' input required for SPHERE problem." << endl);
+                             << "`center' input required for SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("uval_inside")) {
             d_uval_inside = init_data_db->getDouble("uval_inside");
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`uval_inside' input required for "
-                                     << "SPHERE problem." << endl);
+                                     << "SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("uval_outside")) {
             d_uval_outside = init_data_db->getDouble("uval_outside");
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`uval_outside' input required for "
-                                     << "SPHERE problem." << endl);
+                                     << "SPHERE problem." << std::endl);
          }
 
          found_problem_data = true;
@@ -2646,7 +2645,7 @@ void LinAdv::getFromInput(
                TBOX_ERROR(
                   d_object_name << ": `PIECEWISE_CONSTANT_Y' "
                                 << "problem invalid in 1 dimension."
-                                << endl);
+                                << std::endl);
             }
             idir = 1;
          }
@@ -2655,19 +2654,19 @@ void LinAdv::getFromInput(
             if (d_dim < tbox::Dimension(3)) {
                TBOX_ERROR(
                   d_object_name << ": `PIECEWISE_CONSTANT_Z' "
-                                << "problem invalid in 1 or 2 dimensions." << endl);
+                                << "problem invalid in 1 or 2 dimensions." << std::endl);
             }
             idir = 2;
          }
 
-         std::vector<string> init_data_keys = init_data_db->getAllKeys();
+         std::vector<std::string> init_data_keys = init_data_db->getAllKeys();
 
          if (init_data_db->keyExists("front_position")) {
             d_front_position = init_data_db->getDoubleVector("front_position");
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`front_position' input required for "
-                                     << d_data_problem << " problem." << endl);
+                                     << d_data_problem << " problem." << std::endl);
          }
 
          d_number_of_intervals =
@@ -2698,7 +2697,7 @@ void LinAdv::getFromInput(
                } else {
                   TBOX_ERROR(d_object_name << ": "
                                            << "`uval' data missing in input for key = "
-                                           << init_data_keys[nkey] << endl);
+                                           << init_data_keys[nkey] << std::endl);
                }
                ++i;
 
@@ -2721,7 +2720,7 @@ void LinAdv::getFromInput(
             } else {
                TBOX_ERROR(
                   d_object_name << ": "
-                                << "`frequency' input required for SINE problem." << endl);
+                                << "`frequency' input required for SINE problem." << std::endl);
             }
          }
 
@@ -2730,7 +2729,7 @@ void LinAdv::getFromInput(
                d_object_name << ": "
                              << "Insufficient interval data given in input"
                              << " for PIECEWISE_CONSTANT_*problem."
-                             << endl);
+                             << std::endl);
          }
 
          found_problem_data = true;
@@ -2739,7 +2738,7 @@ void LinAdv::getFromInput(
       if (!found_problem_data) {
          TBOX_ERROR(d_object_name << ": "
                                   << "`Initial_data' database found in input."
-                                  << " But bad data supplied." << endl);
+                                  << " But bad data supplied." << std::endl);
       }
 
    } // if !is_from_restart read in problem data
@@ -2775,7 +2774,7 @@ void LinAdv::getFromInput(
    } else {
       TBOX_ERROR(
          d_object_name << ": "
-                       << "Key data `Boundary_data' not found in input. " << endl);
+                       << "Key data `Boundary_data' not found in input. " << std::endl);
    }
 
 }
@@ -2909,14 +2908,14 @@ void LinAdv::getFromRestart()
    if (!(d_nghosts == CELLG)) {
       TBOX_ERROR(
          d_object_name << ": "
-                       << "Key data `d_nghosts' in restart file != CELLG." << endl);
+                       << "Key data `d_nghosts' in restart file != CELLG." << std::endl);
    }
    int* tmp_fluxghosts = &d_fluxghosts[0];
    db->getIntegerArray("d_fluxghosts", tmp_fluxghosts, d_dim.getValue());
    if (!(d_fluxghosts == FLUXG)) {
       TBOX_ERROR(
          d_object_name << ": "
-                       << "Key data `d_fluxghosts' in restart file != FLUXG." << endl);
+                       << "Key data `d_fluxghosts' in restart file != FLUXG." << std::endl);
    }
 
    d_data_problem = db->getString("d_data_problem");
@@ -2993,7 +2992,7 @@ void LinAdv::getFromRestart()
 
 void LinAdv::readDirichletBoundaryDataEntry(
    const std::shared_ptr<tbox::Database>& db,
-   string& db_name,
+   std::string& db_name,
    int bdry_location_index)
 {
    TBOX_ASSERT(db);
@@ -3015,7 +3014,7 @@ void LinAdv::readDirichletBoundaryDataEntry(
 
 void LinAdv::readNeumannBoundaryDataEntry(
    const std::shared_ptr<tbox::Database>& db,
-   string& db_name,
+   std::string& db_name,
    int bdry_location_index)
 {
    NULL_USE(db);
@@ -3025,7 +3024,7 @@ void LinAdv::readNeumannBoundaryDataEntry(
 
 void LinAdv::readStateDataEntry(
    std::shared_ptr<tbox::Database> db,
-   const string& db_name,
+   const std::string& db_name,
    int array_indx,
    std::vector<double>& uval)
 {
@@ -3039,7 +3038,7 @@ void LinAdv::readStateDataEntry(
    } else {
       TBOX_ERROR(d_object_name << ": "
                                << "`uval' entry missing from " << db_name
-                               << " input database. " << endl);
+                               << " input database. " << std::endl);
    }
 
 }
@@ -3147,7 +3146,7 @@ void LinAdv::checkBoundaryData(
                     << "     " << num_bad_values
                     << " bad UVAL values found for\n"
                     << "     boundary type " << btype << " at location "
-                    << bloc << endl;
+                    << bloc << std::endl;
       }
 #endif
 

--- a/source/test/applications/LinAdv/LinAdv.h
+++ b/source/test/applications/LinAdv/LinAdv.h
@@ -33,7 +33,6 @@
 #include <vector>
 #include <memory>
 
-using namespace std;
 
 /**
  * The LinAdv class provides routines for a sample application code that
@@ -77,7 +76,7 @@ public:
     * database (potentially overriding those found in the restart file).
     */
    LinAdv(
-      const string& object_name,
+      const std::string& object_name,
       const tbox::Dimension& dim,
       std::shared_ptr<tbox::Database> input_db,
       std::shared_ptr<geom::CartesianGridGeometry> grid_geom);
@@ -326,7 +325,7 @@ public:
    void
    readDirichletBoundaryDataEntry(
       const std::shared_ptr<tbox::Database>& db,
-      string& db_name,
+      std::string& db_name,
       int bdry_location_index);
 
    /**
@@ -337,7 +336,7 @@ public:
    void
    readNeumannBoundaryDataEntry(
       const std::shared_ptr<tbox::Database>& db,
-      string& db_name,
+      std::string& db_name,
       int bdry_location_index);
 
    void
@@ -388,7 +387,7 @@ public:
     */
    void
    printClassData(
-      ostream& os) const;
+      std::ostream& os) const;
 
 private:
    /*
@@ -411,7 +410,7 @@ private:
    void
    readStateDataEntry(
       std::shared_ptr<tbox::Database> db,
-      const string& db_name,
+      const std::string& db_name,
       int array_indx,
       std::vector<double>& uval);
 
@@ -443,7 +442,7 @@ private:
     * The object name is used for error/warning reporting and also as a
     * string label for restart database entries.
     */
-   string d_object_name;
+   std::string d_object_name;
 
    const tbox::Dimension d_dim;
 
@@ -509,14 +508,14 @@ private:
     *
     */
    int d_godunov_order;
-   string d_corner_transport;
+   std::string d_corner_transport;
    hier::IntVector d_nghosts;
    hier::IntVector d_fluxghosts;
 
    /*
     * Indicator for problem type and initial conditions
     */
-   string d_data_problem;
+   std::string d_data_problem;
    int d_data_problem_int;
 
    /*
@@ -570,7 +569,7 @@ private:
     * Refinement criteria parameters for gradient detector and
     * Richardson extrapolation.
     */
-   std::vector<string> d_refinement_criteria;
+   std::vector<std::string> d_refinement_criteria;
    double d_threshold;
    std::vector<double> d_dev_tol;
    std::vector<double> d_dev;

--- a/source/test/applications/LinAdv/main.C
+++ b/source/test/applications/LinAdv/main.C
@@ -65,7 +65,6 @@
 #include <fstream>
 #include <memory>
 
-using namespace std;
 using namespace SAMRAI;
 
 /************************************************************************
@@ -189,8 +188,8 @@ int main(
       const tbox::SAMRAI_MPI& mpi(tbox::SAMRAI_MPI::getSAMRAIWorld());
 
       {
-         string input_filename;
-         string restart_read_dirname;
+         std::string input_filename;
+         std::string restart_read_dirname;
          int restore_num = 0;
 
          bool is_from_restart = false;
@@ -200,7 +199,7 @@ int main(
                        << "<restart dir> <restore number> [options]\n"
                        << "  options:\n"
                        << "  none at this time"
-                       << endl;
+                       << std::endl;
             tbox::SAMRAI_MPI::abort();
             return -1;
          } else {
@@ -213,9 +212,9 @@ int main(
             }
          }
 
-         tbox::plog << "input_filename = " << input_filename << endl;
-         tbox::plog << "restart_read_dirname = " << restart_read_dirname << endl;
-         tbox::plog << "restore_num = " << restore_num << endl;
+         tbox::plog << "input_filename = " << input_filename << std::endl;
+         tbox::plog << "restart_read_dirname = " << restart_read_dirname << std::endl;
+         tbox::plog << "restore_num = " << restore_num << std::endl;
 
          /*
           * Create input database and parse all data in input file.
@@ -235,7 +234,7 @@ int main(
                input_db->getDatabase("GlobalInputs"));
 #ifdef SGS
             if (global_db->keyExists("tag_clustering_method")) {
-               string tag_clustering_method =
+               std::string tag_clustering_method =
                   global_db->getString("tag_clustering_method");
                mesh::BergerRigoutsos::setClusteringOption(tag_clustering_method);
             }
@@ -304,7 +303,7 @@ int main(
 
          bool use_refined_timestepping = true;
          if (main_db->keyExists("timestepping")) {
-            string timestepping_method = main_db->getString("timestepping");
+            std::string timestepping_method = main_db->getString("timestepping");
             if (timestepping_method == "SYNCHRONIZED") {
                use_refined_timestepping = false;
             }
@@ -446,13 +445,13 @@ int main(
           */
 
          tbox::plog << "\nCheck input data and variables before simulation:"
-                    << endl;
-         tbox::plog << "Input database..." << endl;
+                    << std::endl;
+         tbox::plog << "Input database..." << std::endl;
          input_db->printClassData(tbox::plog);
-         tbox::plog << "\nVariable database..." << endl;
+         tbox::plog << "\nVariable database..." << std::endl;
          hier::VariableDatabase::getDatabase()->printClassData(tbox::plog);
 
-         tbox::plog << "\nCheck Linear Advection data... " << endl;
+         tbox::plog << "\nCheck Linear Advection data... " << std::endl;
          linear_advection_model->printClassData(tbox::plog);
 
          if (viz_dump_data &&
@@ -491,19 +490,19 @@ int main(
 
             iteration_num = time_integrator->getIntegratorStep() + 1;
 
-            tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << endl;
+            tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
             tbox::pout << "At begining of timestep # " << iteration_num - 1
-                       << endl;
-            tbox::pout << "Simulation time is " << loop_time << endl;
+                       << std::endl;
+            tbox::pout << "Simulation time is " << loop_time << std::endl;
 
             double dt_new = time_integrator->advanceHierarchy(dt_now);
 
             loop_time += dt_now;
             dt_now = dt_new;
 
-            tbox::pout << "At end of timestep # " << iteration_num - 1 << endl;
-            tbox::pout << "Simulation time is " << loop_time << endl;
-            tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << endl;
+            tbox::pout << "At end of timestep # " << iteration_num - 1 << std::endl;
+            tbox::pout << "Simulation time is " << loop_time << std::endl;
+            tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
 
             /*
              * At specified intervals, write restart and visualization files.
@@ -638,7 +637,7 @@ int main(
    }
 
    if (num_failures == 0) {
-      tbox::pout << "\nPASSED:  LinAdv" << endl;
+      tbox::pout << "\nPASSED:  LinAdv" << std::endl;
    }
 
    tbox::SAMRAIManager::finalize();

--- a/source/test/assumed_partition/main.C
+++ b/source/test/assumed_partition/main.C
@@ -21,7 +21,6 @@
 #include "SAMRAI/hier/AssumedPartition.h"
 #include "SAMRAI/geom/GridGeometry.h"
 
-using namespace std;
 
 using namespace SAMRAI;
 

--- a/source/test/boundary/BoundaryDataTester.C
+++ b/source/test/boundary/BoundaryDataTester.C
@@ -41,7 +41,7 @@
  */
 
 BoundaryDataTester::BoundaryDataTester(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> input_db,
    std::shared_ptr<geom::CartesianGridGeometry> grid_geom):
@@ -84,8 +84,8 @@ void BoundaryDataTester::setPhysicalBoundaryConditions(
 {
    NULL_USE(fill_time);
    tbox::plog << "\n\nFilling boundary data on patch = " << patch.getBox()
-              << endl;
-   tbox::plog << "ghost_width_to_fill = " << ghost_width_to_fill << endl;
+              << std::endl;
+   tbox::plog << "ghost_width_to_fill = " << ghost_width_to_fill << std::endl;
 
    for (int iv = 0; iv < static_cast<int>(d_variables.size()); ++iv) {
 
@@ -94,8 +94,8 @@ void BoundaryDataTester::setPhysicalBoundaryConditions(
             patch.getPatchData(d_variables[iv], d_variable_context)));
       TBOX_ASSERT(cvdata);
 
-      tbox::plog << "\n   iv = " << iv << " : " << d_variable_name[iv] << endl;
-      tbox::plog << "   depth = " << cvdata->getDepth() << endl;
+      tbox::plog << "\n   iv = " << iv << " : " << d_variable_name[iv] << std::endl;
+      tbox::plog << "   depth = " << cvdata->getDepth() << std::endl;
 
       hier::IntVector fill_gcw(hier::IntVector::min(cvdata->getGhostCellWidth(),
                                   ghost_width_to_fill));
@@ -282,7 +282,7 @@ void BoundaryDataTester::readVariableInputAndMakeVariables(
 {
    TBOX_ASSERT(db);
 
-   std::vector<string> var_keys = db->getAllKeys();
+   std::vector<std::string> var_keys = db->getAllKeys();
    int nkeys = static_cast<int>(var_keys.size());
 
    int var_cnt = 0;
@@ -307,7 +307,7 @@ void BoundaryDataTester::readVariableInputAndMakeVariables(
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "Variable input error: No 'name' string found for "
-                                     << "key = " << var_keys[i] << endl);
+                                     << "key = " << var_keys[i] << std::endl);
          }
 
          if (var_db->keyExists("depth")) {
@@ -328,7 +328,7 @@ void BoundaryDataTester::readVariableInputAndMakeVariables(
             TBOX_ERROR(
                d_object_name << ": "
                              << "Variable input error: No 'interior_values' entry found for "
-                             << "key = " << var_keys[i] << endl);
+                             << "key = " << var_keys[i] << std::endl);
          }
 
          ++v_cntr; 
@@ -451,7 +451,7 @@ void BoundaryDataTester::setBoundaryDataDefaults()
 
 void BoundaryDataTester::readDirichletBoundaryDataEntry(
    const std::shared_ptr<tbox::Database>& db,
-   string& db_name,
+   std::string& db_name,
    int bdry_location_index)
 {
    readBoundaryDataStateEntry(db, db_name, bdry_location_index);
@@ -459,7 +459,7 @@ void BoundaryDataTester::readDirichletBoundaryDataEntry(
 
 void BoundaryDataTester::readNeumannBoundaryDataEntry(
    const std::shared_ptr<tbox::Database>& db,
-   string& db_name,
+   std::string& db_name,
    int bdry_location_index)
 {
    readBoundaryDataStateEntry(db, db_name, bdry_location_index);
@@ -467,7 +467,7 @@ void BoundaryDataTester::readNeumannBoundaryDataEntry(
 
 void BoundaryDataTester::readBoundaryDataStateEntry(
    std::shared_ptr<tbox::Database> db,
-   string& db_name,
+   std::string& db_name,
    int bdry_location_index)
 {
    TBOX_ASSERT(db);
@@ -495,7 +495,7 @@ void BoundaryDataTester::readBoundaryDataStateEntry(
             TBOX_ERROR(d_object_name << ": "
                                      << "Insufficient number of "
                                      << d_variable_name[iv] << " values given in "
-                                     << db_name << " input database." << endl);
+                                     << db_name << " input database." << std::endl);
          }
          for (int id = 0; id < depth; ++id) {
             d_variable_bc_values[iv][bdry_location_index * depth + id] =
@@ -505,7 +505,7 @@ void BoundaryDataTester::readBoundaryDataStateEntry(
          TBOX_ERROR(d_object_name << ": "
                                   << d_variable_name[iv]
                                   << " entry missing from " << db_name
-                                  << " input database. " << endl);
+                                  << " input database. " << std::endl);
       }
 
    }
@@ -553,7 +553,7 @@ void BoundaryDataTester::readBoundaryDataInput(
       } else {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "Key data 'Boundary_data' not found in input. " << endl);
+                          << "Key data 'Boundary_data' not found in input. " << std::endl);
       }
 
    }
@@ -767,7 +767,7 @@ void BoundaryDataTester::checkBoundaryData(
                           << d_variable_name[iv] << " values found for"
                           << "     boundary type " << btype
                           << " at location "
-                          << bloc << endl;
+                          << bloc << std::endl;
             }
 #endif
 
@@ -840,7 +840,7 @@ void BoundaryDataTester::checkBoundaryData(
                              << d_variable_name[iv] << " values found for"
                              << "     boundary type " << btype
                              << " at location "
-                             << bloc << endl;
+                             << bloc << std::endl;
                }
 #endif
 
@@ -863,45 +863,45 @@ void BoundaryDataTester::checkBoundaryData(
  */
 
 void BoundaryDataTester::printClassData(
-   ostream& os) const
+   std::ostream& os) const
 {
    int i, j;
-   os << "\nBoundaryDataTester::printClassData..." << endl;
-   os << "BoundaryDataTester: this = " << (BoundaryDataTester *)this << endl;
-   os << "d_object_name = " << d_object_name << endl;
+   os << "\nBoundaryDataTester::printClassData..." << std::endl;
+   os << "BoundaryDataTester: this = " << (BoundaryDataTester *)this << std::endl;
+   os << "d_object_name = " << d_object_name << std::endl;
    os << "d_grid_geometry = "
-      << d_grid_geometry.get() << endl;
+      << d_grid_geometry.get() << std::endl;
 
    if (d_variable_context) {
       os << "d_variable_context = "
-         << d_variable_context->getName() << endl;
+         << d_variable_context->getName() << std::endl;
    } else {
-      os << "d_variable_context = 0" << endl;
+      os << "d_variable_context = 0" << std::endl;
    }
 
-   os << "\nVariables ...\n" << endl;
+   os << "\nVariables ...\n" << std::endl;
    for (i = 0; i < static_cast<int>(d_variable_name.size()); ++i) {
-      os << "Variable " << i << endl;
-      os << "   name       = " << d_variable_name[i] << endl;
-      os << "   depth      = " << d_variable_depth[i] << endl;
-      os << "   num_ghosts = " << d_variable_num_ghosts[i] << endl;
+      os << "Variable " << i << std::endl;
+      os << "   name       = " << d_variable_name[i] << std::endl;
+      os << "   depth      = " << d_variable_depth[i] << std::endl;
+      os << "   num_ghosts = " << d_variable_num_ghosts[i] << std::endl;
       os << "   interior_values = " << d_variable_interior_values[i][0];
       for (j = 1; j < d_variable_depth[i]; ++j) {
          os << " ,  " << d_variable_interior_values[i][j];
       }
-      os << endl;
+      os << std::endl;
    }
 
-   os << "\n   Boundary condition data... " << endl;
+   os << "\n   Boundary condition data... " << std::endl;
 
    if (d_dim == tbox::Dimension(2)) {
       for (j = 0; j < static_cast<int>(d_master_bdry_edge_conds.size()); ++j) {
          os << "\n       d_master_bdry_edge_conds[" << j << "] = "
-            << d_master_bdry_edge_conds[j] << endl;
+            << d_master_bdry_edge_conds[j] << std::endl;
          os << "       d_scalar_bdry_edge_conds[" << j << "] = "
-            << d_scalar_bdry_edge_conds[j] << endl;
+            << d_scalar_bdry_edge_conds[j] << std::endl;
          os << "       d_vector_bdry_edge_conds[" << j << "] = "
-            << d_vector_bdry_edge_conds[j] << endl;
+            << d_vector_bdry_edge_conds[j] << std::endl;
          if (d_master_bdry_edge_conds[j] == BdryCond::DIRICHLET ||
              d_master_bdry_edge_conds[j] == BdryCond::NEUMANN) {
             for (i = 0; i < static_cast<int>(d_variable_name.size()); ++i) {
@@ -911,30 +911,30 @@ void BoundaryDataTester::printClassData(
                   os << " , "
                      << d_variable_bc_values[i][j * d_variable_depth[i] + id];
                }
-               os << endl;
+               os << std::endl;
             }
          }
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_master_bdry_node_conds.size()); ++j) {
          os << "\n       d_master_bdry_node_conds[" << j << "] = "
-            << d_master_bdry_node_conds[j] << endl;
+            << d_master_bdry_node_conds[j] << std::endl;
          os << "       d_scalar_bdry_node_conds[" << j << "] = "
-            << d_scalar_bdry_node_conds[j] << endl;
+            << d_scalar_bdry_node_conds[j] << std::endl;
          os << "       d_vector_bdry_node_conds[" << j << "] = "
-            << d_vector_bdry_node_conds[j] << endl;
+            << d_vector_bdry_node_conds[j] << std::endl;
          os << "       d_node_bdry_edge[" << j << "] = "
-            << d_node_bdry_edge[j] << endl;
+            << d_node_bdry_edge[j] << std::endl;
       }
    }
    if (d_dim == tbox::Dimension(3)) {
       for (j = 0; j < static_cast<int>(d_master_bdry_face_conds.size()); ++j) {
          os << "\n       d_master_bdry_face_conds[" << j << "] = "
-            << d_master_bdry_face_conds[j] << endl;
+            << d_master_bdry_face_conds[j] << std::endl;
          os << "       d_scalar_bdry_face_conds[" << j << "] = "
-            << d_scalar_bdry_face_conds[j] << endl;
+            << d_scalar_bdry_face_conds[j] << std::endl;
          os << "       d_vector_bdry_face_conds[" << j << "] = "
-            << d_vector_bdry_face_conds[j] << endl;
+            << d_vector_bdry_face_conds[j] << std::endl;
          if (d_master_bdry_face_conds[j] == BdryCond::DIRICHLET ||
              d_master_bdry_face_conds[j] == BdryCond::NEUMANN) {
             for (i = 0; i < static_cast<int>(d_variable_name.size()); ++i) {
@@ -944,31 +944,31 @@ void BoundaryDataTester::printClassData(
                   os << " , "
                      << d_variable_bc_values[i][j * d_variable_depth[i] + id];
                }
-               os << endl;
+               os << std::endl;
             }
          }
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_master_bdry_edge_conds.size()); ++j) {
          os << "\n       d_master_bdry_edge_conds[" << j << "] = "
-            << d_master_bdry_edge_conds[j] << endl;
+            << d_master_bdry_edge_conds[j] << std::endl;
          os << "       d_scalar_bdry_edge_conds[" << j << "] = "
-            << d_scalar_bdry_edge_conds[j] << endl;
+            << d_scalar_bdry_edge_conds[j] << std::endl;
          os << "       d_vector_bdry_edge_conds[" << j << "] = "
-            << d_vector_bdry_edge_conds[j] << endl;
+            << d_vector_bdry_edge_conds[j] << std::endl;
          os << "       d_edge_bdry_face[" << j << "] = "
-            << d_edge_bdry_face[j] << endl;
+            << d_edge_bdry_face[j] << std::endl;
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_master_bdry_node_conds.size()); ++j) {
          os << "\n       d_master_bdry_node_conds[" << j << "] = "
-            << d_master_bdry_node_conds[j] << endl;
+            << d_master_bdry_node_conds[j] << std::endl;
          os << "       d_scalar_bdry_node_conds[" << j << "] = "
-            << d_scalar_bdry_node_conds[j] << endl;
+            << d_scalar_bdry_node_conds[j] << std::endl;
          os << "       d_vector_bdry_node_conds[" << j << "] = "
-            << d_vector_bdry_node_conds[j] << endl;
+            << d_vector_bdry_node_conds[j] << std::endl;
          os << "       d_node_bdry_face[" << j << "] = "
-            << d_node_bdry_face[j] << endl;
+            << d_node_bdry_face[j] << std::endl;
       }
    }
 

--- a/source/test/boundary/BoundaryDataTester.h
+++ b/source/test/boundary/BoundaryDataTester.h
@@ -29,7 +29,6 @@
 #include <vector>
 #include <memory>
 
-using namespace std;
 using namespace SAMRAI;
 
 class BoundaryDataTester:
@@ -41,7 +40,7 @@ public:
     * The constructor reads variable data from input database.
     */
    BoundaryDataTester(
-      const string& object_name,
+      const std::string& object_name,
       const tbox::Dimension& dim,
       std::shared_ptr<tbox::Database> input_db,
       std::shared_ptr<geom::CartesianGridGeometry> grid_geom);
@@ -106,7 +105,7 @@ public:
    void
    readDirichletBoundaryDataEntry(
       const std::shared_ptr<tbox::Database>& db,
-      string& db_name,
+      std::string& db_name,
       int bdry_location_index);
 
    /**
@@ -119,7 +118,7 @@ public:
    void
    readNeumannBoundaryDataEntry(
       const std::shared_ptr<tbox::Database>& db,
-      string& db_name,
+      std::string& db_name,
       int bdry_location_index);
 
    /**
@@ -144,7 +143,7 @@ public:
     */
    void
    printClassData(
-      ostream& os) const;
+      std::ostream& os) const;
 
    /*!
     * @brief Return the dimension of this object.
@@ -158,7 +157,7 @@ private:
    /*
     * The object name is used for error/warning reporting.
     */
-   string d_object_name;
+   std::string d_object_name;
 
    const tbox::Dimension d_dim;
 
@@ -167,7 +166,7 @@ private:
    /*
     * Vectors of information read from input file describing test variables
     */
-   std::vector<string> d_variable_name;
+   std::vector<std::string> d_variable_name;
    std::vector<int> d_variable_depth;
    std::vector<hier::IntVector> d_variable_num_ghosts;
    std::vector<std::vector<double> > d_variable_interior_values;
@@ -214,7 +213,7 @@ private:
    void
    readBoundaryDataStateEntry(
       std::shared_ptr<tbox::Database> db,
-      string& db_name,
+      std::string& db_name,
       int bdry_location_index);
    void
    setBoundaryDataDefaults();

--- a/source/test/boundary/main.C
+++ b/source/test/boundary/main.C
@@ -12,7 +12,6 @@
 
 #include <string>
 #include <memory>
-using namespace std;
 
 // Headers for basic SAMRAI objects used in this code.
 #include "SAMRAI/tbox/SAMRAIManager.h"
@@ -59,11 +58,11 @@ int main(
                        << "<restart dir> <restore number> [options]\n"
                        << "  options:\n"
                        << "  none at this time"
-                       << endl);
+                       << std::endl);
          return -1;
       }
 
-      string input_filename = argv[1];
+      std::string input_filename = argv[1];
 
       /*
        * Create input database and parse all data in input file.
@@ -96,7 +95,7 @@ int main(
 
       const tbox::Dimension dim(static_cast<unsigned short>(main_db->getInteger("dim")));
 
-      string log_file_name = "boundary.log";
+      std::string log_file_name = "boundary.log";
       if (main_db->keyExists("log_file_name")) {
          log_file_name = main_db->getString("log_file_name");
       }
@@ -133,14 +132,14 @@ int main(
 
       tbox::plog
       << "\nPRINTING BoundaryDataTester object state after initialization..."
-      << endl;
+      << std::endl;
       btester->printClassData(tbox::plog);
 
       /*
        * For simplicity, we manually create a hierachy with a single patch level.
        */
 
-      tbox::plog << "\nBuilding patch hierarchy..." << endl;
+      tbox::plog << "\nBuilding patch hierarchy..." << std::endl;
 
       const hier::BoxContainer& domain = grid_geometry->getPhysicalDomain();
       hier::BoxContainer boxes(domain);
@@ -190,15 +189,15 @@ int main(
        */
 
       tbox::plog << "\nAllocate and initialize data on patch hierarchy..."
-                 << endl;
+                 << std::endl;
 
       btester->initializeDataOnPatchInteriors(patch_hierarchy, 0);
 
-      tbox::plog << "Performing tests..." << endl;
+      tbox::plog << "Performing tests..." << std::endl;
 
       fail_count = btester->runBoundaryTest(patch_hierarchy, 0);
 
-      tbox::plog << "\n\n\nDone." << endl;
+      tbox::plog << "\n\n\nDone." << std::endl;
 
       /*
        * At conclusion of test, deallocate objects.
@@ -209,7 +208,7 @@ int main(
       if (btester) delete btester;
 
       if (fail_count == 0) {
-         tbox::pout << "\nPASSED:  boundary test" << endl;
+         tbox::pout << "\nPASSED:  boundary test" << std::endl;
       }
    }
 

--- a/source/test/clustering/async_br/ABRTest.h
+++ b/source/test/clustering/async_br/ABRTest.h
@@ -12,7 +12,6 @@
 
 #include <string>
 #include <memory>
-using namespace std;
 
 #include "SAMRAI/tbox/Database.h"
 

--- a/source/test/clustering/async_br/main.C
+++ b/source/test/clustering/async_br/main.C
@@ -70,9 +70,9 @@ int main(
     */
    tbox::SAMRAI_MPI::init(&argc, &argv);
    if (get_input_filename(&argc, argv, input_filename) == 1) {
-      cout << "Usage: " << argv[0]
+      std::cout << "Usage: " << argv[0]
            << " <input file>."
-           << endl;
+           << std::endl;
       tbox::SAMRAI_MPI::finalize();
       return 0;
    }
@@ -86,9 +86,9 @@ int main(
     */
    {
 
-      tbox::plog << "Input file is " << input_filename << endl;
+      tbox::plog << "Input file is " << input_filename << std::endl;
 
-      string case_name;
+      std::string case_name;
       if (argc >= 2) {
          case_name = argv[1];
       }
@@ -123,7 +123,7 @@ int main(
 
       std::shared_ptr<tbox::Database> main_db(
          input_db->getDatabase("Main"));
-      tbox::plog << "Main database:" << endl;
+      tbox::plog << "Main database:" << std::endl;
       main_db->printClassData(tbox::plog);
 
       const tbox::Dimension dim(static_cast<unsigned short>(main_db->getInteger("dim")));
@@ -136,7 +136,7 @@ int main(
        * Base filename info.
        */
 
-      string base_name = main_db->getStringWithDefault("base_name", "fp");
+      std::string base_name = main_db->getStringWithDefault("base_name", "fp");
 
       /*
        * Modify basename for this particular run.
@@ -156,14 +156,14 @@ int main(
       /*
        * Set the vis filename, defaults to base_name.
        */
-      string vis_filename =
+      std::string vis_filename =
          main_db->getStringWithDefault("vis_filename", base_name);
 
       /*
        * Log file info.
        */
 
-      string log_filename =
+      std::string log_filename =
          main_db->getStringWithDefault("log_filename", base_name + ".log");
       bool log_all = false;
       log_all = main_db->getBoolWithDefault("log_all", log_all);
@@ -196,7 +196,7 @@ int main(
             dim,
             "CartesianGridGeometry",
             input_db->getDatabase("CartesianGridGeometry")));
-      tbox::plog << "Grid Geometry:" << endl;
+      tbox::plog << "Grid Geometry:" << std::endl;
       grid_geometry->printClassData(tbox::plog);
       std::shared_ptr<hier::PatchHierarchy> patch_hierarchy(
          new hier::PatchHierarchy(
@@ -265,15 +265,15 @@ int main(
        * we print the input database and variable database contents
        * to the log file.
        */
-      tbox::plog << "\nCheck input data:" << endl;
-      tbox::plog << "Input database..." << endl;
+      tbox::plog << "\nCheck input data:" << std::endl;
+      tbox::plog << "Input database..." << std::endl;
       input_db->printClassData(tbox::plog);
-      tbox::plog << "\nVariable database..." << endl;
+      tbox::plog << "\nVariable database..." << std::endl;
       hier::VariableDatabase::getDatabase()->printClassData(tbox::plog);
 
       tbox::plog
       << "**********************************************************\n";
-      tbox::plog << "Memory used before mesh generation:" << endl;
+      tbox::plog << "Memory used before mesh generation:" << std::endl;
       tbox::MemoryUtilities::printMemoryInfo(tbox::plog);
       tbox::plog
       << "**********************************************************\n";
@@ -287,12 +287,12 @@ int main(
          getTimer("apps::main::generate_mesh"));
       t_generate_mesh->start();
       gridding_algorithm->makeCoarsestLevel(0.0);
-      tbox::plog << "Memory used after creating level 0:" << endl;
+      tbox::plog << "Memory used after creating level 0:" << std::endl;
       tbox::MemoryUtilities::printMemoryInfo(tbox::plog);
       bool done = false;
       for (int ln = 0; patch_hierarchy->levelCanBeRefined(ln) && !done;
            ++ln) {
-         tbox::plog << "Adding finer levels with ln = " << ln << endl;
+         tbox::plog << "Adding finer levels with ln = " << ln << std::endl;
          std::shared_ptr<hier::PatchLevel> level_(
             patch_hierarchy->getPatchLevel(ln));
          gridding_algorithm->makeFinerLevel(
@@ -302,7 +302,7 @@ int main(
             /* simulation time */ 0.0);
          tbox::plog << "Just added finer level " << ln << " -> " << ln + 1;
          if (patch_hierarchy->getNumberOfLevels() < ln + 2) {
-            tbox::plog << " (no new level!)" << endl;
+            tbox::plog << " (no new level!)" << std::endl;
          } else {
             std::shared_ptr<hier::PatchLevel> finer_level_(
                patch_hierarchy->getPatchLevel(ln + 1));
@@ -310,24 +310,24 @@ int main(
             << " (" << level_->getNumberOfPatches()
             << " -> " << finer_level_->getNumberOfPatches()
             << " patches)"
-            << endl;
+            << std::endl;
          }
          done = !(patch_hierarchy->finerLevelExists(ln));
 
          tbox::plog << "Memory used after creating level " << ln + 1 << ":"
-                    << endl;
+                    << std::endl;
          tbox::MemoryUtilities::printMemoryInfo(tbox::plog);
 
       }
       t_generate_mesh->stop();
 
       if (mpi.getRank() == 0) {
-         tbox::plog << "Hierarchy generated:" << endl;
-         patch_hierarchy->recursivePrint(tbox::plog, string("    "), 1);
+         tbox::plog << "Hierarchy generated:" << std::endl;
+         patch_hierarchy->recursivePrint(tbox::plog, std::string("    "), 1);
       }
       if (log_hierarchy) {
-         tbox::plog << "Hierarchy generated:" << endl;
-         patch_hierarchy->recursivePrint(tbox::plog, string("H-> "), 3);
+         tbox::plog << "Hierarchy generated:" << std::endl;
+         patch_hierarchy->recursivePrint(tbox::plog, std::string("H-> "), 3);
       }
 
 #ifdef HAVE_HDF5
@@ -336,7 +336,7 @@ int main(
        */
       /* Get the output filename. */
       if (plot_step > 0) {
-         const string visit_filename = vis_filename + ".visit";
+         const std::string visit_filename = vis_filename + ".visit";
          /* Create the VisIt data writer. */
          std::shared_ptr<appu::VisItDataWriter> visit_data_writer(
             new appu::VisItDataWriter(
@@ -360,7 +360,7 @@ int main(
 
       for (int istep = 0; istep < num_steps; ++istep) {
 
-         tbox::plog << "Adaption number " << istep << endl;
+         tbox::plog << "Adaption number " << istep << std::endl;
 
          // Recompute the front-dependent data at next time step.
          abrtest.computeHierarchyData(*patch_hierarchy,
@@ -379,19 +379,19 @@ int main(
             regrid_start_time);
 
          if (mpi.getRank() == 0) {
-            patch_hierarchy->recursivePrint(tbox::plog, string("    "), 1);
+            patch_hierarchy->recursivePrint(tbox::plog, std::string("    "), 1);
          }
          if (log_hierarchy) {
-            tbox::plog << "Hierarchy adapted:" << endl;
-            patch_hierarchy->recursivePrint(tbox::plog, string("H-> "), 3);
+            tbox::plog << "Hierarchy adapted:" << std::endl;
+            patch_hierarchy->recursivePrint(tbox::plog, std::string("H-> "), 3);
          }
 
-         tbox::plog << "Memory used after adaption number " << istep << endl;
+         tbox::plog << "Memory used after adaption number " << istep << std::endl;
          tbox::MemoryUtilities::printMemoryInfo(tbox::plog);
 
 #ifdef HAVE_HDF5
          if (plot_step > 0 && (istep + 1) % plot_step == 0) {
-            const string visit_filename = vis_filename + ".visit";
+            const std::string visit_filename = vis_filename + ".visit";
             /* Create the VisIt data writer. */
             std::shared_ptr<appu::VisItDataWriter> visit_data_writer(
                new appu::VisItDataWriter(
@@ -408,14 +408,14 @@ int main(
 
       tbox::TimerManager::getManager()->print(tbox::plog);
 
-      tbox::pout << "\nPASSED:  async_br" << endl;
+      tbox::pout << "\nPASSED:  async_br" << std::endl;
 
    }
 
    /*
     * Exit properly by shutting down services in correct order.
     */
-   tbox::plog << "\nShutting down..." << endl;
+   tbox::plog << "\nShutting down..." << std::endl;
    tbox::SAMRAIManager::shutdown();
    tbox::SAMRAIManager::finalize();
    tbox::SAMRAI_MPI::finalize();

--- a/source/test/communication/CellDataTest.C
+++ b/source/test/communication/CellDataTest.C
@@ -28,15 +28,14 @@
 
 namespace SAMRAI {
 
-using namespace std;
 
 CellDataTest::CellDataTest(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> main_input_db,
    bool do_refine,
    bool do_coarsen,
-   const string& refine_option):
+   const std::string& refine_option):
    PatchDataTestStrategy(dim),
    d_dim(dim)
 {
@@ -89,25 +88,25 @@ void CellDataTest::readTestInput(
    if (db->keyExists("Acoef")) {
       d_Acoef = db->getDouble("Acoef");
    } else {
-      TBOX_ERROR(d_object_name << " input error: No `Acoeff' found." << endl);
+      TBOX_ERROR(d_object_name << " input error: No `Acoeff' found." << std::endl);
    }
    if (db->keyExists("Dcoef")) {
       d_Dcoef = db->getDouble("Dcoef");
    } else {
-      TBOX_ERROR(d_object_name << " input error: No `Dcoef' found." << endl);
+      TBOX_ERROR(d_object_name << " input error: No `Dcoef' found." << std::endl);
    }
    if (d_dim > tbox::Dimension(1)) {
       if (db->keyExists("Bcoef")) {
          d_Bcoef = db->getDouble("Bcoef");
       } else {
-         TBOX_ERROR(d_object_name << " input error: No `Bcoef' found." << endl);
+         TBOX_ERROR(d_object_name << " input error: No `Bcoef' found." << std::endl);
       }
    }
    if (d_dim > tbox::Dimension(2)) {
       if (db->keyExists("Ccoef")) {
          d_Ccoef = db->getDouble("Ccoef");
       } else {
-         TBOX_ERROR(d_object_name << " input error: No `Ccoef' found." << endl);
+         TBOX_ERROR(d_object_name << " input error: No `Ccoef' found." << std::endl);
       }
    }
 
@@ -436,7 +435,7 @@ void CellDataTest::checkPatchInteriorData(
          if (!(tbox::MathUtilities<double>::equalEps((*data)(*ci, d),
                   (*correct_data)(*ci, d)))) {
             tbox::perr << "FAILED: -- patch interior not properly filled"
-                       << endl;
+                       << std::endl;
          }
       }
    }
@@ -562,9 +561,9 @@ bool CellDataTest::verifyResults(
 
    if (d_do_refine || d_do_coarsen) {
 
-      tbox::plog << "\nEntering CellDataTest::verifyResults..." << endl;
-      tbox::plog << "level_number = " << level_number << endl;
-      tbox::plog << "Patch box = " << patch.getBox() << endl;
+      tbox::plog << "\nEntering CellDataTest::verifyResults..." << std::endl;
+      tbox::plog << "level_number = " << level_number << std::endl;
+      tbox::plog << "Patch box = " << patch.getBox() << std::endl;
 
       hier::IntVector tgcw(periodic_shift.getDim(), 0);
       for (int i = 0; i < static_cast<int>(d_variables.size()); ++i) {
@@ -613,12 +612,12 @@ bool CellDataTest::verifyResults(
                              << " : cell index = " << *ci
                              << " of L" << level_number
                              << " P" << patch.getLocalId()
-                             << " " << patch.getBox() << endl;
+                             << " " << patch.getBox() << std::endl;
                   tbox::perr << "    hier::Variable = "
                              << d_variable_src_name[i]
-                             << " : depth index = " << d << endl;
+                             << " : depth index = " << d << std::endl;
                   tbox::perr << "    result = " << result
-                             << " : correct = " << correct << endl;
+                             << " : correct = " << correct << std::endl;
                   test_failed = true;
                }
             }
@@ -626,14 +625,14 @@ bool CellDataTest::verifyResults(
 
       }
       if (!test_failed) {
-         tbox::plog << "CellDataTest Successful!" << endl;
+         tbox::plog << "CellDataTest Successful!" << std::endl;
       }
 
       solution.reset();   // just to be anal...
 
-      tbox::plog << "\nExiting CellDataTest::verifyResults..." << endl;
-      tbox::plog << "level_number = " << level_number << endl;
-      tbox::plog << "Patch box = " << patch.getBox() << endl << endl;
+      tbox::plog << "\nExiting CellDataTest::verifyResults..." << std::endl;
+      tbox::plog << "level_number = " << level_number << std::endl;
+      tbox::plog << "Patch box = " << patch.getBox() << std::endl << std::endl;
 
    }
 
@@ -700,11 +699,11 @@ bool CellDataTest::verifyCompositeBoundaryData(
                   tbox::perr << "Test FAILED: ...."
                              << " : cell index = " << *ci
                              << " on composite boundary stencil"
-                             << " " << solution->getBox() << endl;
+                             << " " << solution->getBox() << std::endl;
                   tbox::perr << "    patch data id " << data_id
-                             << " : depth index = " << d << endl;
+                             << " : depth index = " << d << std::endl;
                   tbox::perr << "    result = " << result
-                             << " : correct = " << correct << endl;
+                             << " : correct = " << correct << std::endl;
                   test_failed = true;
                }
             }

--- a/source/test/communication/CellDataTest.h
+++ b/source/test/communication/CellDataTest.h
@@ -27,7 +27,6 @@
 #include <string>
 #include <memory>
 
-using namespace std;
 
 namespace SAMRAI {
 

--- a/source/test/communication/CommTester.C
+++ b/source/test/communication/CommTester.C
@@ -19,7 +19,6 @@
 
 namespace SAMRAI {
 
-using namespace std;
 
 /*
  *************************************************************************
@@ -30,13 +29,13 @@ using namespace std;
  */
 
 CommTester::CommTester(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> main_input_db,
    PatchDataTestStrategy* data_test,
    bool do_refine,
    bool do_coarsen,
-   const string& refine_option):
+   const std::string& refine_option):
    RefinePatchStrategy(),
    CoarsenPatchStrategy(),
    d_dim(dim),
@@ -71,7 +70,7 @@ CommTester::CommTester(
    if (!((d_refine_option == "INTERIOR_FROM_SAME_LEVEL")
          || (d_refine_option == "INTERIOR_FROM_COARSER_LEVEL"))) {
       TBOX_ERROR(object_name << " input error: illegal refine_option = "
-                             << d_refine_option << endl);
+                             << d_refine_option << std::endl);
    }
 
    d_patch_data_components.clrAllFlags();
@@ -116,7 +115,7 @@ void CommTester::registerVariable(
    const hier::IntVector& src_ghosts,
    const hier::IntVector& dst_ghosts,
    const std::shared_ptr<hier::BaseGridGeometry> xfer_geom,
-   const string& operator_name)
+   const std::string& operator_name)
 {
    TBOX_ASSERT_OBJDIM_EQUALITY2(src_ghosts, dst_ghosts);
 
@@ -191,7 +190,7 @@ void CommTester::registerVariableForReset(
    const hier::IntVector& src_ghosts,
    const hier::IntVector& dst_ghosts,
    const std::shared_ptr<hier::BaseGridGeometry> xfer_geom,
-   const string& operator_name)
+   const std::string& operator_name)
 {
    TBOX_ASSERT_OBJDIM_EQUALITY2(src_ghosts, dst_ghosts);
 

--- a/source/test/communication/CommTester.h
+++ b/source/test/communication/CommTester.h
@@ -33,7 +33,6 @@
 #include "SAMRAI/mesh/StandardTagAndInitStrategy.h"
 #ifndef included_String
 #include <string>
-using namespace std;
 #define included_String
 #endif
 #include "SAMRAI/hier/Variable.h"

--- a/source/test/communication/EdgeDataTest.C
+++ b/source/test/communication/EdgeDataTest.C
@@ -28,7 +28,6 @@
 
 namespace SAMRAI {
 
-using namespace std;
 
 static double GETVALUE(
    const int dim,
@@ -39,12 +38,12 @@ static double GETVALUE(
 }
 
 EdgeDataTest::EdgeDataTest(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> main_input_db,
    bool do_refine,
    bool do_coarsen,
-   const string& refine_option):
+   const std::string& refine_option):
    PatchDataTestStrategy(dim),
    d_dim(dim)
 {
@@ -100,25 +99,25 @@ void EdgeDataTest::readTestInput(
    if (db->keyExists("Acoef")) {
       d_Acoef = db->getDouble("Acoef");
    } else {
-      TBOX_ERROR(d_object_name << " input error: No `Acoeff' found." << endl);
+      TBOX_ERROR(d_object_name << " input error: No `Acoeff' found." << std::endl);
    }
    if (db->keyExists("Dcoef")) {
       d_Dcoef = db->getDouble("Dcoef");
    } else {
-      TBOX_ERROR(d_object_name << " input error: No `Dcoef' found." << endl);
+      TBOX_ERROR(d_object_name << " input error: No `Dcoef' found." << std::endl);
    }
    if (d_dim > tbox::Dimension(1)) {
       if (db->keyExists("Bcoef")) {
          d_Bcoef = db->getDouble("Bcoef");
       } else {
-         TBOX_ERROR(d_object_name << " input error: No `Bcoef' found." << endl);
+         TBOX_ERROR(d_object_name << " input error: No `Bcoef' found." << std::endl);
       }
    }
    if (d_dim > tbox::Dimension(2)) {
       if (db->keyExists("Ccoef")) {
          d_Ccoef = db->getDouble("Ccoef");
       } else {
-         TBOX_ERROR(d_object_name << " input error: No `Ccoef' found." << endl);
+         TBOX_ERROR(d_object_name << " input error: No `Ccoef' found." << std::endl);
       }
    }
 
@@ -130,7 +129,7 @@ void EdgeDataTest::readTestInput(
 
    std::shared_ptr<tbox::Database> var_data(
       db->getDatabase("VariableData"));
-   std::vector<string> var_keys = var_data->getAllKeys();
+   std::vector<std::string> var_keys = var_data->getAllKeys();
    int nkeys = static_cast<int>(var_keys.size());
 
    d_use_fine_value_at_interface.resize(nkeys);
@@ -570,9 +569,9 @@ bool EdgeDataTest::verifyResults(
    }
    if (d_do_refine || d_do_coarsen) {
 
-      tbox::plog << "\nEntering EdgeDataTest::verifyResults..." << endl;
-      tbox::plog << "level_number = " << level_number << endl;
-      tbox::plog << "Patch box = " << patch.getBox() << endl;
+      tbox::plog << "\nEntering EdgeDataTest::verifyResults..." << std::endl;
+      tbox::plog << "level_number = " << level_number << std::endl;
+      tbox::plog << "Patch box = " << patch.getBox() << std::endl;
 
       hier::IntVector tgcw(d_dim, 0);
       for (int i = 0; i < static_cast<int>(d_variables.size()); ++i) {
@@ -617,12 +616,12 @@ bool EdgeDataTest::verifyResults(
                          result)) {
                      test_failed = true;
                      tbox::perr << "Test FAILED: ...."
-                                << " : edge_data index = " << *si << endl;
+                                << " : edge_data index = " << *si << std::endl;
                      tbox::perr << "    hier::Variable = "
                                 << d_variable_src_name[i]
-                                << " : depth index = " << d << endl;
+                                << " : depth index = " << d << std::endl;
                      tbox::perr << "    result = " << result
-                                << " : correct = " << correct << endl;
+                                << " : correct = " << correct << std::endl;
                   }
                }
             }
@@ -632,9 +631,9 @@ bool EdgeDataTest::verifyResults(
 
       solution.reset();   // just to be anal...
 
-      tbox::plog << "\nExiting EdgeDataTest::verifyResults..." << endl;
-      tbox::plog << "level_number = " << level_number << endl;
-      tbox::plog << "Patch box = " << patch.getBox() << endl << endl;
+      tbox::plog << "\nExiting EdgeDataTest::verifyResults..." << std::endl;
+      tbox::plog << "level_number = " << level_number << std::endl;
+      tbox::plog << "Patch box = " << patch.getBox() << std::endl << std::endl;
 
    }
 
@@ -753,7 +752,7 @@ void EdgeDataTest::checkPatchInteriorData(
             if (!(tbox::MathUtilities<double>::equalEps((*data)(*ei,
                                                                 d), value))) {
                tbox::perr
-               << "FAILED:  -- patch interior not properly filled" << endl;
+               << "FAILED:  -- patch interior not properly filled" << std::endl;
             }
          }
 

--- a/source/test/communication/EdgeDataTest.h
+++ b/source/test/communication/EdgeDataTest.h
@@ -24,7 +24,6 @@
 #include "PatchDataTestStrategy.h"
 #ifndef included_String
 #include <string>
-using namespace std;
 #define included_String
 #endif
 #include "SAMRAI/hier/Variable.h"

--- a/source/test/communication/FaceDataTest.C
+++ b/source/test/communication/FaceDataTest.C
@@ -30,15 +30,14 @@
 
 namespace SAMRAI {
 
-using namespace std;
 
 FaceDataTest::FaceDataTest(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> main_input_db,
    bool do_refine,
    bool do_coarsen,
-   const string& refine_option):
+   const std::string& refine_option):
    PatchDataTestStrategy(dim),
    d_dim(dim)
 {
@@ -95,7 +94,7 @@ void FaceDataTest::readTestInput(
    readVariableInput(db->getDatabase("VariableData"));
 
    std::shared_ptr<tbox::Database> var_data(db->getDatabase("VariableData"));
-   std::vector<string> var_keys = var_data->getAllKeys();
+   std::vector<std::string> var_keys = var_data->getAllKeys();
    int nkeys = static_cast<int>(var_keys.size());
 
    d_use_fine_value_at_interface.resize(nkeys);
@@ -116,25 +115,25 @@ void FaceDataTest::readTestInput(
    if (db->keyExists("Acoef")) {
       d_Acoef = db->getDouble("Acoef");
    } else {
-      TBOX_ERROR(d_object_name << " input error: No `Acoeff' found." << endl);
+      TBOX_ERROR(d_object_name << " input error: No `Acoeff' found." << std::endl);
    }
    if (db->keyExists("Dcoef")) {
       d_Dcoef = db->getDouble("Dcoef");
    } else {
-      TBOX_ERROR(d_object_name << " input error: No `Dcoef' found." << endl);
+      TBOX_ERROR(d_object_name << " input error: No `Dcoef' found." << std::endl);
    }
    if (d_dim > tbox::Dimension(1)) {
       if (db->keyExists("Bcoef")) {
          d_Bcoef = db->getDouble("Bcoef");
       } else {
-         TBOX_ERROR(d_object_name << " input error: No `Bcoef' found." << endl);
+         TBOX_ERROR(d_object_name << " input error: No `Bcoef' found." << std::endl);
       }
    }
    if (d_dim > tbox::Dimension(2)) {
       if (db->keyExists("Ccoef")) {
          d_Ccoef = db->getDouble("Ccoef");
       } else {
-         TBOX_ERROR(d_object_name << " input error: No `Ccoef' found." << endl);
+         TBOX_ERROR(d_object_name << " input error: No `Ccoef' found." << std::endl);
       }
    }
 
@@ -402,7 +401,7 @@ void FaceDataTest::checkPatchInteriorData(
             if (!(tbox::MathUtilities<double>::equalEps((*data)(*fi,
                                                                 d), value))) {
                tbox::perr << "FAILED: -- patch interior not properly filled"
-                          << endl;
+                          << std::endl;
             }
          }
       }
@@ -574,9 +573,9 @@ bool FaceDataTest::verifyResults(
    bool test_failed = false;
    if (d_do_refine || d_do_coarsen) {
 
-      tbox::plog << "\nEntering FaceDataTest::verifyResults..." << endl;
-      tbox::plog << "level_number = " << level_number << endl;
-      tbox::plog << "Patch box = " << patch.getBox() << endl;
+      tbox::plog << "\nEntering FaceDataTest::verifyResults..." << std::endl;
+      tbox::plog << "level_number = " << level_number << std::endl;
+      tbox::plog << "Patch box = " << patch.getBox() << std::endl;
 
       hier::IntVector tgcw(d_dim, 0);
       for (int i = 0; i < static_cast<int>(d_variables.size()); ++i) {
@@ -620,12 +619,12 @@ bool FaceDataTest::verifyResults(
                          result)) {
                      test_failed = true;
                      tbox::perr << "Test FAILED: ...."
-                                << " : face_data index = " << *si << endl;
+                                << " : face_data index = " << *si << std::endl;
                      tbox::perr << "    hier::Variable = "
                                 << d_variable_src_name[i]
-                                << " : depth index = " << d << endl;
+                                << " : depth index = " << d << std::endl;
                      tbox::perr << "    result = " << result
-                                << " : correct = " << correct << endl;
+                                << " : correct = " << correct << std::endl;
                   }
                }
             }
@@ -635,9 +634,9 @@ bool FaceDataTest::verifyResults(
 
       solution.reset();   // just to be anal...
 
-      tbox::plog << "\nExiting FaceDataTest::verifyResults..." << endl;
-      tbox::plog << "level_number = " << level_number << endl;
-      tbox::plog << "Patch box = " << patch.getBox() << endl << endl;
+      tbox::plog << "\nExiting FaceDataTest::verifyResults..." << std::endl;
+      tbox::plog << "level_number = " << level_number << std::endl;
+      tbox::plog << "Patch box = " << patch.getBox() << std::endl << std::endl;
 
    }
 

--- a/source/test/communication/FaceDataTest.h
+++ b/source/test/communication/FaceDataTest.h
@@ -25,7 +25,6 @@
 #include "PatchDataTestStrategy.h"
 #ifndef included_String
 #include <string>
-using namespace std;
 #define included_String
 #endif
 #include "SAMRAI/hier/Variable.h"

--- a/source/test/communication/NodeDataTest.C
+++ b/source/test/communication/NodeDataTest.C
@@ -27,15 +27,14 @@
 
 namespace SAMRAI {
 
-using namespace std;
 
 NodeDataTest::NodeDataTest(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> main_input_db,
    bool do_refine,
    bool do_coarsen,
-   const string& refine_option):
+   const std::string& refine_option):
    PatchDataTestStrategy(dim),
    d_dim(dim)
 {
@@ -89,25 +88,25 @@ void NodeDataTest::readTestInput(
    if (db->keyExists("Acoef")) {
       d_Acoef = db->getDouble("Acoef");
    } else {
-      TBOX_ERROR(d_object_name << " input error: No `Acoeff' found." << endl);
+      TBOX_ERROR(d_object_name << " input error: No `Acoeff' found." << std::endl);
    }
    if (db->keyExists("Dcoef")) {
       d_Dcoef = db->getDouble("Dcoef");
    } else {
-      TBOX_ERROR(d_object_name << " input error: No `Dcoef' found." << endl);
+      TBOX_ERROR(d_object_name << " input error: No `Dcoef' found." << std::endl);
    }
    if (d_dim > tbox::Dimension(1)) {
       if (db->keyExists("Bcoef")) {
          d_Bcoef = db->getDouble("Bcoef");
       } else {
-         TBOX_ERROR(d_object_name << " input error: No `Bcoef' found." << endl);
+         TBOX_ERROR(d_object_name << " input error: No `Bcoef' found." << std::endl);
       }
    }
    if (d_dim > tbox::Dimension(2)) {
       if (db->keyExists("Ccoef")) {
          d_Ccoef = db->getDouble("Ccoef");
       } else {
-         TBOX_ERROR(d_object_name << " input error: No `Ccoef' found." << endl);
+         TBOX_ERROR(d_object_name << " input error: No `Ccoef' found." << std::endl);
       }
    }
 
@@ -332,7 +331,7 @@ void NodeDataTest::checkPatchInteriorData(
          if (!(tbox::MathUtilities<double>::equalEps((*data)(*ni, d),
                   (*correct_data)(*ni, d)))) {
             tbox::perr << "FAILED: -- patch interior not properly filled"
-                       << endl;
+                       << std::endl;
          }
       }
    }
@@ -459,9 +458,9 @@ bool NodeDataTest::verifyResults(
 
    if (d_do_refine || d_do_coarsen) {
 
-      tbox::plog << "\nEntering NodeDataTest::verifyResults..." << endl;
-      tbox::plog << "level_number = " << level_number << endl;
-      tbox::plog << "Patch box = " << patch.getBox() << endl;
+      tbox::plog << "\nEntering NodeDataTest::verifyResults..." << std::endl;
+      tbox::plog << "level_number = " << level_number << std::endl;
+      tbox::plog << "Patch box = " << patch.getBox() << std::endl;
 
       hier::IntVector tgcw(periodic_shift.getDim(), 0);
       for (int i = 0; i < static_cast<int>(d_variables.size()); ++i) {
@@ -510,12 +509,12 @@ bool NodeDataTest::verifyResults(
                              << " : node index = " << *ci
                              << " of L" << level_number
                              << " P" << patch.getLocalId()
-                             << " " << patch.getBox() << endl;
+                             << " " << patch.getBox() << std::endl;
                   tbox::perr << "    hier::Variable = "
                              << d_variable_src_name[i]
-                             << " : depth index = " << d << endl;
+                             << " : depth index = " << d << std::endl;
                   tbox::perr << "    result = " << result
-                             << " : correct = " << correct << endl;
+                             << " : correct = " << correct << std::endl;
                   test_failed = true;
                }
             }
@@ -523,14 +522,14 @@ bool NodeDataTest::verifyResults(
 
       }
       if (!test_failed) {
-         tbox::plog << "Node test Successful!" << endl;
+         tbox::plog << "Node test Successful!" << std::endl;
       }
 
       solution.reset();   // just to be anal...
 
-      tbox::plog << "\nExiting NodeDataTest::verifyResults..." << endl;
-      tbox::plog << "level_number = " << level_number << endl;
-      tbox::plog << "Patch box = " << patch.getBox() << endl << endl;
+      tbox::plog << "\nExiting NodeDataTest::verifyResults..." << std::endl;
+      tbox::plog << "level_number = " << level_number << std::endl;
+      tbox::plog << "Patch box = " << patch.getBox() << std::endl << std::endl;
 
    }
 

--- a/source/test/communication/NodeDataTest.h
+++ b/source/test/communication/NodeDataTest.h
@@ -23,7 +23,6 @@
 #include "PatchDataTestStrategy.h"
 #ifndef included_String
 #include <string>
-using namespace std;
 #define included_String
 #endif
 #include "SAMRAI/hier/Variable.h"

--- a/source/test/communication/OuterfaceDataTest.C
+++ b/source/test/communication/OuterfaceDataTest.C
@@ -28,15 +28,14 @@
 
 namespace SAMRAI {
 
-using namespace std;
 
 OuterfaceDataTest::OuterfaceDataTest(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> main_input_db,
    bool do_refine,
    bool do_coarsen,
-   const string& refine_option):
+   const std::string& refine_option):
    PatchDataTestStrategy(dim),
    d_dim(dim)
 {
@@ -94,7 +93,7 @@ void OuterfaceDataTest::readTestInput(
 
    std::shared_ptr<tbox::Database> var_data(
       db->getDatabase("VariableData"));
-   std::vector<string> var_keys = var_data->getAllKeys();
+   std::vector<std::string> var_keys = var_data->getAllKeys();
    int nkeys = static_cast<int>(var_keys.size());
 
    d_use_fine_value_at_interface.resize(nkeys);
@@ -115,25 +114,25 @@ void OuterfaceDataTest::readTestInput(
    if (db->keyExists("Acoef")) {
       d_Acoef = db->getDouble("Acoef");
    } else {
-      TBOX_ERROR(d_object_name << " input error: No `Acoeff' found." << endl);
+      TBOX_ERROR(d_object_name << " input error: No `Acoeff' found." << std::endl);
    }
    if (db->keyExists("Dcoef")) {
       d_Dcoef = db->getDouble("Dcoef");
    } else {
-      TBOX_ERROR(d_object_name << " input error: No `Dcoef' found." << endl);
+      TBOX_ERROR(d_object_name << " input error: No `Dcoef' found." << std::endl);
    }
    if (d_dim > tbox::Dimension(1)) {
       if (db->keyExists("Bcoef")) {
          d_Bcoef = db->getDouble("Bcoef");
       } else {
-         TBOX_ERROR(d_object_name << " input error: No `Bcoef' found." << endl);
+         TBOX_ERROR(d_object_name << " input error: No `Bcoef' found." << std::endl);
       }
    }
    if (d_dim > tbox::Dimension(2)) {
       if (db->keyExists("Ccoef")) {
          d_Ccoef = db->getDouble("Ccoef");
       } else {
-         TBOX_ERROR(d_object_name << " input error: No `Ccoef' found." << endl);
+         TBOX_ERROR(d_object_name << " input error: No `Ccoef' found." << std::endl);
       }
    }
 
@@ -319,7 +318,7 @@ void OuterfaceDataTest::checkPatchInteriorData(
             if (!(tbox::MathUtilities<double>::equalEps((*data)(*fi,
                                                                 d), value))) {
                tbox::perr << "FAILED: -- patch interior not properly filled"
-                          << endl;
+                          << std::endl;
             }
          }
       }
@@ -489,9 +488,9 @@ bool OuterfaceDataTest::verifyResults(
    bool test_failed = false;
    if (d_do_refine || d_do_coarsen) {
 
-      tbox::plog << "\nEntering OuterfaceDataTest::verifyResults..." << endl;
-      tbox::plog << "level_number = " << level_number << endl;
-      tbox::plog << "Patch box = " << patch.getBox() << endl;
+      tbox::plog << "\nEntering OuterfaceDataTest::verifyResults..." << std::endl;
+      tbox::plog << "level_number = " << level_number << std::endl;
+      tbox::plog << "Patch box = " << patch.getBox() << std::endl;
 
       hier::IntVector tgcw(d_dim, 0);
       for (int i = 0; i < static_cast<int>(d_variables_dst.size()); ++i) {
@@ -532,12 +531,12 @@ bool OuterfaceDataTest::verifyResults(
                      if (!tbox::MathUtilities<double>::equalEps(correct,
                             result)) {
                         tbox::perr << "Test FAILED: ...."
-                                   << " : face_data index = " << *fi << endl;
+                                   << " : face_data index = " << *fi << std::endl;
                         tbox::perr << "    hier::Variable = "
                                    << d_variable_src_name[i]
-                                   << " : depth index = " << d << endl;
+                                   << " : depth index = " << d << std::endl;
                         tbox::perr << "    result = " << result
-                                   << " : correct = " << correct << endl;
+                                   << " : correct = " << correct << std::endl;
                         test_failed = true;
                      }
                   }
@@ -563,12 +562,12 @@ bool OuterfaceDataTest::verifyResults(
                      if (!tbox::MathUtilities<double>::equalEps(correct,
                             result)) {
                         tbox::perr << "Test FAILED: ...."
-                                   << " : oface_data index = " << fndx << endl;
+                                   << " : oface_data index = " << fndx << std::endl;
                         tbox::perr << "    hier::Variable = "
                                    << d_variable_src_name[i]
-                                   << " : depth index = " << d << endl;
+                                   << " : depth index = " << d << std::endl;
                         tbox::perr << "    result = " << result
-                                   << " : correct = " << correct << endl;
+                                   << " : correct = " << correct << std::endl;
                         test_failed = true;
                      }
                   }
@@ -585,12 +584,12 @@ bool OuterfaceDataTest::verifyResults(
                      if (!tbox::MathUtilities<double>::equalEps(correct,
                             result)) {
                         tbox::perr << "Test FAILED: ...."
-                                   << " : oface_data index = " << fndx << endl;
+                                   << " : oface_data index = " << fndx << std::endl;
                         tbox::perr << "    hier::Variable = "
                                    << d_variable_src_name[i]
-                                   << " : depth index = " << d << endl;
+                                   << " : depth index = " << d << std::endl;
                         tbox::perr << "    result = " << result
-                                   << " : correct = " << correct << endl;
+                                   << " : correct = " << correct << std::endl;
                         test_failed = true;
                      }
                   }
@@ -599,14 +598,14 @@ bool OuterfaceDataTest::verifyResults(
          }
       }
       if (!test_failed) {
-         tbox::plog << "Outerface test Successful!" << endl;
+         tbox::plog << "Outerface test Successful!" << std::endl;
       }
 
       solution.reset();   // just to be anal...
 
-      tbox::plog << "\nExiting OuterfaceDataTest::verifyResults..." << endl;
-      tbox::plog << "level_number = " << level_number << endl;
-      tbox::plog << "Patch box = " << patch.getBox() << endl << endl;
+      tbox::plog << "\nExiting OuterfaceDataTest::verifyResults..." << std::endl;
+      tbox::plog << "level_number = " << level_number << std::endl;
+      tbox::plog << "Patch box = " << patch.getBox() << std::endl << std::endl;
 
    }
 

--- a/source/test/communication/OuterfaceDataTest.h
+++ b/source/test/communication/OuterfaceDataTest.h
@@ -26,7 +26,6 @@
 #include "PatchDataTestStrategy.h"
 #ifndef included_String
 #include <string>
-using namespace std;
 #define included_String
 #endif
 #include "SAMRAI/hier/Variable.h"

--- a/source/test/communication/OuternodeDataTest.C
+++ b/source/test/communication/OuternodeDataTest.C
@@ -27,15 +27,14 @@
 
 namespace SAMRAI {
 
-using namespace std;
 
 OuternodeDataTest::OuternodeDataTest(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> main_input_db,
    bool do_refine,
    bool do_coarsen,
-   const string& refine_option):
+   const std::string& refine_option):
    PatchDataTestStrategy(dim),
    d_dim(dim)
 {
@@ -97,25 +96,25 @@ void OuternodeDataTest::readTestInput(
    if (db->keyExists("Acoef")) {
       d_Acoef = db->getDouble("Acoef");
    } else {
-      TBOX_ERROR(d_object_name << " input error: No `Acoeff' found." << endl);
+      TBOX_ERROR(d_object_name << " input error: No `Acoeff' found." << std::endl);
    }
    if (db->keyExists("Dcoef")) {
       d_Dcoef = db->getDouble("Dcoef");
    } else {
-      TBOX_ERROR(d_object_name << " input error: No `Dcoef' found." << endl);
+      TBOX_ERROR(d_object_name << " input error: No `Dcoef' found." << std::endl);
    }
    if (d_dim > tbox::Dimension(1)) {
       if (db->keyExists("Bcoef")) {
          d_Bcoef = db->getDouble("Bcoef");
       } else {
-         TBOX_ERROR(d_object_name << " input error: No `Bcoef' found." << endl);
+         TBOX_ERROR(d_object_name << " input error: No `Bcoef' found." << std::endl);
       }
    }
    if (d_dim > tbox::Dimension(2)) {
       if (db->keyExists("Ccoef")) {
          d_Ccoef = db->getDouble("Ccoef");
       } else {
-         TBOX_ERROR(d_object_name << " input error: No `Ccoef' found." << endl);
+         TBOX_ERROR(d_object_name << " input error: No `Ccoef' found." << std::endl);
       }
    }
 
@@ -381,7 +380,7 @@ void OuternodeDataTest::checkPatchInteriorData(
          if (!(tbox::MathUtilities<double>::equalEps((*data)(*ci,
                                                              d), value))) {
             tbox::perr << "FAILED: -- patch interior not properly filled"
-                       << endl;
+                       << std::endl;
          }
       }
 
@@ -419,9 +418,9 @@ bool OuternodeDataTest::verifyResults(
    bool test_failed = false;
    if (d_do_refine || d_do_coarsen) {
 
-      tbox::plog << "\nEntering OuternodeDataTest::verifyResults..." << endl;
-      tbox::plog << "level_number = " << level_number << endl;
-      tbox::plog << "Patch box = " << patch.getBox() << endl;
+      tbox::plog << "\nEntering OuternodeDataTest::verifyResults..." << std::endl;
+      tbox::plog << "level_number = " << level_number << std::endl;
+      tbox::plog << "Patch box = " << patch.getBox() << std::endl;
 
       hier::IntVector tgcw(d_dim, 0);
       for (int i = 0; i < static_cast<int>(d_variables_dst.size()); ++i) {
@@ -460,12 +459,12 @@ bool OuternodeDataTest::verifyResults(
                double result = (*node_data)(*ci, d);
                if (!tbox::MathUtilities<double>::equalEps(correct, result)) {
                   tbox::perr << "Test FAILED: ...."
-                             << " : node index = " << *ci << endl;
+                             << " : node index = " << *ci << std::endl;
                   tbox::perr << "    hier::Variable = "
                              << d_variable_src_name[i]
-                             << " : depth index = " << d << endl;
+                             << " : depth index = " << d << std::endl;
                   tbox::perr << "    result = " << result
-                             << " : correct = " << correct << endl;
+                             << " : correct = " << correct << std::endl;
                   test_failed = true;
                }
             }
@@ -473,14 +472,14 @@ bool OuternodeDataTest::verifyResults(
 
       }
       if (!test_failed) {
-         tbox::plog << "Outernode test Successful!" << endl;
+         tbox::plog << "Outernode test Successful!" << std::endl;
       }
 
       solution.reset();   // just to be anal...
 
-      tbox::plog << "\nExiting OuternodeDataTest::verifyResults..." << endl;
-      tbox::plog << "level_number = " << level_number << endl;
-      tbox::plog << "Patch box = " << patch.getBox() << endl << endl;
+      tbox::plog << "\nExiting OuternodeDataTest::verifyResults..." << std::endl;
+      tbox::plog << "level_number = " << level_number << std::endl;
+      tbox::plog << "Patch box = " << patch.getBox() << std::endl << std::endl;
 
    }
 

--- a/source/test/communication/OuternodeDataTest.h
+++ b/source/test/communication/OuternodeDataTest.h
@@ -24,7 +24,6 @@
 #include "PatchDataTestStrategy.h"
 #ifndef included_String
 #include <string>
-using namespace std;
 #define included_String
 #endif
 #include "SAMRAI/hier/Variable.h"

--- a/source/test/communication/OutersideDataTest.C
+++ b/source/test/communication/OutersideDataTest.C
@@ -28,15 +28,14 @@
 
 namespace SAMRAI {
 
-using namespace std;
 
 OutersideDataTest::OutersideDataTest(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> main_input_db,
    bool do_refine,
    bool do_coarsen,
-   const string& refine_option):
+   const std::string& refine_option):
    PatchDataTestStrategy(dim),
    d_dim(dim)
 {
@@ -99,7 +98,7 @@ void OutersideDataTest::readTestInput(
    readVariableInput(db->getDatabase("VariableData"));
 
    std::shared_ptr<tbox::Database> var_data(db->getDatabase("VariableData"));
-   std::vector<string> var_keys = var_data->getAllKeys();
+   std::vector<std::string> var_keys = var_data->getAllKeys();
    int nkeys = static_cast<int>(var_keys.size());
 
    d_use_fine_value_at_interface.resize(nkeys);
@@ -120,25 +119,25 @@ void OutersideDataTest::readTestInput(
    if (db->keyExists("Acoef")) {
       d_Acoef = db->getDouble("Acoef");
    } else {
-      TBOX_ERROR(d_object_name << " input error: No `Acoeff' found." << endl);
+      TBOX_ERROR(d_object_name << " input error: No `Acoeff' found." << std::endl);
    }
    if (db->keyExists("Dcoef")) {
       d_Dcoef = db->getDouble("Dcoef");
    } else {
-      TBOX_ERROR(d_object_name << " input error: No `Dcoef' found." << endl);
+      TBOX_ERROR(d_object_name << " input error: No `Dcoef' found." << std::endl);
    }
    if (d_dim > tbox::Dimension(1)) {
       if (db->keyExists("Bcoef")) {
          d_Bcoef = db->getDouble("Bcoef");
       } else {
-         TBOX_ERROR(d_object_name << " input error: No `Bcoef' found." << endl);
+         TBOX_ERROR(d_object_name << " input error: No `Bcoef' found." << std::endl);
       }
    }
    if (d_dim > tbox::Dimension(2)) {
       if (db->keyExists("Ccoef")) {
          d_Ccoef = db->getDouble("Ccoef");
       } else {
-         TBOX_ERROR(d_object_name << " input error: No `Ccoef' found." << endl);
+         TBOX_ERROR(d_object_name << " input error: No `Ccoef' found." << std::endl);
       }
    }
 
@@ -318,7 +317,7 @@ void OutersideDataTest::checkPatchInteriorData(
             if (!(tbox::MathUtilities<double>::equalEps((*data)(*si,
                                                                 d), value))) {
                tbox::perr << "FAILED: -- patch interior not properly filled"
-                          << endl;
+                          << std::endl;
             }
          }
       }
@@ -482,9 +481,9 @@ bool OutersideDataTest::verifyResults(
    bool test_failed = false;
    if (d_do_refine || d_do_coarsen) {
 
-      tbox::plog << "\nEntering OutersideDataTest::verifyResults..." << endl;
-      tbox::plog << "level_number = " << level_number << endl;
-      tbox::plog << "Patch box = " << patch.getBox() << endl;
+      tbox::plog << "\nEntering OutersideDataTest::verifyResults..." << std::endl;
+      tbox::plog << "level_number = " << level_number << std::endl;
+      tbox::plog << "Patch box = " << patch.getBox() << std::endl;
 
       hier::IntVector tgcw(d_dim, 0);
       for (int i = 0; i < static_cast<int>(d_variables_dst.size()); ++i) {
@@ -528,12 +527,12 @@ bool OutersideDataTest::verifyResults(
                         if (!tbox::MathUtilities<double>::equalEps(correct,
                                result)) {
                            tbox::perr << "Test FAILED: ...."
-                                      << " : side_data index = " << *si << endl;
+                                      << " : side_data index = " << *si << std::endl;
                            tbox::perr << "    hier::Variable = "
                                       << d_variable_src_name[i]
-                                      << " : depth index = " << d << endl;
+                                      << " : depth index = " << d << std::endl;
                            tbox::perr << "    result = " << result
-                                      << " : correct = " << correct << endl;
+                                      << " : correct = " << correct << std::endl;
                            test_failed = true;
                         }
                      }
@@ -560,12 +559,12 @@ bool OutersideDataTest::verifyResults(
                      if (!tbox::MathUtilities<double>::equalEps(correct,
                             result)) {
                         tbox::perr << "Test FAILED: ...."
-                                   << " : oside_data index = " << sndx << endl;
+                                   << " : oside_data index = " << sndx << std::endl;
                         tbox::perr << "    hier::Variable = "
                                    << d_variable_src_name[i]
-                                   << " : depth index = " << d << endl;
+                                   << " : depth index = " << d << std::endl;
                         tbox::perr << "    result = " << result
-                                   << " : correct = " << correct << endl;
+                                   << " : correct = " << correct << std::endl;
                         test_failed = true;
                      }
                   }
@@ -582,12 +581,12 @@ bool OutersideDataTest::verifyResults(
                      if (!tbox::MathUtilities<double>::equalEps(correct,
                             result)) {
                         tbox::perr << "Test FAILED: ...."
-                                   << " : oside_data index = " << sndx << endl;
+                                   << " : oside_data index = " << sndx << std::endl;
                         tbox::perr << "    hier::Variable = "
                                    << d_variable_src_name[i]
-                                   << " : depth index = " << d << endl;
+                                   << " : depth index = " << d << std::endl;
                         tbox::perr << "    result = " << result
-                                   << " : correct = " << correct << endl;
+                                   << " : correct = " << correct << std::endl;
                         test_failed = true;
                      }
                   }
@@ -597,14 +596,14 @@ bool OutersideDataTest::verifyResults(
 
       }
       if (!test_failed) {
-         tbox::plog << "Outerside test Successful!" << endl;
+         tbox::plog << "Outerside test Successful!" << std::endl;
       }
 
       solution.reset();   // just to be anal...
 
-      tbox::plog << "\nExiting OutersidedataTest::verifyResults..." << endl;
-      tbox::plog << "level_number = " << level_number << endl;
-      tbox::plog << "Patch box = " << patch.getBox() << endl << endl;
+      tbox::plog << "\nExiting OutersidedataTest::verifyResults..." << std::endl;
+      tbox::plog << "level_number = " << level_number << std::endl;
+      tbox::plog << "Patch box = " << patch.getBox() << std::endl << std::endl;
 
    }
 

--- a/source/test/communication/OutersideDataTest.h
+++ b/source/test/communication/OutersideDataTest.h
@@ -26,7 +26,6 @@
 #include "PatchDataTestStrategy.h"
 #ifndef included_String
 #include <string>
-using namespace std;
 #define included_String
 #endif
 #include "SAMRAI/hier/Variable.h"

--- a/source/test/communication/PatchDataTestStrategy.C
+++ b/source/test/communication/PatchDataTestStrategy.C
@@ -19,7 +19,6 @@
 
 namespace SAMRAI {
 
-using namespace std;
 
 // These are used in the cell tagging routine.
 #ifndef TRUE
@@ -67,7 +66,7 @@ void PatchDataTestStrategy::readVariableInput(
 {
    TBOX_ASSERT(db);
 
-   std::vector<string> var_keys = db->getAllKeys();
+   std::vector<std::string> var_keys = db->getAllKeys();
    int nkeys = static_cast<int>(var_keys.size());
 
    d_variable_src_name.resize(nkeys);
@@ -86,14 +85,14 @@ void PatchDataTestStrategy::readVariableInput(
          d_variable_src_name[i] = var_db->getString("src_name");
       } else {
          TBOX_ERROR("Variable input error: No `src_name' string found for "
-            << "key = " << var_keys[i] << endl);
+            << "key = " << var_keys[i] << std::endl);
       }
 
       if (var_db->keyExists("dst_name")) {
          d_variable_dst_name[i] = var_db->getString("dst_name");
       } else {
          TBOX_ERROR("Variable input error: No `dst_name' string found for "
-            << "key = " << var_keys[i] << endl);
+            << "key = " << var_keys[i] << std::endl);
       }
 
       if (var_db->keyExists("depth")) {

--- a/source/test/communication/PatchDataTestStrategy.h
+++ b/source/test/communication/PatchDataTestStrategy.h
@@ -24,7 +24,6 @@
 #include <string>
 #include <memory>
 
-using namespace std;
 
 namespace SAMRAI {
 

--- a/source/test/communication/SideDataTest.C
+++ b/source/test/communication/SideDataTest.C
@@ -30,15 +30,14 @@
 
 namespace SAMRAI {
 
-using namespace std;
 
 SideDataTest::SideDataTest(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> main_input_db,
    bool do_refine,
    bool do_coarsen,
-   const string& refine_option):
+   const std::string& refine_option):
    PatchDataTestStrategy(dim),
    d_dim(dim)
 {
@@ -94,7 +93,7 @@ void SideDataTest::readTestInput(
 
    std::shared_ptr<tbox::Database> var_data(
       db->getDatabase("VariableData"));
-   std::vector<string> var_keys = var_data->getAllKeys();
+   std::vector<std::string> var_keys = var_data->getAllKeys();
    int nkeys = static_cast<int>(var_keys.size());
 
    d_test_direction.resize(nkeys, hier::IntVector::getZero(d_dim));
@@ -123,25 +122,25 @@ void SideDataTest::readTestInput(
    if (db->keyExists("Acoef")) {
       d_Acoef = db->getDouble("Acoef");
    } else {
-      TBOX_ERROR(d_object_name << " input error: No `Acoeff' found." << endl);
+      TBOX_ERROR(d_object_name << " input error: No `Acoeff' found." << std::endl);
    }
    if (db->keyExists("Dcoef")) {
       d_Dcoef = db->getDouble("Dcoef");
    } else {
-      TBOX_ERROR(d_object_name << " input error: No `Dcoef' found." << endl);
+      TBOX_ERROR(d_object_name << " input error: No `Dcoef' found." << std::endl);
    }
    if (d_dim > tbox::Dimension(1)) {
       if (db->keyExists("Bcoef")) {
          d_Bcoef = db->getDouble("Bcoef");
       } else {
-         TBOX_ERROR(d_object_name << " input error: No `Bcoef' found." << endl);
+         TBOX_ERROR(d_object_name << " input error: No `Bcoef' found." << std::endl);
       }
    }
    if (d_dim > tbox::Dimension(2)) {
       if (db->keyExists("Ccoef")) {
          d_Ccoef = db->getDouble("Ccoef");
       } else {
-         TBOX_ERROR(d_object_name << " input error: No `Ccoef' found." << endl);
+         TBOX_ERROR(d_object_name << " input error: No `Ccoef' found." << std::endl);
       }
    }
 
@@ -414,7 +413,7 @@ void SideDataTest::checkPatchInteriorData(
                   tbox::perr << "FAILED: -- patch interior not properly filled"
                              << " : side_data index = "
                              << si->getAxis() << '/' << *si
-                             << endl;
+                             << std::endl;
                }
             }
          }
@@ -662,9 +661,9 @@ bool SideDataTest::verifyResults(
 
    if (d_do_refine || d_do_coarsen) {
 
-      tbox::plog << "\nEntering SideDataTest::verifyResults..." << endl;
-      tbox::plog << "level_number = " << level_number << endl;
-      tbox::plog << "Patch box = " << patch.getBox() << endl;
+      tbox::plog << "\nEntering SideDataTest::verifyResults..." << std::endl;
+      tbox::plog << "level_number = " << level_number << std::endl;
+      tbox::plog << "Patch box = " << patch.getBox() << std::endl;
 
       hier::IntVector tgcw(periodic_shift.getDim(), 0);
       for (int i = 0; i < static_cast<int>(d_variables.size()); ++i) {
@@ -715,12 +714,12 @@ bool SideDataTest::verifyResults(
                         test_failed = true;
                         tbox::perr << "Test FAILED: ...."
                                    << " : side_data index = "
-                                   << si->getAxis() << '/' << *si << endl;
+                                   << si->getAxis() << '/' << *si << std::endl;
                         tbox::perr << "    hier::Variable = "
                                    << d_variable_src_name[i]
-                                   << " : depth index = " << d << endl;
+                                   << " : depth index = " << d << std::endl;
                         tbox::perr << "    result = " << result
-                                   << " : correct = " << correct << endl;
+                                   << " : correct = " << correct << std::endl;
                      }
                   }
                }
@@ -731,9 +730,9 @@ bool SideDataTest::verifyResults(
 
       solution.reset();   // just to be anal...
 
-      tbox::plog << "\nExiting SideDataTest::verifyResults..." << endl;
-      tbox::plog << "level_number = " << level_number << endl;
-      tbox::plog << "Patch box = " << patch.getBox() << endl << endl;
+      tbox::plog << "\nExiting SideDataTest::verifyResults..." << std::endl;
+      tbox::plog << "level_number = " << level_number << std::endl;
+      tbox::plog << "Patch box = " << patch.getBox() << std::endl << std::endl;
 
    }
    return !test_failed;

--- a/source/test/communication/SideDataTest.h
+++ b/source/test/communication/SideDataTest.h
@@ -25,7 +25,6 @@
 #include "PatchDataTestStrategy.h"
 #ifndef included_String
 #include <string>
-using namespace std;
 #define included_String
 #endif
 #include "SAMRAI/hier/Variable.h"

--- a/source/test/communication/main.C
+++ b/source/test/communication/main.C
@@ -12,7 +12,6 @@
 
 #include <string>
 #include <memory>
-using namespace std;
 
 #include "SAMRAI/tbox/SAMRAIManager.h"
 
@@ -206,12 +205,12 @@ int main(
        *    executable <input file name>
        *
        */
-      string input_filename;
+      std::string input_filename;
 
       if (argc != 2) {
          TBOX_ERROR("USAGE:  " << argv[0] << " <input file> \n"
                                << "  options:\n"
-                               << "  none at this time" << endl);
+                               << "  none at this time" << std::endl);
       } else {
          input_filename = argv[1];
       }
@@ -255,10 +254,10 @@ int main(
 
       const tbox::Dimension dim(static_cast<unsigned short>(main_db->getInteger("dim")));
 
-      const string base_name =
+      const std::string base_name =
          main_db->getStringWithDefault("base_name", "component_test");
 
-      string log_file_name = base_name + ".log";
+      std::string log_file_name = base_name + ".log";
       bool log_all_nodes = false;
       if (main_db->keyExists("log_all_nodes")) {
          log_all_nodes = main_db->getBool("log_all_nodes");
@@ -282,24 +281,24 @@ int main(
          ntimes_run = main_db->getInteger("ntimes_run");
       }
 
-      string test_to_run;
+      std::string test_to_run;
       if (main_db->keyExists("test_to_run")) {
          test_to_run = main_db->getString("test_to_run");
       } else {
-         TBOX_ERROR("Error in Main input: no test specified." << endl);
+         TBOX_ERROR("Error in Main input: no test specified." << std::endl);
       }
 
       bool do_refine = false;
       bool do_coarsen = false;
-      string refine_option = "INTERIOR_FROM_SAME_LEVEL";
+      std::string refine_option = "INTERIOR_FROM_SAME_LEVEL";
       if (main_db->keyExists("do_refine")) {
          do_refine = main_db->getBool("do_refine");
          if (do_refine) {
-            tbox::plog << "\nPerforming refine data test..." << endl;
+            tbox::plog << "\nPerforming refine data test..." << std::endl;
             if (main_db->keyExists("refine_option")) {
                refine_option = main_db->getString("refine_option");
             }
-            tbox::plog << "\nRefine data option = " << refine_option << endl;
+            tbox::plog << "\nRefine data option = " << refine_option << std::endl;
 
          }
       }
@@ -309,7 +308,7 @@ int main(
             do_coarsen = main_db->getBool("do_coarsen");
          }
          if (do_coarsen) {
-            tbox::plog << "\nPerforming coarsen data test..." << endl;
+            tbox::plog << "\nPerforming coarsen data test..." << std::endl;
          }
       }
 
@@ -377,10 +376,10 @@ int main(
                do_coarsen,
                refine_option);
       } else if (test_to_run == "MultiVariableDataTest") {
-         TBOX_ERROR("Error in Main input: no multi-variable test yet." << endl);
+         TBOX_ERROR("Error in Main input: no multi-variable test yet." << std::endl);
       } else {
          TBOX_ERROR(
-            "Error in Main input: illegal test = " << test_to_run << endl);
+            "Error in Main input: illegal test = " << test_to_run << std::endl);
       }
 
       std::shared_ptr<CommTester> comm_tester(
@@ -401,12 +400,12 @@ int main(
 
       comm_tester->setupHierarchy(input_db, cell_tagger);
 
-      tbox::plog << "Specified input file is: " << input_filename << endl;
+      tbox::plog << "Specified input file is: " << input_filename << std::endl;
 
-      tbox::plog << "\nInput file data is ...." << endl;
+      tbox::plog << "\nInput file data is ...." << std::endl;
       input_db->printClassData(tbox::plog);
 
-      tbox::plog << "\nCheck hier::Variable database..." << endl;
+      tbox::plog << "\nCheck hier::Variable database..." << std::endl;
       hier::VariableDatabase::getDatabase()->printClassData(tbox::plog);
 
       tbox::TimerManager* time_man = tbox::TimerManager::getManager();
@@ -644,11 +643,11 @@ int main(
 
       tbox::TimerManager::getManager()->print(tbox::plog);
 
-      tbox::plog << "\nInput file data at end of run is ...." << endl;
+      tbox::plog << "\nInput file data at end of run is ...." << std::endl;
       input_db->printClassData(tbox::plog);
 
       if (test1_passed && test2_passed && composite_test_passed) {
-         tbox::pout << "\nPASSED:  communication" << endl;
+         tbox::pout << "\nPASSED:  communication" << std::endl;
          return_val = 0;
       }
    }

--- a/source/test/dataaccess/main.C
+++ b/source/test/dataaccess/main.C
@@ -23,7 +23,6 @@
 
 #include <stdlib.h>
 
-using namespace std;
 using namespace SAMRAI;
 
 int main(
@@ -45,10 +44,10 @@ int main(
       /*
        * Process command line arguments.
        */
-      string input_filename;
+      std::string input_filename;
 
       if (argc != 2) {
-         tbox::pout << "USAGE:  " << argv[0] << " <input filename> " << endl;
+         tbox::pout << "USAGE:  " << argv[0] << " <input filename> " << std::endl;
          exit(-1);
       } else {
          input_filename = argv[1];

--- a/source/test/dataops/cell_patchtest.C
+++ b/source/test/dataops/cell_patchtest.C
@@ -11,14 +11,12 @@
 #include "SAMRAI/SAMRAI_config.h"
 
 #include <typeinfo>
-// using namespace std;
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <fstream>
 #include <iomanip>
 #include <memory>
-// using namespace std;
 
 #include "SAMRAI/tbox/SAMRAI_MPI.h"
 #include "SAMRAI/tbox/PIO.h"
@@ -51,7 +49,6 @@
 
 #include <cmath>
 
-// using namespace std;
 using namespace SAMRAI;
 
 /* Helper function declarations */

--- a/source/test/dataops/edge_hiertest.C
+++ b/source/test/dataops/edge_hiertest.C
@@ -15,7 +15,6 @@
 #include <fstream>
 #include <iomanip>
 #include <memory>
-// using namespace std;
 
 #include "SAMRAI/tbox/SAMRAI_MPI.h"
 #include "SAMRAI/tbox/PIO.h"

--- a/source/test/dataops/face_cplxtest.C
+++ b/source/test/dataops/face_cplxtest.C
@@ -15,7 +15,6 @@
 #include <fstream>
 #include <iomanip>
 #include <memory>
-using namespace std;
 
 #include "SAMRAI/tbox/SAMRAI_MPI.h"
 #include "SAMRAI/tbox/PIO.h"

--- a/source/test/dataops/face_hiertest.C
+++ b/source/test/dataops/face_hiertest.C
@@ -15,7 +15,6 @@
 #include <fstream>
 #include <iomanip>
 #include <memory>
-using namespace std;
 
 #include "SAMRAI/tbox/SAMRAI_MPI.h"
 #include "SAMRAI/tbox/PIO.h"

--- a/source/test/dataops/node_cplxtest.C
+++ b/source/test/dataops/node_cplxtest.C
@@ -15,7 +15,6 @@
 #include <fstream>
 #include <iomanip>
 #include <memory>
-using namespace std;
 
 #include "SAMRAI/tbox/SAMRAI_MPI.h"
 #include "SAMRAI/tbox/PIO.h"

--- a/source/test/dataops/node_hiertest.C
+++ b/source/test/dataops/node_hiertest.C
@@ -15,7 +15,6 @@
 #include <fstream>
 #include <iomanip>
 #include <memory>
-using namespace std;
 
 #include "SAMRAI/tbox/SAMRAI_MPI.h"
 #include "SAMRAI/tbox/PIO.h"

--- a/source/test/dataops/side_cplxtest.C
+++ b/source/test/dataops/side_cplxtest.C
@@ -15,7 +15,6 @@
 #include <fstream>
 #include <iomanip>
 #include <memory>
-using namespace std;
 
 #include "SAMRAI/tbox/SAMRAI_MPI.h"
 #include "SAMRAI/tbox/PIO.h"

--- a/source/test/dataops/side_hiertest.C
+++ b/source/test/dataops/side_hiertest.C
@@ -16,7 +16,6 @@
 #include <fstream>
 #include <iomanip>
 #include <memory>
-using namespace std;
 
 #include "SAMRAI/tbox/SAMRAI_MPI.h"
 #include "SAMRAI/tbox/PIO.h"

--- a/source/test/dimension/main.C
+++ b/source/test/dimension/main.C
@@ -19,7 +19,6 @@
 #include <string>
 #include <cassert>
 
-using namespace std;
 
 using namespace SAMRAI;
 

--- a/source/test/dlbg/DLBGTest.C
+++ b/source/test/dlbg/DLBGTest.C
@@ -23,7 +23,6 @@
 
 using namespace SAMRAI;
 
-// using namespace std;
 
 DLBGTest::DLBGTest(
    const std::string& object_name,

--- a/source/test/fill_pattern/main-fill-pattern.C
+++ b/source/test/fill_pattern/main-fill-pattern.C
@@ -28,7 +28,6 @@
 #include <cstring>
 #include <stdlib.h>
 
-using namespace std;
 using namespace SAMRAI;
 
 /*
@@ -60,7 +59,7 @@ void txt2boxes(
       }
    }
    if (-1 == width) {
-      cout << "error in box txt" << endl;
+      std::cout << "error in box txt" << std::endl;
       exit(1);
    }
 
@@ -71,25 +70,25 @@ void txt2boxes(
    int cell_max = cell_height - 1;
 
    // make vector of x locations
-   vector<pair<int, int> > ix;
+   std::vector<std::pair<int, int> > ix;
    for (unsigned int idx = 0; idx < strlen(txt); ++idx) {
       if ('x' == txt[idx]) {
          int j = idx / width;
          int i = idx - j * width;
-         ix.push_back(pair<int, int>(i, j));
+         ix.push_back(std::pair<int, int>(i, j));
       }
    }
 
    // foreach x1 in x
-   vector<pair<int, int> >::iterator it;
+   std::vector<std::pair<int, int> >::iterator it;
    for (it = ix.begin(); it != ix.end(); ++it) {
 
-      vector<pair<int, int> >::iterator it2;
+      std::vector<std::pair<int, int> >::iterator it2;
 
       // We need to gather all potential boxes rooted here, and then
       // only take the smallest one.
 
-      vector<hier::Box> boxes_here;
+      std::vector<hier::Box> boxes_here;
       boxes_here.clear();
 
       for (it2 = ix.begin(); it2 != ix.end(); ++it2) {
@@ -153,7 +152,7 @@ void txt2boxes(
 
          hier::Box smallest_box(boxes_here[0]);
 
-         for (vector<hier::Box>::iterator itb = boxes_here.begin();
+         for (std::vector<hier::Box>::iterator itb = boxes_here.begin();
               itb != boxes_here.end(); ++itb) {
             if ((*itb).numberCells() < smallest_box.numberCells()) {
                smallest_box = *itb;
@@ -184,7 +183,7 @@ int txt_width(
       }
    }
    if (-1 == width) {
-      cout << "error in box txt" << endl;
+      std::cout << "error in box txt" << std::endl;
       exit(1);
    }
    return width;
@@ -264,7 +263,7 @@ bool txt_next_val(
       // Check for non-zero zone data
       if (' ' != txt[txt_zone_idx]) {
 
-         istringstream valstr(&txt[txt_zone_idx]);
+         std::istringstream valstr(&txt[txt_zone_idx]);
          valstr >> *datapt;
          return true;
       }
@@ -281,7 +280,7 @@ bool txt_next_val(
           '8' == txt[txt_node_idx] ||
           '9' == txt[txt_node_idx]) {
 
-         istringstream valstr(&txt[txt_node_idx]);
+         std::istringstream valstr(&txt[txt_node_idx]);
          valstr >> *datapt;
          return true;
       }
@@ -290,9 +289,9 @@ bool txt_next_val(
 
    } while (cnt++ < cnt_max);
 
-   cout << "Data reading loop exceeded maximum iterations"
+   std::cout << "Data reading loop exceeded maximum iterations"
         << __LINE__ << " in "
-        << __FILE__ << endl;
+        << __FILE__ << std::endl;
 
    exit(1);
    return false;
@@ -505,7 +504,7 @@ bool SingleLevelTestCase(
    }
 
    if (failed) {
-      tbox::perr << "FAILED: - Test of " << pattern_name << endl;
+      tbox::perr << "FAILED: - Test of " << pattern_name << std::endl;
    }
 
    return failed;
@@ -1551,7 +1550,7 @@ int main(
    failures += Test_SecondLayerNodeVariableFillPattern();
 
    if (failures == 0) {
-      tbox::pout << "\nPASSED:  fill_pattern" << endl;
+      tbox::pout << "\nPASSED:  fill_pattern" << std::endl;
    }
 
    tbox::SAMRAIManager::shutdown();

--- a/source/test/hierarchy/main.C
+++ b/source/test/hierarchy/main.C
@@ -17,7 +17,6 @@
 #include "SAMRAI/tbox/SAMRAI_MPI.h"
 #include "SAMRAI/tbox/PIO.h"
 #include <string>
-// using namespace std;
 #include "SAMRAI/hier/VariableDatabase.h"
 
 #include "HierarchyTester.h"

--- a/source/test/hypre/HyprePoisson.C
+++ b/source/test/hypre/HyprePoisson.C
@@ -52,7 +52,7 @@ namespace SAMRAI {
  *************************************************************************
  */
 HyprePoisson::HyprePoisson(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<solv::CellPoissonHypreSolver>& hypre_solver,
    std::shared_ptr<solv::LocationIndexRobinBcCoefs>& bc_coefs):

--- a/source/test/hypre/HyprePoisson.h
+++ b/source/test/hypre/HyprePoisson.h
@@ -44,7 +44,6 @@
 
 #include <memory>
 
-using namespace std;
 
 namespace SAMRAI {
 
@@ -90,7 +89,7 @@ public:
     * @param database
     */
    HyprePoisson(
-      const string& object_name,
+      const std::string& object_name,
       const tbox::Dimension& dim,
       std::shared_ptr<solv::CellPoissonHypreSolver>& hypre_solver,
       std::shared_ptr<solv::LocationIndexRobinBcCoefs>& bc_coefs);

--- a/source/test/hypre/main.C
+++ b/source/test/hypre/main.C
@@ -11,7 +11,6 @@
 
 #include <string>
 #include <memory>
-using namespace std;
 
 #include "SAMRAI/mesh/BergerRigoutsos.h"
 #include "SAMRAI/geom/CartesianGridGeometry.h"
@@ -81,7 +80,7 @@ int main(
       tbox::pout << "This example requires the package HYPRE"
                  << "\nto work properly.  SAMRAI was not configured"
                  << "\nwith this package."
-                 << endl;
+                 << std::endl;
 #else
 
       /*
@@ -91,12 +90,12 @@ int main(
        *    executable <input file name>
        *
        */
-      string input_filename;
+      std::string input_filename;
 
       if (argc != 2) {
          TBOX_ERROR("USAGE:  " << argv[0] << " <input file> \n"
                                << "  options:\n"
-                               << "  none at this time" << endl);
+                               << "  none at this time" << std::endl);
       } else {
          input_filename = argv[1];
       }
@@ -121,13 +120,13 @@ int main(
 
       const tbox::Dimension dim(static_cast<unsigned short>(main_db->getInteger("dim")));
 
-      string base_name = "unnamed";
+      std::string base_name = "unnamed";
       base_name = main_db->getStringWithDefault("base_name", base_name);
 
       /*
        * Start logging.
        */
-      const string log_file_name = base_name + ".log";
+      const std::string log_file_name = base_name + ".log";
       bool log_all_nodes = false;
       log_all_nodes = main_db->getBoolWithDefault("log_all_nodes",
             log_all_nodes);
@@ -150,7 +149,7 @@ int main(
             dim,
             base_name + "CartesianGeometry",
             input_db->getDatabase("CartesianGeometry")));
-      tbox::plog << "Cartesian Geometry:" << endl;
+      tbox::plog << "Cartesian Geometry:" << std::endl;
       grid_geometry->printClassData(tbox::plog);
 
       std::shared_ptr<hier::PatchHierarchy> patch_hierarchy(
@@ -225,7 +224,7 @@ int main(
             tag_and_initializer,
             box_generator,
             load_balancer));
-      tbox::plog << "Gridding algorithm:" << endl;
+      tbox::plog << "Gridding algorithm:" << std::endl;
       gridding_algorithm->printClassData(tbox::plog);
 
       /*
@@ -240,7 +239,7 @@ int main(
        * with the plotter.
        */
 #ifdef HAVE_HDF5
-      string vis_filename =
+      std::string vis_filename =
          main_db->getStringWithDefault("vis_filename", base_name);
       std::shared_ptr<appu::VisItDataWriter> visit_writer(
          std::make_shared<appu::VisItDataWriter>(dim,
@@ -255,8 +254,8 @@ int main(
        * to the log file.
        */
       tbox::plog << "\nCheck input data and variables before simulation:"
-                 << endl;
-      tbox::plog << "Input database..." << endl;
+                 << std::endl;
+      tbox::plog << "Input database..." << std::endl;
       input_db->printClassData(tbox::plog);
 
       /*
@@ -281,7 +280,7 @@ int main(
 
 #ifdef TESTING
       if (converged) {
-         tbox::pout << "\nPASSED:  hypre" << endl;
+         tbox::pout << "\nPASSED:  hypre" << std::endl;
       } else {
          TBOX_WARNING("Hypre test did not converge.");
       }

--- a/source/test/indexdata/main.C
+++ b/source/test/indexdata/main.C
@@ -31,7 +31,6 @@ using namespace hier;
 using namespace pdat;
 using namespace tbox;
 
-using namespace std;
 
 #define NN 10
 
@@ -554,7 +553,7 @@ int main(
             tbox::TimerManager::getManager()->
             getTimer("IndexDataAppendItemSequential", true));
 
-         tbox::plog << "Begin Timing" << endl;
+         tbox::plog << "Begin Timing" << std::endl;
 
          Index lo = Index(dim, 0);
          Index hi = Index(dim, size);
@@ -578,14 +577,14 @@ int main(
          size_t numberOfItems = idx_data.getNumberOfItems();
          timer->stop();
 
-         tbox::plog << numberOfItems << endl;
+         tbox::plog << numberOfItems << std::endl;
 
          tbox::plog.precision(16);
 
          tbox::plog << "IndexData appendItem Sequential insert time : "
-                    << timer->getTotalWallclockTime() << endl;
+                    << timer->getTotalWallclockTime() << std::endl;
 
-         tbox::plog << "End Timing" << endl;
+         tbox::plog << "End Timing" << std::endl;
       }
 
       {
@@ -593,7 +592,7 @@ int main(
             tbox::TimerManager::getManager()->
             getTimer("IndexDataAppendItemPointerSequential", true));
 
-         tbox::plog << "Begin Timing" << endl;
+         tbox::plog << "Begin Timing" << std::endl;
 
          Index lo = Index(dim, 0);
          Index hi = Index(dim, size);
@@ -619,9 +618,9 @@ int main(
          tbox::plog.precision(16);
 
          tbox::plog << "IndexData appendItemPointer sequential insert time : "
-                    << timer->getTotalWallclockTime() << endl;
+                    << timer->getTotalWallclockTime() << std::endl;
 
-         tbox::plog << "End Timing" << endl;
+         tbox::plog << "End Timing" << std::endl;
       }
 
       size = 100;
@@ -632,7 +631,7 @@ int main(
             tbox::TimerManager::getManager()->
             getTimer("IndexDataAppendItemRandom", true));
 
-         tbox::plog << "Begin Timing" << endl;
+         tbox::plog << "Begin Timing" << std::endl;
 
          Index lo = Index(dim, 0);
          Index hi = Index(dim, size);
@@ -657,14 +656,14 @@ int main(
          size_t numberOfItems = idx_data.getNumberOfItems();
          timer->stop();
 
-         tbox::plog << numberOfItems << endl;
+         tbox::plog << numberOfItems << std::endl;
 
          tbox::plog.precision(16);
 
          tbox::plog << "IndexData appendItem random insert time : "
-                    << timer->getTotalWallclockTime() << endl;
+                    << timer->getTotalWallclockTime() << std::endl;
 
-         tbox::plog << "End Timing" << endl;
+         tbox::plog << "End Timing" << std::endl;
       }
 
       {
@@ -672,7 +671,7 @@ int main(
             tbox::TimerManager::getManager()->
             getTimer("IndexDataAppendItemPointerRandom", true));
 
-         tbox::plog << "Begin Timing" << endl;
+         tbox::plog << "Begin Timing" << std::endl;
 
          Index lo = Index(dim, 0);
          Index hi = Index(dim, size);
@@ -699,9 +698,9 @@ int main(
          tbox::plog.precision(16);
 
          tbox::plog << "IndexData appendItemPointer random insert time : "
-                    << timer->getTotalWallclockTime() << endl;
+                    << timer->getTotalWallclockTime() << std::endl;
 
-         tbox::plog << "End Timing" << endl;
+         tbox::plog << "End Timing" << std::endl;
       }
 
       size = 100;
@@ -711,7 +710,7 @@ int main(
             tbox::TimerManager::getManager()->
             getTimer("IndexDataReplace", true));
 
-         tbox::plog << "Begin Timing" << endl;
+         tbox::plog << "Begin Timing" << std::endl;
 
          Index lo = Index(dim, 0);
          Index hi = Index(dim, size);
@@ -738,13 +737,13 @@ int main(
          tbox::plog.precision(16);
 
          tbox::plog << "IndexData replaceAddItemPointer random insert time : "
-                    << timer->getTotalWallclockTime() << endl;
+                    << timer->getTotalWallclockTime() << std::endl;
 
-         tbox::plog << "End Timing" << endl;
+         tbox::plog << "End Timing" << std::endl;
       }
    }
 
-   tbox::pout << "PASSED" << endl;
+   tbox::pout << "PASSED" << std::endl;
 
    SAMRAIManager::shutdown();
    SAMRAIManager::finalize();

--- a/source/test/inputdb/inputdb.C
+++ b/source/test/inputdb/inputdb.C
@@ -27,7 +27,6 @@
 #include <memory>
 
 using namespace SAMRAI;
-using namespace std;
 
 int main(
    int argc,
@@ -101,11 +100,11 @@ int main(
       }
       if (!tbox::MathUtilities<float>::equalEps(f0, f0_correct)) {
          ++fail_count;
-         tbox::perr << "Float test #0 FAILED" << endl;
+         tbox::perr << "Float test #0 FAILED" << std::endl;
       }
       if (!tbox::MathUtilities<double>::equalEps(d0, d0_correct)) {
          ++fail_count;
-         tbox::perr << "Double test #0 FAILED" << endl;
+         tbox::perr << "Double test #0 FAILED" << std::endl;
       }
       if (b0 != b0_correct) {
          ++fail_count;
@@ -169,11 +168,11 @@ int main(
          }
          if (!tbox::MathUtilities<float>::equalEps(f1[i], f1_correct[i])) {
             ++fail_count;
-            tbox::perr << "Float test #1 FAILED" << endl;
+            tbox::perr << "Float test #1 FAILED" << std::endl;
          }
          if (!tbox::MathUtilities<double>::equalEps(d1[i], d1_correct[i])) {
             ++fail_count;
-            tbox::perr << "Double test #1 FAILED" << endl;
+            tbox::perr << "Double test #1 FAILED" << std::endl;
          }
          if (b1[i] != b1_correct[i]) {
             ++fail_count;
@@ -238,11 +237,11 @@ int main(
          }
          if (!tbox::MathUtilities<float>::equalEps(f2[i], f2_correct[i])) {
             ++fail_count;
-            tbox::perr << "Float test #2 FAILED" << endl;
+            tbox::perr << "Float test #2 FAILED" << std::endl;
          }
          if (!tbox::MathUtilities<double>::equalEps(d2[i], d2_correct[i])) {
             ++fail_count;
-            tbox::perr << "Double test #2 FAILED" << endl;
+            tbox::perr << "Double test #2 FAILED" << std::endl;
          }
          if (b2[i] != b2_correct[i]) {
             ++fail_count;
@@ -284,11 +283,11 @@ int main(
       }
       if (!tbox::MathUtilities<float>::equalEps(f3, f0_correct)) {
          ++fail_count;
-         tbox::perr << "Float test #3 FAILED" << endl;
+         tbox::perr << "Float test #3 FAILED" << std::endl;
       }
       if (!tbox::MathUtilities<double>::equalEps(d3, d0_correct)) {
          ++fail_count;
-         tbox::perr << "Double test #3 FAILED" << endl;
+         tbox::perr << "Double test #3 FAILED" << std::endl;
       }
       if (b3 != b0_correct) {
          ++fail_count;
@@ -337,7 +336,7 @@ int main(
    }
 
    if (fail_count == 0) {
-      tbox::pout << "\nPASSED:  inputdb" << endl;
+      tbox::pout << "\nPASSED:  inputdb" << std::endl;
    }
 
    tbox::SAMRAIManager::shutdown();

--- a/source/test/logger/defaultloggertest.C
+++ b/source/test/logger/defaultloggertest.C
@@ -17,7 +17,6 @@
 #include "SAMRAI/tbox/Logger.h"
 
 #include <string>
-using namespace std;
 
 using namespace SAMRAI;
 

--- a/source/test/logger/userloggertest.C
+++ b/source/test/logger/userloggertest.C
@@ -12,7 +12,6 @@
 
 #include <string>
 #include <iostream>
-using namespace std;
 
 #include "SAMRAI/tbox/SAMRAI_MPI.h"
 #include "SAMRAI/tbox/SAMRAIManager.h"
@@ -29,7 +28,7 @@ class StreamAppender:public tbox::Logger::Appender
 
 public:
    StreamAppender(
-      ostream* stream) {
+      std::ostream* stream) {
       d_stream = stream;
    }
 
@@ -43,7 +42,7 @@ public:
    }
 
 private:
-   ostream* d_stream;
+   std::ostream* d_stream;
 };
 
 int main(
@@ -62,7 +61,7 @@ int main(
     */
    {
 
-      fstream file("user.log", fstream::out);
+      std::fstream file("user.log", std::fstream::out);
 
       std::shared_ptr<tbox::Logger::Appender> appender(
          new StreamAppender(&file));

--- a/source/test/mapped_box_set_iterators/main-iterators.C
+++ b/source/test/mapped_box_set_iterators/main-iterators.C
@@ -18,7 +18,6 @@
 #include "SAMRAI/tbox/SAMRAI_MPI.h"
 #include "SAMRAI/tbox/PIO.h"
 
-using namespace std;
 using namespace SAMRAI;
 
 int main(
@@ -74,7 +73,7 @@ int main(
 
             if (bi->getBlockId() != bid) {
                tbox::perr << "FAILED: - Test #1: box id " << bi->getBlockId()
-                          << " should have BlockId " << bid << endl;
+                          << " should have BlockId " << bid << std::endl;
                ++fail_count;
             }
 
@@ -90,7 +89,7 @@ int main(
 
             if (bi->getOwnerRank() != owner_rank) {
                tbox::perr << "FAILED: - Test #2: box id " << bi->getBlockId()
-                          << " should have rank " << owner_rank << endl;
+                          << " should have rank " << owner_rank << std::endl;
                ++fail_count;
             }
 
@@ -98,7 +97,7 @@ int main(
       }
 
       if (fail_count == 0) {
-         tbox::pout << "\nPASSED:  testboxcontaineriterator" << endl;
+         tbox::pout << "\nPASSED:  testboxcontaineriterator" << std::endl;
       }
    }
 

--- a/source/test/mblkcomm/CellMultiblockTest.C
+++ b/source/test/mblkcomm/CellMultiblockTest.C
@@ -22,10 +22,10 @@
 using namespace SAMRAI;
 
 CellMultiblockTest::CellMultiblockTest(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> main_input_db,
-   const string& refine_option):
+   const std::string& refine_option):
    PatchMultiblockTestStrategy(dim),
    d_dim(dim)
 {
@@ -367,9 +367,9 @@ bool CellMultiblockTest::verifyResults(
    const hier::BlockId& block_id)
 {
 
-   tbox::plog << "\nEntering CellMultiblockTest::verifyResults..." << endl;
-   tbox::plog << "level_number = " << level_number << endl;
-   tbox::plog << "Patch box = " << patch.getBox() << endl;
+   tbox::plog << "\nEntering CellMultiblockTest::verifyResults..." << std::endl;
+   tbox::plog << "level_number = " << level_number << std::endl;
+   tbox::plog << "Patch box = " << patch.getBox() << std::endl;
 
    hier::IntVector tgcw(d_dim, 0);
    for (int i = 0; i < static_cast<int>(d_variables.size()); ++i) {
@@ -414,11 +414,11 @@ bool CellMultiblockTest::verifyResults(
 
             if (!tbox::MathUtilities<double>::equalEps(correct, result)) {
                tbox::perr << "Test FAILED: ...."
-                          << " : cell index = " << *ci << endl;
+                          << " : cell index = " << *ci << std::endl;
                tbox::perr << "    Variable = " << d_variable_src_name[i]
-                          << " : depth index = " << d << endl;
+                          << " : depth index = " << d << std::endl;
                tbox::perr << "    result = " << result
-                          << " : correct = " << correct << endl;
+                          << " : correct = " << correct << std::endl;
                test_failed = true;
             }
          }
@@ -453,11 +453,11 @@ bool CellMultiblockTest::verifyResults(
                   if (!tbox::MathUtilities<double>::equalEps(correct,
                          result)) {
                      tbox::perr << "Test FAILED: ...."
-                                << " : cell index = " << *ci << endl;
+                                << " : cell index = " << *ci << std::endl;
                      tbox::perr << "    Variable = " << d_variable_src_name[i]
-                                << " : depth index = " << d << endl;
+                                << " : depth index = " << d << std::endl;
                      tbox::perr << "    result = " << result
-                                << " : correct = " << correct << endl;
+                                << " : correct = " << correct << std::endl;
                      test_failed = true;
                   }
                }
@@ -521,11 +521,11 @@ bool CellMultiblockTest::verifyResults(
                   if (!tbox::MathUtilities<double>::equalEps(correct,
                          result)) {
                      tbox::perr << "Test FAILED: ...."
-                                << " : cell index = " << *ci << endl;
+                                << " : cell index = " << *ci << std::endl;
                      tbox::perr << "    Variable = " << d_variable_src_name[i]
-                                << " : depth index = " << d << endl;
+                                << " : depth index = " << d << std::endl;
                      tbox::perr << "    result = " << result
-                                << " : correct = " << correct << endl;
+                                << " : correct = " << correct << std::endl;
                      test_failed = true;
                   }
                }
@@ -537,16 +537,16 @@ bool CellMultiblockTest::verifyResults(
    }
 
    if (!test_failed) {
-      tbox::plog << "CellMultiblockTest Successful!" << endl;
+      tbox::plog << "CellMultiblockTest Successful!" << std::endl;
    } else {
-      tbox::perr << "Multiblock CellMultiblockTest FAILED: \n" << endl;
+      tbox::perr << "Multiblock CellMultiblockTest FAILED: \n" << std::endl;
    }
 
    solution.reset();   // just to be anal...
 
-   tbox::plog << "\nExiting CellMultiblockTest::verifyResults..." << endl;
-   tbox::plog << "level_number = " << level_number << endl;
-   tbox::plog << "Patch box = " << patch.getBox() << endl << endl;
+   tbox::plog << "\nExiting CellMultiblockTest::verifyResults..." << std::endl;
+   tbox::plog << "level_number = " << level_number << std::endl;
+   tbox::plog << "Patch box = " << patch.getBox() << std::endl << std::endl;
 
    return !test_failed;
 }

--- a/source/test/mblkcomm/CellMultiblockTest.h
+++ b/source/test/mblkcomm/CellMultiblockTest.h
@@ -32,10 +32,10 @@ public:
     * The constructor initializes variable data arrays to zero length.
     */
    CellMultiblockTest(
-      const string& object_name,
+      const std::string& object_name,
       const tbox::Dimension& dim,
       std::shared_ptr<tbox::Database> main_input_db,
-      const string& refine_option);
+      const std::string& refine_option);
 
    /**
     * Virtual destructor for CellMultiblockTest.
@@ -117,7 +117,7 @@ private:
    /*
     * Object string identifier for error reporting
     */
-   string d_object_name;
+   std::string d_object_name;
 
    const tbox::Dimension d_dim;
 
@@ -126,7 +126,7 @@ private:
     */
 //   std::vector<std::shared_ptr<hier::BaseGridGeometry> > d_skel_grid_geometry;
 
-   string d_refine_option;
+   std::string d_refine_option;
    int d_finest_level_number;
 
    std::vector<std::shared_ptr<hier::Variable> > d_variables;

--- a/source/test/mblkcomm/EdgeMultiblockTest.C
+++ b/source/test/mblkcomm/EdgeMultiblockTest.C
@@ -22,10 +22,10 @@
 using namespace SAMRAI;
 
 EdgeMultiblockTest::EdgeMultiblockTest(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> main_input_db,
-   const string& refine_option):
+   const std::string& refine_option):
    PatchMultiblockTestStrategy(dim),
    d_dim(dim)
 {
@@ -531,9 +531,9 @@ bool EdgeMultiblockTest::verifyResults(
    const hier::BlockId& block_id)
 {
 
-   tbox::plog << "\nEntering EdgeMultiblockTest::verifyResults..." << endl;
-   tbox::plog << "level_number = " << level_number << endl;
-   tbox::plog << "Patch box = " << patch.getBox() << endl;
+   tbox::plog << "\nEntering EdgeMultiblockTest::verifyResults..." << std::endl;
+   tbox::plog << "level_number = " << level_number << std::endl;
+   tbox::plog << "Patch box = " << patch.getBox() << std::endl;
 
    hier::IntVector tgcw(d_dim, 0);
    for (int i = 0; i < static_cast<int>(d_variables.size()); ++i) {
@@ -583,11 +583,11 @@ bool EdgeMultiblockTest::verifyResults(
 
                if (!tbox::MathUtilities<double>::equalEps(correct, result)) {
                   tbox::perr << "Test FAILED: ...."
-                             << " : edge index = " << *ci << endl;
+                             << " : edge index = " << *ci << std::endl;
                   tbox::perr << "    Variable = " << d_variable_src_name[i]
-                             << " : depth index = " << d << endl;
+                             << " : depth index = " << d << std::endl;
                   tbox::perr << "    result = " << result
-                             << " : correct = " << correct << endl;
+                             << " : correct = " << correct << std::endl;
                   test_failed = true;
                }
             }
@@ -654,12 +654,12 @@ bool EdgeMultiblockTest::verifyResults(
                         if (!tbox::MathUtilities<double>::equalEps(correct,
                                result)) {
                            tbox::perr << "Test FAILED: ...."
-                                      << " : edge index = " << ei << endl;
+                                      << " : edge index = " << ei << std::endl;
                            tbox::perr << "  Variable = "
                                       << d_variable_src_name[i]
-                                      << " : depth index = " << d << endl;
+                                      << " : depth index = " << d << std::endl;
                            tbox::perr << "    result = " << result
-                                      << " : correct = " << correct << endl;
+                                      << " : correct = " << correct << std::endl;
                            test_failed = true;
                         }
                      }
@@ -746,12 +746,12 @@ bool EdgeMultiblockTest::verifyResults(
                            if (!tbox::MathUtilities<double>::equalEps(correct,
                                   result)) {
                               tbox::perr << "Test FAILED: ...."
-                                         << " : edge index = " << *ci << endl;
+                                         << " : edge index = " << *ci << std::endl;
                               tbox::perr << "  Variable = "
                                          << d_variable_src_name[i]
-                                         << " : depth index = " << d << endl;
+                                         << " : depth index = " << d << std::endl;
                               tbox::perr << "    result = " << result
-                                         << " : correct = " << correct << endl;
+                                         << " : correct = " << correct << std::endl;
                               test_failed = true;
                            }
                         }
@@ -764,16 +764,16 @@ bool EdgeMultiblockTest::verifyResults(
    }
 
    if (!test_failed) {
-      tbox::plog << "EdgeMultiblockTest Successful!" << endl;
+      tbox::plog << "EdgeMultiblockTest Successful!" << std::endl;
    } else {
-      tbox::perr << "Multiblock EdgeMultiblockTest FAILED: \n" << endl;
+      tbox::perr << "Multiblock EdgeMultiblockTest FAILED: \n" << std::endl;
    }
 
    solution.reset();   // just to be anal...
 
-   tbox::plog << "\nExiting EdgeMultiblockTest::verifyResults..." << endl;
-   tbox::plog << "level_number = " << level_number << endl;
-   tbox::plog << "Patch box = " << patch.getBox() << endl << endl;
+   tbox::plog << "\nExiting EdgeMultiblockTest::verifyResults..." << std::endl;
+   tbox::plog << "level_number = " << level_number << std::endl;
+   tbox::plog << "Patch box = " << patch.getBox() << std::endl << std::endl;
 
    return !test_failed;
 }

--- a/source/test/mblkcomm/EdgeMultiblockTest.h
+++ b/source/test/mblkcomm/EdgeMultiblockTest.h
@@ -40,10 +40,10 @@ public:
     * The constructor initializes variable data arrays to zero length.
     */
    EdgeMultiblockTest(
-      const string& object_name,
+      const std::string& object_name,
       const tbox::Dimension& dim,
       std::shared_ptr<tbox::Database> main_input_db,
-      const string& refine_option);
+      const std::string& refine_option);
 
    /**
     * Virtual destructor for EdgeMultiblockTest.
@@ -134,11 +134,11 @@ private:
    /*
     * Object string identifier for error reporting
     */
-   string d_object_name;
+   std::string d_object_name;
 
    const tbox::Dimension d_dim;
 
-   string d_refine_option;
+   std::string d_refine_option;
    int d_finest_level_number;
 
    std::vector<std::shared_ptr<hier::Variable> > d_variables;

--- a/source/test/mblkcomm/FaceMultiblockTest.C
+++ b/source/test/mblkcomm/FaceMultiblockTest.C
@@ -23,10 +23,10 @@
 using namespace SAMRAI;
 
 FaceMultiblockTest::FaceMultiblockTest(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> main_input_db,
-   const string& refine_option):
+   const std::string& refine_option):
    PatchMultiblockTestStrategy(dim),
    d_dim(dim)
 {
@@ -533,9 +533,9 @@ bool FaceMultiblockTest::verifyResults(
    const hier::BlockId& block_id)
 {
 
-   tbox::plog << "\nEntering FaceMultiblockTest::verifyResults..." << endl;
-   tbox::plog << "level_number = " << level_number << endl;
-   tbox::plog << "Patch box = " << patch.getBox() << endl;
+   tbox::plog << "\nEntering FaceMultiblockTest::verifyResults..." << std::endl;
+   tbox::plog << "level_number = " << level_number << std::endl;
+   tbox::plog << "Patch box = " << patch.getBox() << std::endl;
 
    hier::IntVector tgcw(d_dim, 0);
    for (int i = 0; i < static_cast<int>(d_variables.size()); ++i) {
@@ -585,11 +585,11 @@ bool FaceMultiblockTest::verifyResults(
 
                if (!tbox::MathUtilities<double>::equalEps(correct, result)) {
                   tbox::perr << "Test FAILED: ...."
-                             << " : face index = " << *ci << endl;
+                             << " : face index = " << *ci << std::endl;
                   tbox::perr << "    Variable = " << d_variable_src_name[i]
-                             << " : depth index = " << d << endl;
+                             << " : depth index = " << d << std::endl;
                   tbox::perr << "    result = " << result
-                             << " : correct = " << correct << endl;
+                             << " : correct = " << correct << std::endl;
                   test_failed = true;
                }
             }
@@ -645,12 +645,12 @@ bool FaceMultiblockTest::verifyResults(
                         if (!tbox::MathUtilities<double>::equalEps(correct,
                                result)) {
                            tbox::perr << "Test FAILED: ...."
-                                      << " : face index = " << fi << endl;
+                                      << " : face index = " << fi << std::endl;
                            tbox::perr << "  Variable = "
                                       << d_variable_src_name[i]
-                                      << " : depth index = " << d << endl;
+                                      << " : depth index = " << d << std::endl;
                            tbox::perr << "    result = " << result
-                                      << " : correct = " << correct << endl;
+                                      << " : correct = " << correct << std::endl;
                            test_failed = true;
                         }
                      }
@@ -736,12 +736,12 @@ bool FaceMultiblockTest::verifyResults(
                            if (!tbox::MathUtilities<double>::equalEps(correct,
                                   result)) {
                               tbox::perr << "Test FAILED: ...."
-                                         << " : face index = " << *ci << endl;
+                                         << " : face index = " << *ci << std::endl;
                               tbox::perr << "  Variable = "
                                          << d_variable_src_name[i]
-                                         << " : depth index = " << d << endl;
+                                         << " : depth index = " << d << std::endl;
                               tbox::perr << "    result = " << result
-                                         << " : correct = " << correct << endl;
+                                         << " : correct = " << correct << std::endl;
                               test_failed = true;
                            }
                         }
@@ -754,16 +754,16 @@ bool FaceMultiblockTest::verifyResults(
    }
 
    if (!test_failed) {
-      tbox::plog << "FaceMultiblockTest Successful!" << endl;
+      tbox::plog << "FaceMultiblockTest Successful!" << std::endl;
    } else {
-      tbox::perr << "Multiblock FaceMultiblockTest FAILED: .\n" << endl;
+      tbox::perr << "Multiblock FaceMultiblockTest FAILED: .\n" << std::endl;
    }
 
    solution.reset();   // just to be anal...
 
-   tbox::plog << "\nExiting FaceMultiblockTest::verifyResults..." << endl;
-   tbox::plog << "level_number = " << level_number << endl;
-   tbox::plog << "Patch box = " << patch.getBox() << endl << endl;
+   tbox::plog << "\nExiting FaceMultiblockTest::verifyResults..." << std::endl;
+   tbox::plog << "level_number = " << level_number << std::endl;
+   tbox::plog << "Patch box = " << patch.getBox() << std::endl << std::endl;
 
    return !test_failed;
 }

--- a/source/test/mblkcomm/FaceMultiblockTest.h
+++ b/source/test/mblkcomm/FaceMultiblockTest.h
@@ -41,10 +41,10 @@ public:
     * The constructor initializes variable data arrays to zero length.
     */
    FaceMultiblockTest(
-      const string& object_name,
+      const std::string& object_name,
       const tbox::Dimension& dim,
       std::shared_ptr<tbox::Database> main_input_db,
-      const string& refine_option);
+      const std::string& refine_option);
 
    /**
     * Virtual destructor for FaceMultiblockTest.
@@ -135,11 +135,11 @@ private:
    /*
     * Object string identifier for error reporting
     */
-   string d_object_name;
+   std::string d_object_name;
 
    const tbox::Dimension d_dim;
 
-   string d_refine_option;
+   std::string d_refine_option;
    int d_finest_level_number;
 
    std::vector<std::shared_ptr<hier::Variable> > d_variables;

--- a/source/test/mblkcomm/MultiblockTester.C
+++ b/source/test/mblkcomm/MultiblockTester.C
@@ -33,12 +33,12 @@ using namespace SAMRAI;
  */
 
 MultiblockTester::MultiblockTester(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database>& main_input_db,
    std::shared_ptr<hier::PatchHierarchy>& hierarchy,
    PatchMultiblockTestStrategy* data_test,
-   const string& refine_option):
+   const std::string& refine_option):
    xfer::RefinePatchStrategy(),
    xfer::SingularityPatchStrategy(),
    d_object_name(object_name),
@@ -71,7 +71,7 @@ MultiblockTester::MultiblockTester(
    if (!((d_refine_option == "INTERIOR_FROM_SAME_LEVEL")
          || (d_refine_option == "INTERIOR_FROM_COARSER_LEVEL"))) {
       TBOX_ERROR(object_name << " input error: illegal refine_option = "
-                             << d_refine_option << endl);
+                             << d_refine_option << std::endl);
    }
 
    d_patch_data_components.clrAllFlags();
@@ -98,7 +98,7 @@ void MultiblockTester::registerVariable(
    const hier::IntVector& src_ghosts,
    const hier::IntVector& dst_ghosts,
    const std::shared_ptr<hier::BaseGridGeometry> xfer_geom,
-   const string& operator_name)
+   const std::string& operator_name)
 {
    TBOX_ASSERT(src_variable);
    TBOX_ASSERT(dst_variable);
@@ -160,7 +160,7 @@ void MultiblockTester::registerVariableForReset(
    const hier::IntVector& src_ghosts,
    const hier::IntVector& dst_ghosts,
    const std::shared_ptr<hier::BaseGridGeometry> xfer_geom,
-   const string& operator_name)
+   const std::string& operator_name)
 {
    TBOX_ASSERT(src_variable);
    TBOX_ASSERT(dst_variable);

--- a/source/test/mblkcomm/MultiblockTester.h
+++ b/source/test/mblkcomm/MultiblockTester.h
@@ -39,7 +39,6 @@
 
 #include <memory>
 
-using namespace std;
 using namespace SAMRAI;
 
 class PatchMultiblockTestStrategy;
@@ -68,12 +67,12 @@ public:
     * Constructor performs basic setup operations.
     */
    MultiblockTester(
-      const string& object_name,
+      const std::string& object_name,
       const tbox::Dimension& dim,
       std::shared_ptr<tbox::Database>& main_input_db,
       std::shared_ptr<hier::PatchHierarchy>& hierarchy,
       PatchMultiblockTestStrategy* strategy,
-      const string& refine_option = "INTERIOR_FROM_SAME_LEVEL");
+      const std::string& refine_option = "INTERIOR_FROM_SAME_LEVEL");
 
    /**
     * Destructor is empty.
@@ -101,7 +100,7 @@ public:
       const hier::IntVector& src_ghosts,
       const hier::IntVector& dst_ghosts,
       const std::shared_ptr<hier::BaseGridGeometry> xfer_geom,
-      const string& operator_name);
+      const std::string& operator_name);
 
    /**
     * Register variable for communication testing.
@@ -115,7 +114,7 @@ public:
       const hier::IntVector& src_ghosts,
       const hier::IntVector& dst_ghosts,
       const std::shared_ptr<hier::BaseGridGeometry> xfer_geom,
-      const string& operator_name);
+      const std::string& operator_name);
 
    /**
     * Create communication schedules for refining data to given level.
@@ -244,7 +243,7 @@ private:
    /*
     * Object name for error reporting.
     */
-   string d_object_name;
+   std::string d_object_name;
 
    const tbox::Dimension d_dim;
 
@@ -258,7 +257,7 @@ private:
     * data on refined patches.  Options are "INTERIOR_FROM_SAME_LEVEL"
     * and "INTERIOR_FROM_COARSER_LEVEL".
     */
-   string d_refine_option;
+   std::string d_refine_option;
 
    /*
     * Patch hierarchy on which tests occur.

--- a/source/test/mblkcomm/NodeMultiblockTest.C
+++ b/source/test/mblkcomm/NodeMultiblockTest.C
@@ -21,10 +21,10 @@
 using namespace SAMRAI;
 
 NodeMultiblockTest::NodeMultiblockTest(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> main_input_db,
-   const string& refine_option):
+   const std::string& refine_option):
    PatchMultiblockTestStrategy(dim),
    d_dim(dim)
 {
@@ -486,9 +486,9 @@ bool NodeMultiblockTest::verifyResults(
    const hier::BlockId& block_id)
 {
 
-   tbox::plog << "\nEntering NodeMultiblockTest::verifyResults..." << endl;
-   tbox::plog << "level_number = " << level_number << endl;
-   tbox::plog << "Patch box = " << patch.getBox() << endl;
+   tbox::plog << "\nEntering NodeMultiblockTest::verifyResults..." << std::endl;
+   tbox::plog << "level_number = " << level_number << std::endl;
+   tbox::plog << "Patch box = " << patch.getBox() << std::endl;
 
    hier::IntVector tgcw(d_dim, 0);
    for (int i = 0; i < static_cast<int>(d_variables.size()); ++i) {
@@ -537,11 +537,11 @@ bool NodeMultiblockTest::verifyResults(
 
             if (!tbox::MathUtilities<double>::equalEps(correct, result)) {
                tbox::perr << "Test FAILED: ...."
-                          << " : node index = " << *ci << endl;
+                          << " : node index = " << *ci << std::endl;
                tbox::perr << "    Variable = " << d_variable_src_name[i]
-                          << " : depth index = " << d << endl;
+                          << " : depth index = " << d << std::endl;
                tbox::perr << "    result = " << result
-                          << " : correct = " << correct << endl;
+                          << " : correct = " << correct << std::endl;
                test_failed = true;
             }
          }
@@ -601,11 +601,11 @@ bool NodeMultiblockTest::verifyResults(
                      if (!tbox::MathUtilities<double>::equalEps(correct,
                             result)) {
                         tbox::perr << "Test FAILED: ...."
-                                   << " : node index = " << ni << endl;
+                                   << " : node index = " << ni << std::endl;
                         tbox::perr << "  Variable = " << d_variable_src_name[i]
-                                   << " : depth index = " << d << endl;
+                                   << " : depth index = " << d << std::endl;
                         tbox::perr << "    result = " << result
-                                   << " : correct = " << correct << endl;
+                                   << " : correct = " << correct << std::endl;
                         test_failed = true;
                      }
                   }
@@ -683,12 +683,12 @@ bool NodeMultiblockTest::verifyResults(
                         if (!tbox::MathUtilities<double>::equalEps(correct,
                                result)) {
                            tbox::perr << "Test FAILED: ...."
-                                      << " : node index = " << *ci << endl;
+                                      << " : node index = " << *ci << std::endl;
                            tbox::perr << "  Variable = "
                                       << d_variable_src_name[i]
-                                      << " : depth index = " << d << endl;
+                                      << " : depth index = " << d << std::endl;
                            tbox::perr << "    result = " << result
-                                      << " : correct = " << correct << endl;
+                                      << " : correct = " << correct << std::endl;
                            test_failed = true;
                         }
                      }
@@ -700,16 +700,16 @@ bool NodeMultiblockTest::verifyResults(
    }
 
    if (!test_failed) {
-      tbox::plog << "NodeMultiblockTest Successful!" << endl;
+      tbox::plog << "NodeMultiblockTest Successful!" << std::endl;
    } else {
-      tbox::perr << "Multiblock NodeMultiblockTest FAILED: .\n" << endl;
+      tbox::perr << "Multiblock NodeMultiblockTest FAILED: .\n" << std::endl;
    }
 
    solution.reset();   // just to be anal...
 
-   tbox::plog << "\nExiting NodeMultiblockTest::verifyResults..." << endl;
-   tbox::plog << "level_number = " << level_number << endl;
-   tbox::plog << "Patch box = " << patch.getBox() << endl << endl;
+   tbox::plog << "\nExiting NodeMultiblockTest::verifyResults..." << std::endl;
+   tbox::plog << "level_number = " << level_number << std::endl;
+   tbox::plog << "Patch box = " << patch.getBox() << std::endl << std::endl;
 
    return !test_failed;
 }

--- a/source/test/mblkcomm/NodeMultiblockTest.h
+++ b/source/test/mblkcomm/NodeMultiblockTest.h
@@ -40,10 +40,10 @@ public:
     * The constructor initializes variable data arrays to zero length.
     */
    NodeMultiblockTest(
-      const string& object_name,
+      const std::string& object_name,
       const tbox::Dimension& dim,
       std::shared_ptr<tbox::Database> main_input_db,
-      const string& refine_option);
+      const std::string& refine_option);
 
    /**
     * Virtual destructor for NodeMultiblockTest.
@@ -125,11 +125,11 @@ private:
    /*
     * Object string identifier for error reporting
     */
-   string d_object_name;
+   std::string d_object_name;
 
    const tbox::Dimension d_dim;
 
-   string d_refine_option;
+   std::string d_refine_option;
    int d_finest_level_number;
 
    std::vector<std::shared_ptr<hier::Variable> > d_variables;

--- a/source/test/mblkcomm/PatchMultiblockTestStrategy.C
+++ b/source/test/mblkcomm/PatchMultiblockTestStrategy.C
@@ -64,7 +64,7 @@ void PatchMultiblockTestStrategy::readVariableInput(
 {
    TBOX_ASSERT(db);
 
-   std::vector<string> var_keys = db->getAllKeys();
+   std::vector<std::string> var_keys = db->getAllKeys();
    int nkeys = static_cast<int>(var_keys.size());
 
    d_variable_src_name.resize(nkeys);
@@ -82,14 +82,14 @@ void PatchMultiblockTestStrategy::readVariableInput(
          d_variable_src_name[i] = var_db->getString("src_name");
       } else {
          TBOX_ERROR("Variable input error: No `src_name' string found for "
-            << "key = " << var_keys[i] << endl);
+            << "key = " << var_keys[i] << std::endl);
       }
 
       if (var_db->keyExists("dst_name")) {
          d_variable_dst_name[i] = var_db->getString("dst_name");
       } else {
          TBOX_ERROR("Variable input error: No `dst_name' string found for "
-            << "key = " << var_keys[i] << endl);
+            << "key = " << var_keys[i] << std::endl);
       }
 
       if (var_db->keyExists("depth")) {
@@ -123,7 +123,7 @@ void PatchMultiblockTestStrategy::readRefinementInput(
 {
    TBOX_ASSERT(db);
 
-   std::vector<string> box_keys = db->getAllKeys();
+   std::vector<std::string> box_keys = db->getAllKeys();
    int nkeys = static_cast<int>(box_keys.size());
 
    d_refine_level_boxes.resize(nkeys);

--- a/source/test/mblkcomm/PatchMultiblockTestStrategy.h
+++ b/source/test/mblkcomm/PatchMultiblockTestStrategy.h
@@ -291,12 +291,12 @@ protected:
    /*
     * Vectors of information read from input file describing test variables
     */
-   std::vector<string> d_variable_src_name;
-   std::vector<string> d_variable_dst_name;
+   std::vector<std::string> d_variable_src_name;
+   std::vector<std::string> d_variable_dst_name;
    std::vector<int> d_variable_depth;
    std::vector<hier::IntVector> d_variable_src_ghosts;
    std::vector<hier::IntVector> d_variable_dst_ghosts;
-   std::vector<string> d_variable_refine_op;
+   std::vector<std::string> d_variable_refine_op;
 
    /*
     * Vectors of information read from input file describing test variables

--- a/source/test/mblkcomm/SideMultiblockTest.C
+++ b/source/test/mblkcomm/SideMultiblockTest.C
@@ -23,10 +23,10 @@
 using namespace SAMRAI;
 
 SideMultiblockTest::SideMultiblockTest(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> main_input_db,
-   const string& refine_option):
+   const std::string& refine_option):
    PatchMultiblockTestStrategy(dim),
    d_dim(dim)
 {
@@ -534,9 +534,9 @@ bool SideMultiblockTest::verifyResults(
    const hier::BlockId& block_id)
 {
 
-   tbox::plog << "\nEntering SideMultiblockTest::verifyResults..." << endl;
-   tbox::plog << "level_number = " << level_number << endl;
-   tbox::plog << "Patch box = " << patch.getBox() << endl;
+   tbox::plog << "\nEntering SideMultiblockTest::verifyResults..." << std::endl;
+   tbox::plog << "level_number = " << level_number << std::endl;
+   tbox::plog << "Patch box = " << patch.getBox() << std::endl;
 
    hier::IntVector tgcw(d_dim, 0);
    for (int i = 0; i < static_cast<int>(d_variables.size()); ++i) {
@@ -586,11 +586,11 @@ bool SideMultiblockTest::verifyResults(
 
                if (!tbox::MathUtilities<double>::equalEps(correct, result)) {
                   tbox::perr << "Test FAILED: ...."
-                             << " : side index = " << *ci << endl;
+                             << " : side index = " << *ci << std::endl;
                   tbox::perr << "    Variable = " << d_variable_src_name[i]
-                             << " : depth index = " << d << endl;
+                             << " : depth index = " << d << std::endl;
                   tbox::perr << "    result = " << result
-                             << " : correct = " << correct << endl;
+                             << " : correct = " << correct << std::endl;
                   test_failed = true;
                }
             }
@@ -646,12 +646,12 @@ bool SideMultiblockTest::verifyResults(
                         if (!tbox::MathUtilities<double>::equalEps(correct,
                                result)) {
                            tbox::perr << "Test FAILED: ...."
-                                      << " : side index = " << si << endl;
+                                      << " : side index = " << si << std::endl;
                            tbox::perr << "  Variable = "
                                       << d_variable_src_name[i]
-                                      << " : depth index = " << d << endl;
+                                      << " : depth index = " << d << std::endl;
                            tbox::perr << "    result = " << result
-                                      << " : correct = " << correct << endl;
+                                      << " : correct = " << correct << std::endl;
                            test_failed = true;
                         }
                      }
@@ -737,12 +737,12 @@ bool SideMultiblockTest::verifyResults(
                            if (!tbox::MathUtilities<double>::equalEps(correct,
                                   result)) {
                               tbox::perr << "Test FAILED: ...."
-                                         << " : side index = " << *ci << endl;
+                                         << " : side index = " << *ci << std::endl;
                               tbox::perr << "  Variable = "
                                          << d_variable_src_name[i]
-                                         << " : depth index = " << d << endl;
+                                         << " : depth index = " << d << std::endl;
                               tbox::perr << "    result = " << result
-                                         << " : correct = " << correct << endl;
+                                         << " : correct = " << correct << std::endl;
                               test_failed = true;
                            }
                         }
@@ -755,16 +755,16 @@ bool SideMultiblockTest::verifyResults(
    }
 
    if (!test_failed) {
-      tbox::plog << "SideMultiblockTest Successful!" << endl;
+      tbox::plog << "SideMultiblockTest Successful!" << std::endl;
    } else {
-      tbox::perr << "Multiblock SideMultiblockTest FAILED: .\n" << endl;
+      tbox::perr << "Multiblock SideMultiblockTest FAILED: .\n" << std::endl;
    }
 
    solution.reset();   // just to be anal...
 
-   tbox::plog << "\nExiting SideMultiblockTest::verifyResults..." << endl;
-   tbox::plog << "level_number = " << level_number << endl;
-   tbox::plog << "Patch box = " << patch.getBox() << endl << endl;
+   tbox::plog << "\nExiting SideMultiblockTest::verifyResults..." << std::endl;
+   tbox::plog << "level_number = " << level_number << std::endl;
+   tbox::plog << "Patch box = " << patch.getBox() << std::endl << std::endl;
 
    return !test_failed;
 }

--- a/source/test/mblkcomm/SideMultiblockTest.h
+++ b/source/test/mblkcomm/SideMultiblockTest.h
@@ -32,10 +32,10 @@ public:
     * The constructor initializes variable data arrays to zero length.
     */
    SideMultiblockTest(
-      const string& object_name,
+      const std::string& object_name,
       const tbox::Dimension& dim,
       std::shared_ptr<tbox::Database> main_input_db,
-      const string& refine_option);
+      const std::string& refine_option);
 
    /**
     * Virtual destructor for SideMultiblockTest.
@@ -126,11 +126,11 @@ private:
    /*
     * Object string identifier for error reporting
     */
-   string d_object_name;
+   std::string d_object_name;
 
    const tbox::Dimension d_dim;
 
-   string d_refine_option;
+   std::string d_refine_option;
    int d_finest_level_number;
 
    std::vector<std::shared_ptr<hier::Variable> > d_variables;

--- a/source/test/mblkcomm/main.C
+++ b/source/test/mblkcomm/main.C
@@ -181,12 +181,12 @@ int main(
        *    executable <input file name>
        *
        */
-      string input_filename;
+      std::string input_filename;
 
       if (argc != 2) {
          TBOX_ERROR("USAGE:  " << argv[0] << " <input file> \n"
                                << "  options:\n"
-                               << "  none at this time" << endl);
+                               << "  none at this time" << std::endl);
       } else {
          input_filename = argv[1];
       }
@@ -210,7 +210,7 @@ int main(
 
       const tbox::Dimension dim(static_cast<unsigned short>(main_db->getInteger("dim")));
 
-      string log_file_name = "mblkcomm.log";
+      std::string log_file_name = "mblkcomm.log";
       if (main_db->keyExists("log_file_name")) {
          log_file_name = main_db->getString("log_file_name");
       }
@@ -237,16 +237,16 @@ int main(
          ntimes_run = main_db->getInteger("ntimes_run");
       }
 
-      string test_to_run;
+      std::string test_to_run;
       if (main_db->keyExists("test_to_run")) {
          test_to_run = main_db->getString("test_to_run");
       } else {
-         TBOX_ERROR("Error in Main input: no test specified." << endl);
+         TBOX_ERROR("Error in Main input: no test specified." << std::endl);
       }
 
-      string refine_option = "INTERIOR_FROM_SAME_LEVEL";
+      std::string refine_option = "INTERIOR_FROM_SAME_LEVEL";
 
-      tbox::plog << "\nPerforming refine data test..." << endl;
+      tbox::plog << "\nPerforming refine data test..." << std::endl;
 
 #if 1
       if (0) {
@@ -297,10 +297,10 @@ int main(
                input_db,
                refine_option);
       } else if (test_to_run == "MultiVariableMultiblockTest") {
-         TBOX_ERROR("Error in Main input: no multi-variable test yet." << endl);
+         TBOX_ERROR("Error in Main input: no multi-variable test yet." << std::endl);
       } else {
          TBOX_ERROR("Error in Main input: illegal test = "
-            << test_to_run << endl);
+            << test_to_run << std::endl);
       }
 
       std::shared_ptr<tbox::Database> hier_db(
@@ -329,12 +329,12 @@ int main(
 
       comm_tester->setupHierarchy(input_db, cell_tagger);
 
-      tbox::plog << "Specified input file is: " << input_filename << endl;
+      tbox::plog << "Specified input file is: " << input_filename << std::endl;
 
-      tbox::plog << "\nInput file data is ...." << endl;
+      tbox::plog << "\nInput file data is ...." << std::endl;
       input_db->printClassData(tbox::plog);
 
-      tbox::plog << "\nCheck Variable database..." << endl;
+      tbox::plog << "\nCheck Variable database..." << std::endl;
       hier::VariableDatabase::getDatabase()->printClassData(tbox::plog);
 
       /*
@@ -396,7 +396,7 @@ int main(
       tbox::TimerManager::getManager()->print(tbox::plog);
 
       if (test_passed) {
-         tbox::pout << "\nPASSED:  mblkcomm" << endl;
+         tbox::pout << "\nPASSED:  mblkcomm" << std::endl;
          return_val = 0;
       }
 

--- a/source/test/nonlinear/ModifiedBratuProblem.C
+++ b/source/test/nonlinear/ModifiedBratuProblem.C
@@ -110,7 +110,7 @@ std::shared_ptr<tbox::Timer> ModifiedBratuProblem::s_pc_timer;
  */
 
 ModifiedBratuProblem::ModifiedBratuProblem(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    const std::shared_ptr<solv::CellPoissonFACSolver> fac_solver,
    std::shared_ptr<tbox::Database> input_db,
@@ -769,10 +769,10 @@ bool ModifiedBratuProblem::checkNewSolution(
                  << " on level " << amr_level
                  << " max err is " << levelerror
                  << " wtd l2 err is " << levell2error
-                 << endl;
+                 << std::endl;
    }
 
-   tbox::plog << " At " << new_time << " err is " << maxerror << endl;
+   tbox::plog << " At " << new_time << " err is " << maxerror << std::endl;
 
    return true;
 }
@@ -2742,32 +2742,32 @@ void ModifiedBratuProblem::putToRestart(
  */
 
 void ModifiedBratuProblem::printClassData(
-   ostream& os) const
+   std::ostream& os) const
 {
-   os << "\nModifiedBratuProblem::printClassData..." << endl;
+   os << "\nModifiedBratuProblem::printClassData..." << std::endl;
    os << "ModifiedBratuProblem: this = " << (ModifiedBratuProblem *)this
-      << endl;
-   os << "d_object_name = " << d_object_name << endl;
+      << std::endl;
+   os << "d_object_name = " << d_object_name << std::endl;
    os << "d_grid_geometry = "
-      << d_grid_geometry.get() << endl;
+      << d_grid_geometry.get() << std::endl;
 
-   os << "d_soln_scratch_id =   " << d_soln_scratch_id << endl;
-   os << "d_flux_id =   " << d_flux_id << endl;
-   os << "d_coarse_fine_flux_id =   " << d_coarse_fine_flux_id << endl;
-   os << "d_jacobian_a_id =   " << d_jacobian_a_id << endl;
-   os << "d_jacobian_b_id =   " << d_jacobian_b_id << endl;
-   os << "d_weight_id =   " << d_weight_id << endl;
-   os << "d_nghosts =   " << d_nghosts << endl;
+   os << "d_soln_scratch_id =   " << d_soln_scratch_id << std::endl;
+   os << "d_flux_id =   " << d_flux_id << std::endl;
+   os << "d_coarse_fine_flux_id =   " << d_coarse_fine_flux_id << std::endl;
+   os << "d_jacobian_a_id =   " << d_jacobian_a_id << std::endl;
+   os << "d_jacobian_b_id =   " << d_jacobian_b_id << std::endl;
+   os << "d_weight_id =   " << d_weight_id << std::endl;
+   os << "d_nghosts =   " << d_nghosts << std::endl;
 
-   os << "d_lambda =   " << d_lambda << endl;
-   os << "d_input_dt = " << d_input_dt << endl;
+   os << "d_lambda =   " << d_lambda << std::endl;
+   os << "d_input_dt = " << d_input_dt << std::endl;
 
-   os << "d_current_time =   " << d_current_time << endl;
-   os << "d_new_time = " << d_new_time << endl;
-   os << "d_current_dt =   " << d_current_dt << endl;
+   os << "d_current_time =   " << d_current_time << std::endl;
+   os << "d_new_time = " << d_new_time << std::endl;
+   os << "d_current_dt =   " << d_current_dt << std::endl;
 
-   os << "d_max_precond_its =   " << d_max_precond_its << endl;
-   os << "d_precond_tol = " << d_precond_tol << endl;
+   os << "d_max_precond_its =   " << d_max_precond_its << std::endl;
+   os << "d_precond_tol = " << d_precond_tol << std::endl;
 
 }
 

--- a/source/test/nonlinear/ModifiedBratuProblem.h
+++ b/source/test/nonlinear/ModifiedBratuProblem.h
@@ -69,7 +69,6 @@
 
 using namespace SAMRAI;
 using namespace xfer;
-using namespace std;
 using namespace hier;
 
 /**
@@ -104,7 +103,7 @@ public:
     * for communicating data between patches on the hierarchy.
     */
    ModifiedBratuProblem(
-      const string& object_name,
+      const std::string& object_name,
       const tbox::Dimension& dim,
       const std::shared_ptr<solv::CellPoissonFACSolver> fac_solver,
       std::shared_ptr<tbox::Database> input_db,
@@ -410,7 +409,7 @@ public:
     */
    void
    printClassData(
-      ostream& os) const;
+      std::ostream& os) const;
 
 private:
    /*
@@ -500,7 +499,7 @@ private:
     * The object name is used as a handle to databases stored in
     * restart files and for error reporting purposes.
     */
-   string d_object_name;
+   std::string d_object_name;
 
    /*
     * Dimension of the problem.

--- a/source/test/nonlinear/main.C
+++ b/source/test/nonlinear/main.C
@@ -13,7 +13,6 @@
 #include <string>
 #include <sys/stat.h>
 #include <string>
-using namespace std;
 
 /*
  * Headers for basic SAMRAI objects used in this sample code.
@@ -162,7 +161,7 @@ int main(
       tbox::pout << "This example requires the packages PETSC, SUNDIALS, "
                  << "\nand HYPRE to work properly.  SAMRAI was not configured"
                  << "\nwith one or more of these packages."
-                 << endl;
+                 << std::endl;
 #else
 
       /*
@@ -171,12 +170,12 @@ int main(
        *
        *     executable <input file name>
        */
-      string input_filename;
+      std::string input_filename;
 
       if (argc != 3) {
          TBOX_ERROR("USAGE:  " << argv[0] << " <input file> -skip_petscrc \n"
                                << "  options:\n"
-                               << "  none at this time" << endl);
+                               << "  none at this time" << std::endl);
       } else {
          input_filename = argv[1];
       }
@@ -198,24 +197,24 @@ int main(
 
       const tbox::Dimension dim(static_cast<unsigned short>(main_db->getInteger("dim")));
 
-      string base_name = "default";
+      std::string base_name = "default";
       base_name = main_db->getStringWithDefault("base_name", base_name);
 
-      string log_file_name = base_name + ".log";
+      std::string log_file_name = base_name + ".log";
       tbox::PIO::logOnlyNodeZero(log_file_name);
-      tbox::plog << "input_filename = " << input_filename << endl;
+      tbox::plog << "input_filename = " << input_filename << std::endl;
 
       int viz_dump_interval = 0;
       if (main_db->keyExists("viz_dump_interval")) {
          viz_dump_interval = main_db->getInteger("viz_dump_interval");
       }
 
-      string visit_dump_dirname;
+      std::string visit_dump_dirname;
       bool uses_visit = false;
       int visit_number_procs_per_file = 1;
       if (viz_dump_interval > 0) {
          uses_visit = true;
-         string viz_dump_dirname;
+         std::string viz_dump_dirname;
          if (main_db->keyExists("viz_dump_dirname")) {
             viz_dump_dirname = main_db->getString("viz_dump_dirname");
          }
@@ -224,7 +223,7 @@ int main(
             TBOX_ERROR("main(): "
                << "\nviz_dump_dirname is null ... "
                << "\nThis must be specified for use with VisIt"
-               << endl);
+               << std::endl);
          }
          if (main_db->keyExists("visit_number_procs_per_file")) {
             visit_number_procs_per_file =
@@ -237,7 +236,7 @@ int main(
          regrid_interval = main_db->getInteger("regrid_interval");
       }
 
-      string nonlinear_solver_package = "KINSOL";
+      std::string nonlinear_solver_package = "KINSOL";
       if (main_db->keyExists("nonlinear_solver_package")) {
          nonlinear_solver_package =
             main_db->getString("nonlinear_solver_package");
@@ -440,10 +439,10 @@ int main(
        */
 
       tbox::plog << "\nCheck input data and variables before simulation:"
-                 << endl;
-      tbox::plog << "Input database..." << endl;
+                 << std::endl;
+      tbox::plog << "Input database..." << std::endl;
       input_db->printClassData(tbox::plog);
-      tbox::plog << "\nVariable database..." << endl;
+      tbox::plog << "\nVariable database..." << std::endl;
       hier::VariableDatabase::getDatabase()->printClassData(tbox::plog);
 
       /*
@@ -521,11 +520,11 @@ int main(
              imp_integrator->stepsRemaining()) {
 
          int iteration_num = imp_integrator->getIntegratorStep() + 1;
-         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << endl;
+         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
          tbox::pout << "At begining of timestep # " << iteration_num - 1
-                    << endl;
-         tbox::pout << "Simulation time is " << sim_time << endl;
-         tbox::pout << "Time increment is " << dt << endl;
+                    << std::endl;
+         tbox::pout << "Simulation time is " << sim_time << std::endl;
+         tbox::pout << "Time increment is " << dt << std::endl;
 
          solve_timer->start();
          int solver_retcode = imp_integrator->advanceSolution(dt, first_step);
@@ -537,7 +536,7 @@ int main(
             int nonlinear_itns = snes_solver->getNumberOfNonlinearIterations();
             int linear_itns = snes_solver->getTotalNumberOfLinearIterations();
             tbox::plog << " Nonlinear iterations:  " << nonlinear_itns
-                       << " Linear iterations:     " << linear_itns << endl;
+                       << " Linear iterations:     " << linear_itns << std::endl;
          }
 
          bool good_solution = imp_integrator->checkNewSolution(solver_retcode);
@@ -545,10 +544,10 @@ int main(
          if (good_solution) {
             sim_time = imp_integrator->updateSolution();
 
-            tbox::pout << "At end of timestep # " << iteration_num - 1 << endl;
-            tbox::pout << "Simulation time is " << sim_time << endl;
+            tbox::pout << "At end of timestep # " << iteration_num - 1 << std::endl;
+            tbox::pout << "Simulation time is " << sim_time << std::endl;
             tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++"
-                       << endl;
+                       << std::endl;
 
             /*
              * If desired, write plot file.
@@ -582,10 +581,10 @@ int main(
             }
          } else {
 
-            tbox::pout << "At end of timestep # " << iteration_num - 1 << endl;
-            tbox::pout << "Failed to advance solution to " << sim_time << endl;
+            tbox::pout << "At end of timestep # " << iteration_num - 1 << std::endl;
+            tbox::pout << "Failed to advance solution to " << sim_time << std::endl;
             tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++"
-                       << endl;
+                       << std::endl;
             break;
 
          }
@@ -624,7 +623,7 @@ int main(
       t_all->stop();
       int size = tbox::SAMRAI_MPI::getSAMRAIWorld().getSize();
       if (tbox::SAMRAI_MPI::getSAMRAIWorld().getRank() == 0) {
-         string timing_file =
+         std::string timing_file =
             base_name + ".timing" + tbox::Utilities::intToString(size);
          FILE* fp = fopen(timing_file.c_str(), "w");
          fprintf(fp, "%f\n", t_all->getTotalWallclockTime());
@@ -639,7 +638,7 @@ int main(
        * makes it here, it passes.  We need to find a way to check
        * the solution accuracy.
        */
-      tbox::pout << "\nPASSED:  nonlinear" << endl;
+      tbox::pout << "\nPASSED:  nonlinear" << std::endl;
 #endif
    }
 

--- a/source/test/patchbdrysum/HierSumTest.C
+++ b/source/test/patchbdrysum/HierSumTest.C
@@ -204,7 +204,7 @@ HierSumTest::setInitialNodeValues(
          // output initial cell values
          int level_number = level->getLevelNumber();
          tbox::plog << "INITIAL Cell values for NODE - Level: " << level_number
-                    << "\tPatch: " << patch->getBox() << endl;
+                    << "\tPatch: " << patch->getBox() << std::endl;
          ucell->print(ucell->getGhostBox(), plog);
 
          // loop over nodes of patch
@@ -317,7 +317,7 @@ HierSumTest::setInitialNodeValues(
 
          // output initial node values
          tbox::plog << "INITIAL Node values - Level: " << level->getLevelNumber()
-                    << "\tPatch: " << patch->getBox() << endl;
+                    << "\tPatch: " << patch->getBox() << std::endl;
          unode->print(unode->getGhostBox(), plog);
 
       } // loop over patches
@@ -361,7 +361,7 @@ HierSumTest::setInitialEdgeValues(
       // output initial cell values
       int level_number = level->getLevelNumber();
       tbox::plog << "INITIAL Cell values for EDGE - Level: " << level_number
-                 << "\tPatch: " << patch->getBox() << endl;
+                 << "\tPatch: " << patch->getBox() << std::endl;
       ucell->print(ucell->getGhostBox(), plog);
 
       const Index ifirst(patch->getBox().lower());
@@ -431,7 +431,7 @@ HierSumTest::setInitialEdgeValues(
                << "PatchBdrySum Edge test FAILED:  Errors on Level: "
                << level->getLevelNumber()
                << "\t Patch: " << patch->getBox()
-               << "\nAll edges are not correct value." << endl;
+               << "\nAll edges are not correct value." << std::endl;
             } else {
 #if (TESTING == 1)
                tbox::plog
@@ -440,7 +440,7 @@ HierSumTest::setInitialEdgeValues(
 #endif
                << "All edges on Level: " << level->getLevelNumber()
                << "\t Patch: " << patch->getBox()
-               << "\tare correct." << endl;
+               << "\tare correct." << std::endl;
             }
          }
 
@@ -448,7 +448,7 @@ HierSumTest::setInitialEdgeValues(
 
 #if (TESTING == 1)
       tbox::plog << "INITIAL Edge values - Level: " << level->getLevelNumber()
-                 << "\tPatch: " << patch->getBox() << endl;
+                 << "\tPatch: " << patch->getBox() << std::endl;
       uedge->print(uedge->getGhostBox(), plog);
 #endif
 
@@ -618,7 +618,7 @@ int HierSumTest::checkNodeResult(
                                 << *i
                                 << " in L" << ln << " " << patch->getBox()
                                 << " depth = " << d << " should be "
-                                << correct_val << endl;
+                                << correct_val << std::endl;
                      all_correct = false;
                      break;
                   }
@@ -631,7 +631,7 @@ int HierSumTest::checkNodeResult(
             tbox::perr << "PatchBdrySum Node test FAILED:  Errors on Level: "
                        << level->getLevelNumber()
                        << "\t Patch: " << patch->getBox()
-                       << "\nAll nodes are not correct value." << endl;
+                       << "\nAll nodes are not correct value." << std::endl;
          } else {
 #if (TESTING == 1)
             tbox::plog
@@ -640,7 +640,7 @@ int HierSumTest::checkNodeResult(
 #endif
             << "All nodes on Level: " << level->getLevelNumber()
             << "\t Patch: " << patch->getBox()
-            << "\tare correct." << endl;
+            << "\tare correct." << std::endl;
          }
 
 #if (TESTING == 1)
@@ -651,12 +651,12 @@ int HierSumTest::checkNodeResult(
 
          tbox::plog << "FINAL Cell values for NODE - Level: "
                     << level->getLevelNumber()
-                    << "\tPatch: " << patch->getBox() << endl;
+                    << "\tPatch: " << patch->getBox() << std::endl;
          ucell_node->print(ucell_node->getGhostBox(), plog);
 
          tbox::plog << "FINAL Node values - Level: " << level->getLevelNumber()
                     << "\tPatch " << patch->getBox()
-                    << endl;
+                    << std::endl;
          unode->print(unode->getBox(), plog);
 #endif
 
@@ -739,7 +739,7 @@ int HierSumTest::checkEdgeResult(
             tbox::perr << "PatchBdrySum Edge test FAILED:  Errors on Level: "
                        << level->getLevelNumber()
                        << "\t Patch: " << patch->getBox()
-                       << "\nAll edges are not correct value." << endl;
+                       << "\nAll edges are not correct value." << std::endl;
          } else {
 #if (TESTING == 1)
             tbox::plog
@@ -748,7 +748,7 @@ int HierSumTest::checkEdgeResult(
 #endif
             << "All edges on Level: " << level->getLevelNumber()
             << "\t Patch: " << patch->getBox()
-            << "\tare correct." << endl;
+            << "\tare correct." << std::endl;
          }
 
       } // loop over depth
@@ -761,12 +761,12 @@ int HierSumTest::checkEdgeResult(
 
       tbox::plog << "FINAL Cell values for EDGE - Level: "
                  << level->getLevelNumber()
-                 << "\tPatch: " << patch->getBox() << endl;
+                 << "\tPatch: " << patch->getBox() << std::endl;
       ucell_edge->print(ucell_edge->getGhostBox(), plog);
 
       tbox::plog << "FINAL Edge values - Level: "
                  << level->getLevelNumber()
-                 << "\tPatch: " << patch->getBox() << endl;
+                 << "\tPatch: " << patch->getBox() << std::endl;
       uedge->print(uedge->getGhostBox(), plog);
 #endif
 
@@ -1394,7 +1394,7 @@ HierSumTest::getFromInput(
       if (static_cast<int>(tmp_array.size()) != d_dim.getValue()) {
          TBOX_ERROR("HierSumTest::getFromInput()"
             << "invalid 'node_ghosts' entry - must be integer"
-            << "array of size d_dim" << endl);
+            << "array of size d_dim" << std::endl);
       }
    } else {
       tmp_array.resize(d_dim.getValue());
@@ -1412,7 +1412,7 @@ HierSumTest::getFromInput(
       if (static_cast<int>(tmp_array.size()) != d_dim.getValue()) {
          TBOX_ERROR("HierSumTest::getFromInput()"
             << "invalid 'edge_ghosts' entry - must be integer"
-            << "array of size d_dim" << endl);
+            << "array of size d_dim" << std::endl);
       }
    } else {
       tmp_array.resize(d_dim.getValue());

--- a/source/test/patchbdrysum/HierSumTest.h
+++ b/source/test/patchbdrysum/HierSumTest.h
@@ -36,7 +36,6 @@
 #include <vector>
 #include <memory>
 
-using namespace std;
 using namespace SAMRAI;
 using namespace tbox;
 using namespace hier;

--- a/source/test/patchbdrysum/main.C
+++ b/source/test/patchbdrysum/main.C
@@ -78,14 +78,14 @@ int main(
 
       if (argc != 2) {
          tbox::pout << "USAGE:  " << argv[0] << " <input filename> "
-                    << "[options]\n" << endl;
+                    << "[options]\n" << std::endl;
          tbox::SAMRAI_MPI::abort();
          return -1;
       } else {
          input_filename = argv[1];
       }
 
-      tbox::plog << "input_filename = " << input_filename << endl;
+      tbox::plog << "input_filename = " << input_filename << std::endl;
 
       /****************************************************************
       *
@@ -257,10 +257,10 @@ int main(
        */
 
       tbox::plog << "\nCheck input data and variables before simulation:"
-                 << endl;
-      tbox::plog << "Input database..." << endl;
+                 << std::endl;
+      tbox::plog << "Input database..." << std::endl;
       input_db->printClassData(plog);
-      tbox::plog << "\nVariable database..." << endl;
+      tbox::plog << "\nVariable database..." << std::endl;
       VariableDatabase::getDatabase()->printClassData(plog);
 
       /****************************************************************
@@ -318,15 +318,15 @@ int main(
          std::shared_ptr<PatchLevel> level(
             patch_hierarchy->getPatchLevel(pln));
 
-         tbox::plog << "\n PRINTING PATCHES ON LEVEL " << pln << endl;
+         tbox::plog << "\n PRINTING PATCHES ON LEVEL " << pln << std::endl;
 
          for (PatchLevel::iterator ip(level->begin());
               ip != level->end(); ++ip) {
             tbox::plog << "patch # " << ip->getBox().getBoxId() << " : "
-                       << ip->getBox() << endl;
+                       << ip->getBox() << std::endl;
          }
       }
-      tbox::plog << endl;
+      tbox::plog << std::endl;
 
       /*******************************************************************
        *
@@ -401,7 +401,7 @@ int main(
          fail_count += hier_sum_test->checkNodeResult(patch_hierarchy);
       }
 
-      tbox::pout << "\n" << endl;
+      tbox::pout << "\n" << std::endl;
 
       if (do_edge_sum) {
          for (int ln = 0; ln < nlevels; ++ln) {
@@ -442,7 +442,7 @@ int main(
       main_db.reset();
 
       if (fail_count == 0) {
-         tbox::pout << "\nPASSED:  patchbdrysum" << endl;
+         tbox::pout << "\nPASSED:  patchbdrysum" << std::endl;
       }
    }
 

--- a/source/test/performance/Euler/Euler.C
+++ b/source/test/performance/Euler/Euler.C
@@ -26,7 +26,6 @@
 #endif
 #endif
 
-using namespace std;
 
 #include <cstdlib>
 #include <cstdio>
@@ -283,7 +282,7 @@ Euler::Euler(
          d_object_name << ": "
                        << "Unknown d_riemann_solve string = "
                        << d_riemann_solve
-                       << " encountered in constructor" << endl);
+                       << " encountered in constructor" << std::endl);
    }
 
    if (d_data_problem == "PIECEWISE_CONSTANT_X") {
@@ -301,7 +300,7 @@ Euler::Euler(
          d_object_name << ": "
                        << "Unknown d_data_problem string = "
                        << d_data_problem
-                       << " encountered in constructor" << endl);
+                       << " encountered in constructor" << std::endl);
    }
 
    /*
@@ -493,7 +492,7 @@ void Euler::registerModelVariables(
       TBOX_WARNING(d_object_name << ": registerModelVariables()\n"
                                  << "VisIt data writer was not registered\n"
                                  << "Consequently, no plot data will\n"
-                                 << "be written." << endl);
+                                 << "be written." << std::endl);
    }
 #endif
 
@@ -540,7 +539,7 @@ void Euler::setupLoadBalancer(
          TBOX_WARNING(
             d_object_name << ": "
                           << "  Unknown load balancer used in gridding algorithm."
-                          << "  Ignoring request for nonuniform load balancing." << endl);
+                          << "  Ignoring request for nonuniform load balancing." << std::endl);
          d_use_nonuniform_workload = false;
       }
    } else {
@@ -3139,7 +3138,7 @@ void Euler::writeData1dPencil(
          file << vel << " ";
          file << eint << " ";
 
-         file << endl;
+         file << std::endl;
       }
 
    }
@@ -3159,288 +3158,288 @@ void Euler::printClassData(
 {
    int j, k;
 
-   os << "\nEuler::printClassData..." << endl;
-   os << "Euler: this = " << (Euler *)this << endl;
-   os << "d_object_name = " << d_object_name << endl;
+   os << "\nEuler::printClassData..." << std::endl;
+   os << "Euler: this = " << (Euler *)this << std::endl;
+   os << "d_object_name = " << d_object_name << std::endl;
    os << "d_grid_geometry = "
-      << d_grid_geometry.get() << endl;
+      << d_grid_geometry.get() << std::endl;
 
-   os << "Parameters for physical problem ..." << endl;
-   os << "   d_gamma = " << d_gamma << endl;
+   os << "Parameters for physical problem ..." << std::endl;
+   os << "   d_gamma = " << d_gamma << std::endl;
 
-   os << "Numerical method description and ghost sizes..." << endl;
-   os << "   d_riemann_solve = " << d_riemann_solve << endl;
-   os << "   d_riemann_solve_int = " << d_riemann_solve_int << endl;
-   os << "   d_godunov_order = " << d_godunov_order << endl;
-   os << "   d_corner_transport = " << d_corner_transport << endl;
-   os << "   d_nghosts = " << d_nghosts << endl;
-   os << "   d_fluxghosts = " << d_fluxghosts << endl;
+   os << "Numerical method description and ghost sizes..." << std::endl;
+   os << "   d_riemann_solve = " << d_riemann_solve << std::endl;
+   os << "   d_riemann_solve_int = " << d_riemann_solve_int << std::endl;
+   os << "   d_godunov_order = " << d_godunov_order << std::endl;
+   os << "   d_corner_transport = " << d_corner_transport << std::endl;
+   os << "   d_nghosts = " << d_nghosts << std::endl;
+   os << "   d_fluxghosts = " << d_fluxghosts << std::endl;
 
-   os << "Problem description and initial data..." << endl;
-   os << "   d_data_problem = " << d_data_problem << endl;
-   os << "   d_data_problem_int = " << d_data_problem_int << endl;
+   os << "Problem description and initial data..." << std::endl;
+   os << "   d_data_problem = " << d_data_problem << std::endl;
+   os << "   d_data_problem_int = " << d_data_problem_int << std::endl;
 
-   os << "       d_radius = " << d_radius << endl;
+   os << "       d_radius = " << d_radius << std::endl;
    os << "       d_center = ";
    for (j = 0; j < d_dim.getValue(); ++j) os << d_center[j] << " ";
-   os << endl;
-   os << "       d_density_inside = " << d_density_inside << endl;
+   os << std::endl;
+   os << "       d_density_inside = " << d_density_inside << std::endl;
    os << "       d_velocity_inside = ";
    for (j = 0; j < d_dim.getValue(); ++j) os << d_velocity_inside[j] << " ";
-   os << endl;
-   os << "       d_pressure_inside = " << d_pressure_inside << endl;
-   os << "       d_density_outside = " << d_density_outside << endl;
+   os << std::endl;
+   os << "       d_pressure_inside = " << d_pressure_inside << std::endl;
+   os << "       d_density_outside = " << d_density_outside << std::endl;
    os << "       d_velocity_outside = ";
    for (j = 0; j < d_dim.getValue(); ++j) os << d_velocity_outside[j] << " ";
-   os << endl;
-   os << "       d_pressure_outside = " << d_pressure_outside << endl;
+   os << std::endl;
+   os << "       d_pressure_outside = " << d_pressure_outside << std::endl;
 
-   os << "       d_number_of_intervals = " << d_number_of_intervals << endl;
+   os << "       d_number_of_intervals = " << d_number_of_intervals << std::endl;
    os << "       d_front_position = ";
    for (k = 0; k < d_number_of_intervals - 1; ++k) {
       os << d_front_position[k] << "  ";
    }
-   os << endl;
-   os << "       d_interval_density = " << endl;
+   os << std::endl;
+   os << "       d_interval_density = " << std::endl;
    for (k = 0; k < d_number_of_intervals; ++k) {
-      os << "            " << d_interval_density[k] << endl;
+      os << "            " << d_interval_density[k] << std::endl;
    }
-   os << "       d_interval_velocity = " << endl;
+   os << "       d_interval_velocity = " << std::endl;
    for (k = 0; k < d_number_of_intervals; ++k) {
       os << "            ";
       for (j = 0; j < d_dim.getValue(); ++j) {
          os << d_interval_velocity[k * d_dim.getValue() + j] << "  ";
       }
-      os << endl;
+      os << std::endl;
    }
-   os << "       d_interval_pressure = " << endl;
+   os << "       d_interval_pressure = " << std::endl;
    for (k = 0; k < d_number_of_intervals; ++k) {
-      os << "            " << d_interval_pressure[k] << endl;
+      os << "            " << d_interval_pressure[k] << std::endl;
    }
 
-   os << "   Boundary condition data " << endl;
+   os << "   Boundary condition data " << std::endl;
 
    if (d_dim == tbox::Dimension(2)) {
       for (j = 0; j < static_cast<int>(d_master_bdry_edge_conds.size()); ++j) {
          os << "\n       d_master_bdry_edge_conds[" << j << "] = "
-            << d_master_bdry_edge_conds[j] << endl;
+            << d_master_bdry_edge_conds[j] << std::endl;
          os << "       d_scalar_bdry_edge_conds[" << j << "] = "
-            << d_scalar_bdry_edge_conds[j] << endl;
+            << d_scalar_bdry_edge_conds[j] << std::endl;
          os << "       d_vector_bdry_edge_conds[" << j << "] = "
-            << d_vector_bdry_edge_conds[j] << endl;
+            << d_vector_bdry_edge_conds[j] << std::endl;
          if (d_master_bdry_edge_conds[j] == BdryCond::DIRICHLET) {
             os << "         d_bdry_edge_density[" << j << "] = "
-               << d_bdry_edge_density[j] << endl;
+               << d_bdry_edge_density[j] << std::endl;
             os << "         d_bdry_edge_velocity[" << j << "] = "
                << d_bdry_edge_velocity[j * d_dim.getValue() + 0] << " , "
-               << d_bdry_edge_velocity[j * d_dim.getValue() + 1] << endl;
+               << d_bdry_edge_velocity[j * d_dim.getValue() + 1] << std::endl;
             os << "         d_bdry_edge_pressure[" << j << "] = "
-               << d_bdry_edge_pressure[j] << endl;
+               << d_bdry_edge_pressure[j] << std::endl;
          }
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_master_bdry_node_conds.size()); ++j) {
          os << "\n       d_master_bdry_node_conds[" << j << "] = "
-            << d_master_bdry_node_conds[j] << endl;
+            << d_master_bdry_node_conds[j] << std::endl;
          os << "       d_scalar_bdry_node_conds[" << j << "] = "
-            << d_scalar_bdry_node_conds[j] << endl;
+            << d_scalar_bdry_node_conds[j] << std::endl;
          os << "       d_vector_bdry_node_conds[" << j << "] = "
-            << d_vector_bdry_node_conds[j] << endl;
+            << d_vector_bdry_node_conds[j] << std::endl;
          os << "       d_node_bdry_edge[" << j << "] = "
-            << d_node_bdry_edge[j] << endl;
+            << d_node_bdry_edge[j] << std::endl;
       }
    }
    if (d_dim == tbox::Dimension(3)) {
       for (j = 0; j < static_cast<int>(d_master_bdry_face_conds.size()); ++j) {
          os << "\n       d_master_bdry_face_conds[" << j << "] = "
-            << d_master_bdry_face_conds[j] << endl;
+            << d_master_bdry_face_conds[j] << std::endl;
          os << "       d_scalar_bdry_face_conds[" << j << "] = "
-            << d_scalar_bdry_face_conds[j] << endl;
+            << d_scalar_bdry_face_conds[j] << std::endl;
          os << "       d_vector_bdry_face_conds[" << j << "] = "
-            << d_vector_bdry_face_conds[j] << endl;
+            << d_vector_bdry_face_conds[j] << std::endl;
          if (d_master_bdry_face_conds[j] == BdryCond::DIRICHLET) {
             os << "         d_bdry_face_density[" << j << "] = "
-               << d_bdry_face_density[j] << endl;
+               << d_bdry_face_density[j] << std::endl;
             os << "         d_bdry_face_velocity[" << j << "] = "
                << d_bdry_face_velocity[j * d_dim.getValue() + 0] << " , "
                << d_bdry_face_velocity[j * d_dim.getValue() + 1] << " , "
-               << d_bdry_face_velocity[j * d_dim.getValue() + 2] << endl;
+               << d_bdry_face_velocity[j * d_dim.getValue() + 2] << std::endl;
             os << "         d_bdry_face_pressure[" << j << "] = "
-               << d_bdry_face_pressure[j] << endl;
+               << d_bdry_face_pressure[j] << std::endl;
          }
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_master_bdry_edge_conds.size()); ++j) {
          os << "\n       d_master_bdry_edge_conds[" << j << "] = "
-            << d_master_bdry_edge_conds[j] << endl;
+            << d_master_bdry_edge_conds[j] << std::endl;
          os << "       d_scalar_bdry_edge_conds[" << j << "] = "
-            << d_scalar_bdry_edge_conds[j] << endl;
+            << d_scalar_bdry_edge_conds[j] << std::endl;
          os << "       d_vector_bdry_edge_conds[" << j << "] = "
-            << d_vector_bdry_edge_conds[j] << endl;
+            << d_vector_bdry_edge_conds[j] << std::endl;
          os << "       d_edge_bdry_face[" << j << "] = "
-            << d_edge_bdry_face[j] << endl;
+            << d_edge_bdry_face[j] << std::endl;
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_master_bdry_node_conds.size()); ++j) {
          os << "\n       d_master_bdry_node_conds[" << j << "] = "
-            << d_master_bdry_node_conds[j] << endl;
+            << d_master_bdry_node_conds[j] << std::endl;
          os << "       d_scalar_bdry_node_conds[" << j << "] = "
-            << d_scalar_bdry_node_conds[j] << endl;
+            << d_scalar_bdry_node_conds[j] << std::endl;
          os << "       d_vector_bdry_node_conds[" << j << "] = "
-            << d_vector_bdry_node_conds[j] << endl;
+            << d_vector_bdry_node_conds[j] << std::endl;
          os << "       d_node_bdry_face[" << j << "] = "
-            << d_node_bdry_face[j] << endl;
+            << d_node_bdry_face[j] << std::endl;
       }
    }
 
-   os << "   Refinement criteria parameters " << endl;
+   os << "   Refinement criteria parameters " << std::endl;
 
    for (j = 0; j < static_cast<int>(d_refinement_criteria.size()); ++j) {
       os << "       d_refinement_criteria[" << j << "] = "
-         << d_refinement_criteria[j] << endl;
+         << d_refinement_criteria[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_dev_tol.size()); ++j) {
       os << "       d_density_dev_tol[" << j << "] = "
-         << d_density_dev_tol[j] << endl;
+         << d_density_dev_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_dev.size()); ++j) {
       os << "       d_density_dev[" << j << "] = "
-         << d_density_dev[j] << endl;
+         << d_density_dev[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_dev_time_max.size()); ++j) {
       os << "       d_density_dev_time_max[" << j << "] = "
-         << d_density_dev_time_max[j] << endl;
+         << d_density_dev_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_dev_time_min.size()); ++j) {
       os << "       d_density_dev_time_min[" << j << "] = "
-         << d_density_dev_time_min[j] << endl;
+         << d_density_dev_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_grad_tol.size()); ++j) {
       os << "       d_density_grad_tol[" << j << "] = "
-         << d_density_grad_tol[j] << endl;
+         << d_density_grad_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_grad_time_max.size()); ++j) {
       os << "       d_density_grad_time_max[" << j << "] = "
-         << d_density_grad_time_max[j] << endl;
+         << d_density_grad_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_grad_time_min.size()); ++j) {
       os << "       d_density_grad_time_min[" << j << "] = "
-         << d_density_grad_time_min[j] << endl;
+         << d_density_grad_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_shock_onset.size()); ++j) {
       os << "       d_density_shock_onset[" << j << "] = "
-         << d_density_shock_onset[j] << endl;
+         << d_density_shock_onset[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_shock_tol.size()); ++j) {
       os << "       d_density_shock_tol[" << j << "] = "
-         << d_density_shock_tol[j] << endl;
+         << d_density_shock_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_shock_time_max.size()); ++j) {
       os << "       d_density_shock_time_max[" << j << "] = "
-         << d_density_shock_time_max[j] << endl;
+         << d_density_shock_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_shock_time_min.size()); ++j) {
       os << "       d_density_shock_time_min[" << j << "] = "
-         << d_density_shock_time_min[j] << endl;
+         << d_density_shock_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_rich_tol.size()); ++j) {
       os << "       d_density_rich_tol[" << j << "] = "
-         << d_density_rich_tol[j] << endl;
+         << d_density_rich_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_rich_time_max.size()); ++j) {
       os << "       d_density_rich_time_max[" << j << "] = "
-         << d_density_rich_time_max[j] << endl;
+         << d_density_rich_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_density_rich_time_min.size()); ++j) {
       os << "       d_density_rich_time_min[" << j << "] = "
-         << d_density_rich_time_min[j] << endl;
+         << d_density_rich_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
 
    for (j = 0; j < static_cast<int>(d_pressure_dev_tol.size()); ++j) {
       os << "       d_pressure_dev_tol[" << j << "] = "
-         << d_pressure_dev_tol[j] << endl;
+         << d_pressure_dev_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_dev.size()); ++j) {
       os << "       d_pressure_dev[" << j << "] = "
-         << d_pressure_dev[j] << endl;
+         << d_pressure_dev[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_dev_time_max.size()); ++j) {
       os << "       d_pressure_dev_time_max[" << j << "] = "
-         << d_pressure_dev_time_max[j] << endl;
+         << d_pressure_dev_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_dev_time_min.size()); ++j) {
       os << "       d_pressure_dev_time_min[" << j << "] = "
-         << d_pressure_dev_time_min[j] << endl;
+         << d_pressure_dev_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_grad_tol.size()); ++j) {
       os << "       d_pressure_grad_tol[" << j << "] = "
-         << d_pressure_grad_tol[j] << endl;
+         << d_pressure_grad_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_grad_time_max.size()); ++j) {
       os << "       d_pressure_grad_time_max[" << j << "] = "
-         << d_pressure_grad_time_max[j] << endl;
+         << d_pressure_grad_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_grad_time_min.size()); ++j) {
       os << "       d_pressure_grad_time_min[" << j << "] = "
-         << d_pressure_grad_time_min[j] << endl;
+         << d_pressure_grad_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_shock_onset.size()); ++j) {
       os << "       d_pressure_shock_onset[" << j << "] = "
-         << d_pressure_shock_onset[j] << endl;
+         << d_pressure_shock_onset[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_shock_tol.size()); ++j) {
       os << "       d_pressure_shock_tol[" << j << "] = "
-         << d_pressure_shock_tol[j] << endl;
+         << d_pressure_shock_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_shock_time_max.size()); ++j) {
       os << "       d_pressure_shock_time_max[" << j << "] = "
-         << d_pressure_shock_time_max[j] << endl;
+         << d_pressure_shock_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_shock_time_min.size()); ++j) {
       os << "       d_pressure_shock_time_min[" << j << "] = "
-         << d_pressure_shock_time_min[j] << endl;
+         << d_pressure_shock_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_rich_tol.size()); ++j) {
       os << "       d_pressure_rich_tol[" << j << "] = "
-         << d_pressure_rich_tol[j] << endl;
+         << d_pressure_rich_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_rich_time_max.size()); ++j) {
       os << "       d_pressure_rich_time_max[" << j << "] = "
-         << d_pressure_rich_time_max[j] << endl;
+         << d_pressure_rich_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_pressure_rich_time_min.size()); ++j) {
       os << "       d_pressure_rich_time_min[" << j << "] = "
-         << d_pressure_rich_time_min[j] << endl;
+         << d_pressure_rich_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
 
 }
 
@@ -3487,7 +3486,7 @@ void Euler::getFromInput(
             d_object_name << ": "
                           << "`riemann_solve' in input must be either string "
                           << "'APPROX_RIEM_SOLVE', 'EXACT_RIEM_SOLVE', "
-                          << "'HLLC_RIEM_SOLVE'." << endl);
+                          << "'HLLC_RIEM_SOLVE'." << std::endl);
 
       }
    } else {
@@ -3502,7 +3501,7 @@ void Euler::getFromInput(
           (d_godunov_order != 4)) {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "`godunov_order' in input must be 1, 2, or 4." << endl);
+                          << "`godunov_order' in input must be 1, 2, or 4." << std::endl);
 
       }
    } else {
@@ -3517,7 +3516,7 @@ void Euler::getFromInput(
          TBOX_ERROR(
             d_object_name << ": "
                           << "`corner_transport' in input must be either string"
-                          << " 'CORNER_TRANSPORT_1' or 'CORNER_TRANSPORT_2'." << endl);
+                          << " 'CORNER_TRANSPORT_1' or 'CORNER_TRANSPORT_2'." << std::endl);
       }
    } else {
       d_corner_transport = input_db->getStringWithDefault("corner_transport",
@@ -3536,7 +3535,7 @@ void Euler::getFromInput(
          TBOX_WARNING(
             d_object_name << ": "
                           << "No key `refine_criteria' found in data for"
-                          << " RefinementData. No refinement will occur." << endl);
+                          << " RefinementData. No refinement will occur." << std::endl);
       }
 
       std::vector<string> ref_keys_defined(num_keys);
@@ -3561,7 +3560,7 @@ void Euler::getFromInput(
                   d_object_name << ": "
                                 << "Unknown refinement criteria: "
                                 << error_key
-                                << "\nin input." << endl);
+                                << "\nin input." << std::endl);
             } else {
                error_db = refine_db->getDatabase(error_key);
                ref_keys_defined[def_key_cnt] = error_key;
@@ -3576,7 +3575,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `dev_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("density_dev")) {
@@ -3585,7 +3584,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `density_dev' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -3615,7 +3614,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `grad_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -3646,7 +3645,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `shock_onset' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("shock_tol")) {
@@ -3655,7 +3654,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `shock_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -3685,7 +3684,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `rich_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -3715,7 +3714,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `dev_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("pressure_dev")) {
@@ -3724,7 +3723,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `pressure_dev' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -3754,7 +3753,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `grad_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -3785,7 +3784,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `shock_onset' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("shock_tol")) {
@@ -3795,7 +3794,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `shock_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -3825,7 +3824,7 @@ void Euler::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `rich_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -3866,7 +3865,7 @@ void Euler::getFromInput(
          if (!key_found) {
             TBOX_ERROR(d_object_name << ": "
                                      << "No input found for specified refine criteria: "
-                                     << d_refinement_criteria[k0] << endl);
+                                     << d_refinement_criteria[k0] << std::endl);
          }
       }
 
@@ -3880,13 +3879,13 @@ void Euler::getFromInput(
          TBOX_ERROR(
             d_object_name << ": "
                           << "`data_problem' value not found in input."
-                          << endl);
+                          << std::endl);
       }
 
       if (!input_db->keyExists("Initial_data")) {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "No `Initial_data' database found in input." << endl);
+                          << "No `Initial_data' database found in input." << std::endl);
       }
       std::shared_ptr<tbox::Database> init_data_db(
          input_db->getDatabase("Initial_data"));
@@ -3900,21 +3899,21 @@ void Euler::getFromInput(
          } else {
             TBOX_ERROR(
                d_object_name << ": "
-                             << "`radius' input required for SPHERE problem." << endl);
+                             << "`radius' input required for SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("center")) {
             init_data_db->getDoubleArray("center", d_center, d_dim.getValue());
          } else {
             TBOX_ERROR(
                d_object_name << ": "
-                             << "`center' input required for SPHERE problem." << endl);
+                             << "`center' input required for SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("density_inside")) {
             d_density_inside = init_data_db->getDouble("density_inside");
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`density_inside' input required for "
-                                     << "SPHERE problem." << endl);
+                                     << "SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("velocity_inside")) {
             init_data_db->getDoubleArray("velocity_inside",
@@ -3922,21 +3921,21 @@ void Euler::getFromInput(
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`velocity_inside' input required for "
-                                     << "SPHERE problem." << endl);
+                                     << "SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("pressure_inside")) {
             d_pressure_inside = init_data_db->getDouble("pressure_inside");
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`pressure_inside' input required for "
-                                     << "SPHERE problem." << endl);
+                                     << "SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("density_outside")) {
             d_density_outside = init_data_db->getDouble("density_outside");
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`density_outside' input required for "
-                                     << "SPHERE problem." << endl);
+                                     << "SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("velocity_outside")) {
             init_data_db->getDoubleArray("velocity_outside",
@@ -3945,7 +3944,7 @@ void Euler::getFromInput(
             TBOX_ERROR(
                d_object_name << ": "
                              << "`velocity_outside' input required for "
-                             << "SPHERE problem." << endl);
+                             << "SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("pressure_outside")) {
             d_pressure_outside = init_data_db->getDouble("pressure_outside");
@@ -3953,7 +3952,7 @@ void Euler::getFromInput(
             TBOX_ERROR(
                d_object_name << ": "
                              << "`pressure_outside' input required for "
-                             << "SPHERE problem." << endl);
+                             << "SPHERE problem." << std::endl);
          }
 
          found_problem_data = true;
@@ -3976,7 +3975,7 @@ void Euler::getFromInput(
                TBOX_ERROR(
                   d_object_name << ": `PIECEWISE_CONSTANT_Z' "
                                 << "problem invalid in 2 dimensions."
-                                << endl);
+                                << std::endl);
             }
             idir = 2;
          }
@@ -3988,7 +3987,7 @@ void Euler::getFromInput(
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`front_position' input required for "
-                                     << "PIECEWISE_CONSTANT_* problem." << endl);
+                                     << "PIECEWISE_CONSTANT_* problem." << std::endl);
          }
 
          d_number_of_intervals =
@@ -4037,7 +4036,7 @@ void Euler::getFromInput(
             TBOX_ERROR(
                d_object_name << ": "
                              << "Insufficient interval data given in input"
-                             << " for PIECEWISE_CONSTANT_* or STEP problem." << endl);
+                             << " for PIECEWISE_CONSTANT_* or STEP problem." << std::endl);
          }
 
          found_problem_data = true;
@@ -4047,7 +4046,7 @@ void Euler::getFromInput(
       if (!found_problem_data) {
          TBOX_ERROR(d_object_name << ": "
                                   << "`Initial_data' database found in input."
-                                  << " But bad data supplied." << endl);
+                                  << " But bad data supplied." << std::endl);
       }
 
    } // if !is_from_restart read in problem data
@@ -4085,7 +4084,7 @@ void Euler::getFromInput(
       } else {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "Key data `Boundary_data' not found in input. " << endl);
+                          << "Key data `Boundary_data' not found in input. " << std::endl);
       }
 
    }
@@ -4265,7 +4264,7 @@ void Euler::getFromRestart()
 
    if (!root_db->isDatabase(d_object_name)) {
       TBOX_ERROR("Restart database corresponding to "
-         << d_object_name << " not found in restart file." << endl);
+         << d_object_name << " not found in restart file." << std::endl);
    }
    std::shared_ptr<tbox::Database> db(root_db->getDatabase(d_object_name));
 
@@ -4273,7 +4272,7 @@ void Euler::getFromRestart()
    if (ver != EULER_VERSION) {
       TBOX_ERROR(
          d_object_name << ": "
-                       << "Restart file version different than class version." << endl);
+                       << "Restart file version different than class version." << std::endl);
    }
 
    d_gamma = db->getDouble("d_gamma");
@@ -4288,7 +4287,7 @@ void Euler::getFromRestart()
       if (d_nghosts(i) != CELLG) {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "Key data `d_nghosts' in restart file != CELLG." << endl);
+                          << "Key data `d_nghosts' in restart file != CELLG." << std::endl);
       }
    }
    int* tmp_fluxghosts = &d_fluxghosts[0];
@@ -4297,7 +4296,7 @@ void Euler::getFromRestart()
       if (d_fluxghosts(i) != FLUXG) {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "Key data `d_fluxghosts' in restart file != FLUXG." << endl);
+                          << "Key data `d_fluxghosts' in restart file != FLUXG." << std::endl);
       }
    }
 
@@ -4499,7 +4498,7 @@ void Euler::readStateDataEntry(
    } else {
       TBOX_ERROR(d_object_name << ": "
                                << "`density' entry missing from " << db_name
-                               << " input database. " << endl);
+                               << " input database. " << std::endl);
    }
    if (db->keyExists("velocity")) {
       std::vector<double> tmp_vel = db->getDoubleVector("velocity");
@@ -4507,7 +4506,7 @@ void Euler::readStateDataEntry(
          TBOX_ERROR(d_object_name << ": "
                                   << "Insufficient number `velocity' values"
                                   << " given in " << db_name
-                                  << " input database." << endl);
+                                  << " input database." << std::endl);
       }
       for (int iv = 0; iv < d_dim.getValue(); ++iv) {
          velocity[array_indx * d_dim.getValue() + iv] = tmp_vel[iv];
@@ -4515,14 +4514,14 @@ void Euler::readStateDataEntry(
    } else {
       TBOX_ERROR(d_object_name << ": "
                                << "`velocity' entry missing from " << db_name
-                               << " input database. " << endl);
+                               << " input database. " << std::endl);
    }
    if (db->keyExists("pressure")) {
       pressure[array_indx] = db->getDouble("pressure");
    } else {
       TBOX_ERROR(d_object_name << ": "
                                << "`pressure' entry missing from " << db_name
-                               << " input database. " << endl);
+                               << " input database. " << std::endl);
    }
 
 }

--- a/source/test/performance/Euler/Euler.h
+++ b/source/test/performance/Euler/Euler.h
@@ -35,7 +35,6 @@
 #include <string>
 #include <vector>
 #include <memory>
-using namespace std;
 
 /**
  * The Euler class provides routines for a sample application code that

--- a/source/test/performance/Euler/intToString.C
+++ b/source/test/performance/Euler/intToString.C
@@ -19,7 +19,6 @@
 #include <sstream>
 #include <iomanip>
 
-using namespace std;
 
 string intToString(
    int i,

--- a/source/test/performance/Euler/main.C
+++ b/source/test/performance/Euler/main.C
@@ -56,7 +56,6 @@
 #include <string>
 #include <fstream>
 #include <memory>
-using namespace std;
 
 #ifndef _MSC_VER
 #include <unistd.h>
@@ -189,7 +188,7 @@ int main(
                     << argv[0] << " <input filename> <case name>"
                     << "or\n"
                     << argv[0] << " <input filename> <case name> <scale size> "
-                    << endl;
+                    << std::endl;
          tbox::SAMRAI_MPI::abort();
          return -1;
       } else {
@@ -202,7 +201,7 @@ int main(
          }
       }
 
-      tbox::pout << "input_filename = " << input_filename << endl;
+      tbox::pout << "input_filename = " << input_filename << std::endl;
       tbox::pout << "case_name = " << case_name << std::endl;
       tbox::pout << "scale_size = " << scale_size << std::endl;
 
@@ -289,7 +288,7 @@ int main(
             TBOX_ERROR("main(): "
                << "\nviz_dump_dirname is null ... "
                << "\nThis must be specified for use with VisIt"
-               << endl);
+               << std::endl);
          }
          if (main_db->keyExists("visit_number_procs_per_file")) {
             visit_number_procs_per_file =
@@ -539,13 +538,13 @@ int main(
 
          int iteration_num = time_integrator->getIntegratorStep() + 1;
 
-         tbox::plog << endl << endl;
-         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << endl;
-         tbox::pout << "At begining of timestep # " << iteration_num - 1 << endl;
-         tbox::pout << "Simulation time is " << loop_time << endl;
-         tbox::pout << "Current dt is " << dt_now << endl;
-         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++\n\n" << endl;
-         tbox::plog << endl << endl;
+         tbox::plog << std::endl << std::endl;
+         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
+         tbox::pout << "At begining of timestep # " << iteration_num - 1 << std::endl;
+         tbox::pout << "Simulation time is " << loop_time << std::endl;
+         tbox::pout << "Current dt is " << dt_now << std::endl;
+         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++\n\n" << std::endl;
+         tbox::plog << std::endl << std::endl;
 
          double dt_new = time_integrator->advanceHierarchy(dt_now);
 
@@ -563,12 +562,12 @@ int main(
             patch_hierarchy->recursivePrint(tbox::plog, "L->", 1);
          }
 
-         tbox::plog << endl << endl;
-         tbox::pout << "\n\n++++++++++++++++++++++++++++++++++++++++++++" << endl;
-         tbox::pout << "At end of timestep # " << iteration_num - 1 << endl;
-         tbox::pout << "Simulation time is " << loop_time << endl;
-         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++\n\n" << endl;
-         tbox::plog << endl << endl;
+         tbox::plog << std::endl << std::endl;
+         tbox::pout << "\n\n++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
+         tbox::pout << "At end of timestep # " << iteration_num - 1 << std::endl;
+         tbox::pout << "Simulation time is " << loop_time << std::endl;
+         tbox::pout << "++++++++++++++++++++++++++++++++++++++++++++\n\n" << std::endl;
+         tbox::plog << std::endl << std::endl;
 
          /*
           * At specified intervals, write restart files.
@@ -604,9 +603,9 @@ int main(
          /*
           * Output statistics.
           */
-         tbox::plog << "HyperbolicLevelIntegrator statistics:" << endl;
+         tbox::plog << "HyperbolicLevelIntegrator statistics:" << std::endl;
          hyp_level_integrator->printStatistics(tbox::plog);
-         tbox::plog << "\nGriddingAlgorithm statistics:" << endl;
+         tbox::plog << "\nGriddingAlgorithm statistics:" << std::endl;
          gridding_algorithm->printStatistics(tbox::plog);
 
       } // End time-stepping loop.
@@ -681,7 +680,7 @@ int main(
    }
 
    if (num_failures == 0) {
-      tbox::pout << "\nPASSED:  Euler" << endl;
+      tbox::pout << "\nPASSED:  Euler" << std::endl;
    }
 
    tbox::SAMRAIManager::shutdown();

--- a/source/test/performance/LinAdv/LinAdv.C
+++ b/source/test/performance/LinAdv/LinAdv.C
@@ -25,7 +25,6 @@
 #endif
 #endif
 
-using namespace std;
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -116,7 +115,7 @@ using namespace std;
  */
 
 LinAdv::LinAdv(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    std::shared_ptr<tbox::Database> input_db,
    std::shared_ptr<geom::CartesianGridGeometry> grid_geom,
@@ -258,7 +257,7 @@ void LinAdv::setupLoadBalancer(
          TBOX_WARNING(
             d_object_name << ": "
                           << "  Unknown load balancer used in gridding algorithm."
-                          << "  Ignoring request for nonuniform load balancing." << endl);
+                          << "  Ignoring request for nonuniform load balancing." << std::endl);
          d_use_nonuniform_workload = false;
       }
    } else {
@@ -568,7 +567,7 @@ void LinAdv::computeFluxesOnPatch(
 
       }
 
-//     tbox::plog << "flux values: option1...." << endl;
+//     tbox::plog << "flux values: option1...." << std::endl;
 //     flux->print(pbox, tbox::plog);
    }
 }
@@ -862,7 +861,7 @@ void LinAdv::compute3DFluxesWithCornerTransport1(
       traced_right.getPointer(1),
       traced_right.getPointer(2));
 
-//     tbox::plog << "flux values: option1...." << endl;
+//     tbox::plog << "flux values: option1...." << std::endl;
 //     flux->print(pbox, tbox::plog);
 
 }
@@ -1090,7 +1089,7 @@ void LinAdv::compute3DFluxesWithCornerTransport2(
       traced_right.getPointer(1),
       traced_right.getPointer(2));
 
-//     tbox::plog << "flux values: option2...." << endl;
+//     tbox::plog << "flux values: option2...." << std::endl;
 //     flux->print(pbox, tbox::plog);
 }
 
@@ -1245,7 +1244,7 @@ void LinAdv::tagRichardsonExtrapolationCells(
    for (int ncrit = 0;
         ncrit < static_cast<int>(d_refinement_criteria.size()); ++ncrit) {
 
-      string ref = d_refinement_criteria[ncrit];
+      std::string ref = d_refinement_criteria[ncrit];
       std::shared_ptr<pdat::CellData<double> > coarsened_fine_var;
       std::shared_ptr<pdat::CellData<double> > advanced_coarse_var;
       int size;
@@ -1453,7 +1452,7 @@ void LinAdv::tagGradientDetectorCells(
       for (int ncrit = 0;
            ncrit < static_cast<int>(d_refinement_criteria.size()); ++ncrit) {
 
-         string ref = d_refinement_criteria[ncrit];
+         std::string ref = d_refinement_criteria[ncrit];
          std::shared_ptr<pdat::CellData<double> > var(
             SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
                patch.getPatchData(d_uval, getDataContext())));
@@ -1673,7 +1672,7 @@ bool LinAdv::packDerivedDataIntoDoubleBuffer(
    double* buffer,
    const hier::Patch& patch,
    const hier::Box& region,
-   const string& variable_name,
+   const std::string& variable_name,
    int depth_id,
    double simulation_time) const
 {
@@ -1696,102 +1695,102 @@ bool LinAdv::packDerivedDataIntoDoubleBuffer(
  */
 
 void LinAdv::printClassData(
-   ostream& os) const
+   std::ostream& os) const
 {
    int j;
 
-   os << "\nLinAdv::printClassData..." << endl;
-   os << "LinAdv: this = " << (LinAdv *)this << endl;
-   os << "d_object_name = " << d_object_name << endl;
+   os << "\nLinAdv::printClassData..." << std::endl;
+   os << "LinAdv: this = " << (LinAdv *)this << std::endl;
+   os << "d_object_name = " << d_object_name << std::endl;
    os << "d_grid_geometry = "
-      << d_grid_geometry.get() << endl;
+      << d_grid_geometry.get() << std::endl;
 
-   os << "Parameters for numerical method ..." << endl;
+   os << "Parameters for numerical method ..." << std::endl;
    os << "   d_advection_velocity = ";
    for (j = 0; j < d_dim.getValue(); ++j) os << d_advection_velocity[j] << " ";
-   os << endl;
-   os << "   d_godunov_order = " << d_godunov_order << endl;
-   os << "   d_corner_transport = " << d_corner_transport << endl;
-   os << "   d_nghosts = " << d_nghosts << endl;
-   os << "   d_fluxghosts = " << d_fluxghosts << endl;
-   os << "   Boundary condition data " << endl;
+   os << std::endl;
+   os << "   d_godunov_order = " << d_godunov_order << std::endl;
+   os << "   d_corner_transport = " << d_corner_transport << std::endl;
+   os << "   d_nghosts = " << d_nghosts << std::endl;
+   os << "   d_fluxghosts = " << d_fluxghosts << std::endl;
+   os << "   Boundary condition data " << std::endl;
 
-   os << "   Refinement criteria parameters " << endl;
+   os << "   Refinement criteria parameters " << std::endl;
 
    for (j = 0; j < static_cast<int>(d_refinement_criteria.size()); ++j) {
       os << "       d_refinement_criteria[" << j << "] = "
-         << d_refinement_criteria[j] << endl;
+         << d_refinement_criteria[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_dev_tol.size()); ++j) {
       os << "       d_dev_tol[" << j << "] = "
-         << d_dev_tol[j] << endl;
+         << d_dev_tol[j] << std::endl;
    }
    for (j = 0; j < static_cast<int>(d_dev.size()); ++j) {
       os << "       d_dev[" << j << "] = "
-         << d_dev[j] << endl;
+         << d_dev[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_dev_time_max.size()); ++j) {
       os << "       d_dev_time_max[" << j << "] = "
-         << d_dev_time_max[j] << endl;
+         << d_dev_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_dev_time_min.size()); ++j) {
       os << "       d_dev_time_min[" << j << "] = "
-         << d_dev_time_min[j] << endl;
+         << d_dev_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_grad_tol.size()); ++j) {
       os << "       d_grad_tol[" << j << "] = "
-         << d_grad_tol[j] << endl;
+         << d_grad_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_grad_time_max.size()); ++j) {
       os << "       d_grad_time_max[" << j << "] = "
-         << d_grad_time_max[j] << endl;
+         << d_grad_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_grad_time_min.size()); ++j) {
       os << "       d_grad_time_min[" << j << "] = "
-         << d_grad_time_min[j] << endl;
+         << d_grad_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_shock_onset.size()); ++j) {
       os << "       d_shock_onset[" << j << "] = "
-         << d_shock_onset[j] << endl;
+         << d_shock_onset[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_shock_tol.size()); ++j) {
       os << "       d_shock_tol[" << j << "] = "
-         << d_shock_tol[j] << endl;
+         << d_shock_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_shock_time_max.size()); ++j) {
       os << "       d_shock_time_max[" << j << "] = "
-         << d_shock_time_max[j] << endl;
+         << d_shock_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_shock_time_min.size()); ++j) {
       os << "       d_shock_time_min[" << j << "] = "
-         << d_shock_time_min[j] << endl;
+         << d_shock_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_rich_tol.size()); ++j) {
       os << "       d_rich_tol[" << j << "] = "
-         << d_rich_tol[j] << endl;
+         << d_rich_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_rich_time_max.size()); ++j) {
       os << "       d_rich_time_max[" << j << "] = "
-         << d_rich_time_max[j] << endl;
+         << d_rich_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_rich_time_min.size()); ++j) {
       os << "       d_rich_time_min[" << j << "] = "
-         << d_rich_time_min[j] << endl;
+         << d_rich_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
 
 }
 
@@ -1840,7 +1839,7 @@ void LinAdv::getFromInput(
           (d_godunov_order != 4)) {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "`godunov_order' in input must be 1, 2, or 4." << endl);
+                          << "`godunov_order' in input must be 1, 2, or 4." << std::endl);
       }
    } else {
       d_godunov_order = input_db->getIntegerWithDefault("d_godunov_order",
@@ -1854,7 +1853,7 @@ void LinAdv::getFromInput(
          TBOX_ERROR(
             d_object_name << ": "
                           << "`corner_transport' in input must be either string"
-                          << " 'CORNER_TRANSPORT_1' or 'CORNER_TRANSPORT_2'." << endl);
+                          << " 'CORNER_TRANSPORT_1' or 'CORNER_TRANSPORT_2'." << std::endl);
       }
    } else {
       d_corner_transport = input_db->getStringWithDefault("corner_transport",
@@ -1864,7 +1863,7 @@ void LinAdv::getFromInput(
    if (input_db->keyExists("Refinement_data")) {
       std::shared_ptr<tbox::Database> refine_db(
          input_db->getDatabase("Refinement_data"));
-      std::vector<string> refinement_keys = refine_db->getAllKeys();
+      std::vector<std::string> refinement_keys = refine_db->getAllKeys();
       int num_keys = static_cast<int>(refinement_keys.size());
 
       if (refine_db->keyExists("refine_criteria")) {
@@ -1874,15 +1873,15 @@ void LinAdv::getFromInput(
          TBOX_WARNING(
             d_object_name << ": "
                           << "No key `refine_criteria' found in data for"
-                          << " RefinementData. No refinement will occur." << endl);
+                          << " RefinementData. No refinement will occur." << std::endl);
       }
 
-      std::vector<string> ref_keys_defined(num_keys);
+      std::vector<std::string> ref_keys_defined(num_keys);
       int def_key_cnt = 0;
       std::shared_ptr<tbox::Database> error_db;
       for (int i = 0; i < num_keys; ++i) {
 
-         string error_key = refinement_keys[i];
+         std::string error_key = refinement_keys[i];
          error_db.reset();
 
          if (!(error_key == "refine_criteria")) {
@@ -1895,7 +1894,7 @@ void LinAdv::getFromInput(
                   d_object_name << ": "
                                 << "Unknown refinement criteria: "
                                 << error_key
-                                << "\nin input." << endl);
+                                << "\nin input." << std::endl);
             } else {
                error_db = refine_db->getDatabase(error_key);
                ref_keys_defined[def_key_cnt] = error_key;
@@ -1910,7 +1909,7 @@ void LinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `dev_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("uval_dev")) {
@@ -1919,7 +1918,7 @@ void LinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `uval_dev' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -1946,7 +1945,7 @@ void LinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `grad_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -1973,7 +1972,7 @@ void LinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `shock_onset' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("shock_tol")) {
@@ -1982,7 +1981,7 @@ void LinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `shock_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -2009,7 +2008,7 @@ void LinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `rich_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -2037,17 +2036,17 @@ void LinAdv::getFromInput(
        */
       for (int k0 = 0;
            k0 < static_cast<int>(d_refinement_criteria.size()); ++k0) {
-         string use_key = d_refinement_criteria[k0];
+         std::string use_key = d_refinement_criteria[k0];
          bool key_found = false;
          for (int k1 = 0; k1 < def_key_cnt; ++k1) {
-            string def_key = ref_keys_defined[k1];
+            std::string def_key = ref_keys_defined[k1];
             if (def_key == use_key) key_found = true;
          }
 
          if (!key_found) {
             TBOX_ERROR(d_object_name << ": "
                                      << "No input found for specified refine criteria: "
-                                     << d_refinement_criteria[k0] << endl);
+                                     << d_refinement_criteria[k0] << std::endl);
          }
       }
 
@@ -2153,14 +2152,14 @@ void LinAdv::getFromRestart()
    if (!(d_nghosts == CELLG)) {
       TBOX_ERROR(
          d_object_name << ": "
-                       << "Key data `d_nghosts' in restart file != CELLG." << endl);
+                       << "Key data `d_nghosts' in restart file != CELLG." << std::endl);
    }
    int* tmp_fluxghosts = &d_fluxghosts[0];
    db->getIntegerArray("d_fluxghosts", tmp_fluxghosts, d_dim.getValue());
    if (!(d_fluxghosts == FLUXG)) {
       TBOX_ERROR(
          d_object_name << ": "
-                       << "Key data `d_fluxghosts' in restart file != FLUXG." << endl);
+                       << "Key data `d_fluxghosts' in restart file != FLUXG." << std::endl);
    }
 
    if (db->keyExists("d_refinement_criteria")) {
@@ -2193,7 +2192,7 @@ void LinAdv::getFromRestart()
 
 void LinAdv::readStateDataEntry(
    std::shared_ptr<tbox::Database> db,
-   const string& db_name,
+   const std::string& db_name,
    int array_indx,
    std::vector<double>& uval)
 {
@@ -2207,7 +2206,7 @@ void LinAdv::readStateDataEntry(
    } else {
       TBOX_ERROR(d_object_name << ": "
                                << "`uval' entry missing from " << db_name
-                               << " input database. " << endl);
+                               << " input database. " << std::endl);
    }
 
 }

--- a/source/test/performance/LinAdv/LinAdv.h
+++ b/source/test/performance/LinAdv/LinAdv.h
@@ -28,7 +28,6 @@
 #include <string>
 #include <vector>
 #include <memory>
-using namespace std;
 #define included_String
 #include "SAMRAI/hier/VariableContext.h"
 #include "SAMRAI/appu/VisItDataWriter.h"
@@ -76,7 +75,7 @@ public:
     * database (potentially overriding those found in the restart file).
     */
    LinAdv(
-      const string& object_name,
+      const std::string& object_name,
       const tbox::Dimension& dim,
       std::shared_ptr<tbox::Database> input_db,
       std::shared_ptr<geom::CartesianGridGeometry> grid_geom,
@@ -332,7 +331,7 @@ public:
     */
    void
    printClassData(
-      ostream& os) const;
+      std::ostream& os) const;
 
    //@{ @name SAMRAI::appu::VisDerivedDataStrategy virtuals
 
@@ -341,7 +340,7 @@ public:
       double* buffer,
       const hier::Patch& patch,
       const hier::Box& region,
-      const string& variable_name,
+      const std::string& variable_name,
       int depth_id,
       double simulation_time) const;
 
@@ -366,7 +365,7 @@ private:
    void
    readStateDataEntry(
       std::shared_ptr<tbox::Database> db,
-      const string& db_name,
+      const std::string& db_name,
       int array_indx,
       std::vector<double>& uval);
 
@@ -388,7 +387,7 @@ private:
     * The object name is used for error/warning reporting and also as a
     * string label for restart database entries.
     */
-   string d_object_name;
+   std::string d_object_name;
 
    const tbox::Dimension d_dim;
 
@@ -438,7 +437,7 @@ private:
     *
     */
    int d_godunov_order;
-   string d_corner_transport;
+   std::string d_corner_transport;
    hier::IntVector d_nghosts;
    hier::IntVector d_fluxghosts;
 
@@ -452,7 +451,7 @@ private:
     * Refinement criteria parameters for gradient detector and
     * Richardson extrapolation.
     */
-   std::vector<string> d_refinement_criteria;
+   std::vector<std::string> d_refinement_criteria;
    std::vector<double> d_dev_tol;
    std::vector<double> d_dev;
    std::vector<double> d_dev_time_max;

--- a/source/test/performance/LinAdv/main.C
+++ b/source/test/performance/LinAdv/main.C
@@ -15,7 +15,6 @@
 #include <string>
 #include <fstream>
 #include <memory>
-using namespace std;
 
 #ifndef _MSC_VER
 #include <unistd.h>
@@ -185,8 +184,8 @@ int main(
    int num_failures = 0;
 
    {
-      string input_filename;
-      string case_name;
+      std::string input_filename;
+      std::string case_name;
       int scale_size = mpi.getSize();
 
       if ((argc != 2) && (argc != 3) && (argc != 4)) {
@@ -196,7 +195,7 @@ int main(
                     << argv[0] << " <input filename> <case name>"
                     << "or\n"
                     << argv[0] << " <input filename> <case name> <scale size> "
-                    << endl;
+                    << std::endl;
          tbox::SAMRAI_MPI::abort();
          return -1;
       } else {
@@ -209,7 +208,7 @@ int main(
          }
       }
 
-      pout << "input_filename = " << input_filename << endl;
+      pout << "input_filename = " << input_filename << std::endl;
       pout << "case_name = " << case_name << std::endl;
       pout << "scale_size = " << scale_size << std::endl;
 
@@ -243,18 +242,18 @@ int main(
       bool use_scaled_input = main_db->getBoolWithDefault("use_scaled_input",
             true);
 
-      string scaled_input_str =
-         string("ScaledInput")
-         + (use_scaled_input ? tbox::Utilities::intToString(scale_size) : string());
+      std::string scaled_input_str =
+         std::string("ScaledInput")
+         + (use_scaled_input ? tbox::Utilities::intToString(scale_size) : std::string());
       std::shared_ptr<Database> scaled_input_db(input_db->getDatabase(scaled_input_str));
 
-      string base_name = main_db->getStringWithDefault("base_name", "unnamed");
+      std::string base_name = main_db->getStringWithDefault("base_name", "unnamed");
 
       /*
        * Modify basename for this particular run.
        * Add the number of processes and the case name.
        */
-      string base_name_ext = base_name;
+      std::string base_name_ext = base_name;
       if (!case_name.empty()) {
          base_name_ext = base_name_ext + '-' + case_name;
       }
@@ -266,7 +265,7 @@ int main(
       /*
        * Logging.
        */
-      string log_filename = base_name_ext + ".log";
+      std::string log_filename = base_name_ext + ".log";
       log_filename =
          main_db->getStringWithDefault("log_filename", base_name_ext + ".log");
 
@@ -284,7 +283,7 @@ int main(
          viz_dump_interval = main_db->getInteger("viz_dump_interval");
       }
 
-      const string viz_dump_dirname = main_db->getStringWithDefault(
+      const std::string viz_dump_dirname = main_db->getStringWithDefault(
             "viz_dump_dirname", base_name_ext + ".visit");
       int visit_number_procs_per_file = 1;
 
@@ -295,7 +294,7 @@ int main(
          restart_interval = main_db->getInteger("restart_interval");
       }
 
-      string restart_write_dirname;
+      std::string restart_write_dirname;
       if (restart_interval > 0) {
          if (main_db->keyExists("restart_write_dirname")) {
             restart_write_dirname = main_db->getString("restart_write_dirname");
@@ -307,7 +306,7 @@ int main(
 
       bool use_refined_timestepping = true;
       if (main_db->keyExists("timestepping")) {
-         string timestepping_method = main_db->getString("timestepping");
+         std::string timestepping_method = main_db->getString("timestepping");
          if (timestepping_method == "SYNCHRONIZED") {
             use_refined_timestepping = false;
          }
@@ -519,13 +518,13 @@ int main(
        */
 
       if (mpi.getRank() == 0) {
-         plog << "\nCheck input data and variables before simulation:" << endl;
-         plog << "Input database..." << endl;
+         plog << "\nCheck input data and variables before simulation:" << std::endl;
+         plog << "Input database..." << std::endl;
          input_db->printClassData(plog);
-         plog << "\nVariable database..." << endl;
+         plog << "\nVariable database..." << std::endl;
          hier::VariableDatabase::getDatabase()->printClassData(plog);
 
-         plog << "\nCheck Linear Advection data... " << endl;
+         plog << "\nCheck Linear Advection data... " << std::endl;
          linear_advection_model->printClassData(plog);
       }
 
@@ -555,9 +554,9 @@ int main(
 
          iteration_num = time_integrator->getIntegratorStep() + 1;
 
-         pout << "++++++++++++++++++++++++++++++++++++++++++++" << endl;
-         pout << "At begining of timestep # " << iteration_num - 1 << endl;
-         pout << "Simulation time is " << loop_time << endl;
+         pout << "++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
+         pout << "At begining of timestep # " << iteration_num - 1 << std::endl;
+         pout << "Simulation time is " << loop_time << std::endl;
 
          double dt_new = time_integrator->advanceHierarchy(dt_now);
 
@@ -575,9 +574,9 @@ int main(
             patch_hierarchy->recursivePrint(plog, "L->", 1);
          }
 
-         pout << "At end of timestep # " << iteration_num - 1 << endl;
-         pout << "Simulation time is " << loop_time << endl;
-         pout << "++++++++++++++++++++++++++++++++++++++++++++" << endl;
+         pout << "At end of timestep # " << iteration_num - 1 << std::endl;
+         pout << "Simulation time is " << loop_time << std::endl;
+         pout << "++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
 
          /*
           * At specified intervals, write restart and visualization files.
@@ -611,9 +610,9 @@ int main(
          /*
           * Output statistics.
           */
-         tbox::plog << "HyperbolicLevelIntegrator statistics:" << endl;
+         tbox::plog << "HyperbolicLevelIntegrator statistics:" << std::endl;
          hyp_level_integrator->printStatistics(tbox::plog);
-         tbox::plog << "\nGriddingAlgorithm statistics:" << endl;
+         tbox::plog << "\nGriddingAlgorithm statistics:" << std::endl;
          gridding_algorithm->printStatistics(tbox::plog);
 #endif
       } // End time-stepping loop.
@@ -655,7 +654,7 @@ int main(
       t_all->stop();
       int size = tbox::SAMRAI_MPI::getSAMRAIWorld().getSize();
       if (tbox::SAMRAI_MPI::getSAMRAIWorld().getRank() == 0) {
-         string timing_file =
+         std::string timing_file =
             base_name + ".timing" + tbox::Utilities::intToString(size);
          FILE* fp = fopen(timing_file.c_str(), "w");
          fprintf(fp, "%f\n", t_all->getTotalWallclockTime());
@@ -687,7 +686,7 @@ int main(
    }
 
    if (num_failures == 0) {
-      tbox::pout << "\nPASSED:  LinAdv" << endl;
+      tbox::pout << "\nPASSED:  LinAdv" << std::endl;
    }
 
    tbox::SAMRAIManager::shutdown();

--- a/source/test/performance/multiblock/MblkLinAdv.C
+++ b/source/test/performance/multiblock/MblkLinAdv.C
@@ -25,7 +25,6 @@
 #endif
 #endif
 
-using namespace std;
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -539,7 +538,7 @@ MblkLinAdv::MblkLinAdv(
          d_object_name << ": "
                        << "Unknown d_data_problem string = "
                        << d_data_problem
-                       << " encountered in constructor" << endl);
+                       << " encountered in constructor" << std::endl);
    }
 
    /*
@@ -703,7 +702,7 @@ void MblkLinAdv::registerModelVariables(
          d_object_name << ": registerModelVariables()"
                        << "\nVisIt data writer was"
                        << "\nregistered.  Consequently, no plot data will"
-                       << "\nbe written." << endl);
+                       << "\nbe written." << std::endl);
    }
 #endif
 
@@ -1150,7 +1149,7 @@ void MblkLinAdv::computeFluxesOnPatch(
 
       }
 
-//     tbox::plog << "flux values: option1...." << endl;
+//     tbox::plog << "flux values: option1...." << std::endl;
 //     flux->print(pbox, tbox::plog);
    }
 
@@ -1453,7 +1452,7 @@ void MblkLinAdv::compute3DFluxesWithCornerTransport1(
       traced_right.getPointer(1),
       traced_right.getPointer(2));
 
-//     tbox::plog << "flux values: option1...." << endl;
+//     tbox::plog << "flux values: option1...." << std::endl;
 //     flux->print(pbox, tbox::plog);
 
 }
@@ -1688,7 +1687,7 @@ void MblkLinAdv::compute3DFluxesWithCornerTransport2(
       traced_right.getPointer(1),
       traced_right.getPointer(2));
 
-//     tbox::plog << "flux values: option2...." << endl;
+//     tbox::plog << "flux values: option2...." << std::endl;
 //     flux->print(pbox, tbox::plog);
 }
 
@@ -2202,7 +2201,7 @@ void MblkLinAdv::tagGradientDetectorCells(
       (*tags)(*ic, 0) = (*temp_tags)(*ic, 0);
    }
 
-//   tbox::plog << "--------------------- end tagGradientCells" << endl;
+//   tbox::plog << "--------------------- end tagGradientCells" << std::endl;
 
 }
 
@@ -2255,7 +2254,7 @@ void MblkLinAdv::setMappedGridOnPatch(
    int num_domain_boxes = domain_boxes.size();
 
    if (num_domain_boxes > 1) {
-      TBOX_ERROR("Sorry, cannot handle non-rectangular domains..." << endl);
+      TBOX_ERROR("Sorry, cannot handle non-rectangular domains..." << std::endl);
    }
 
    int xyz_id = hier::VariableDatabase::getDatabase()->
@@ -2299,164 +2298,164 @@ void MblkLinAdv::printClassData(
 {
    int j, k;
 
-   os << "\nMblkLinAdv::printClassData..." << endl;
-   os << "MblkLinAdv: this = " << (MblkLinAdv *)this << endl;
-   os << "d_object_name = " << d_object_name << endl;
-   os << "d_grid_geometry = " << endl;
+   os << "\nMblkLinAdv::printClassData..." << std::endl;
+   os << "MblkLinAdv: this = " << (MblkLinAdv *)this << std::endl;
+   os << "d_object_name = " << d_object_name << std::endl;
+   os << "d_grid_geometry = " << std::endl;
 //   for (j=0; j < d_grid_geometry.getSize(); ++j) {
-//      os << (*((std::shared_ptr<geom::GridGeometry >)(d_grid_geometry[j]))) << endl;
+//      os << (*((std::shared_ptr<geom::GridGeometry >)(d_grid_geometry[j]))) << std::endl;
 //   }
 
-   os << "Parameters for numerical method ..." << endl;
+   os << "Parameters for numerical method ..." << std::endl;
    os << "   d_advection_velocity = ";
    for (j = 0; j < d_dim.getValue(); ++j) os << d_advection_velocity[j] << " ";
-   os << endl;
-   os << "   d_godunov_order = " << d_godunov_order << endl;
-   os << "   d_corner_transport = " << d_corner_transport << endl;
-   os << "   d_nghosts = " << d_nghosts << endl;
-   os << "   d_fluxghosts = " << d_fluxghosts << endl;
+   os << std::endl;
+   os << "   d_godunov_order = " << d_godunov_order << std::endl;
+   os << "   d_corner_transport = " << d_corner_transport << std::endl;
+   os << "   d_nghosts = " << d_nghosts << std::endl;
+   os << "   d_fluxghosts = " << d_fluxghosts << std::endl;
 
-   os << "Problem description and initial data..." << endl;
-   os << "   d_data_problem = " << d_data_problem << endl;
-   os << "   d_data_problem_int = " << d_data_problem << endl;
+   os << "Problem description and initial data..." << std::endl;
+   os << "   d_data_problem = " << d_data_problem << std::endl;
+   os << "   d_data_problem_int = " << d_data_problem << std::endl;
 
-   os << "       d_radius = " << d_radius << endl;
+   os << "       d_radius = " << d_radius << std::endl;
    os << "       d_center = ";
    for (j = 0; j < d_dim.getValue(); ++j) os << d_center[j] << " ";
-   os << endl;
-   os << "       d_uval_inside = " << d_uval_inside << endl;
-   os << "       d_uval_outside = " << d_uval_outside << endl;
+   os << std::endl;
+   os << "       d_uval_inside = " << d_uval_inside << std::endl;
+   os << "       d_uval_outside = " << d_uval_outside << std::endl;
 
-   os << "       d_number_of_intervals = " << d_number_of_intervals << endl;
+   os << "       d_number_of_intervals = " << d_number_of_intervals << std::endl;
    os << "       d_front_position = ";
    for (k = 0; k < d_number_of_intervals - 1; ++k) {
       os << d_front_position[k] << "  ";
    }
-   os << endl;
-   os << "       d_interval_uval = " << endl;
+   os << std::endl;
+   os << "       d_interval_uval = " << std::endl;
    for (k = 0; k < d_number_of_intervals; ++k) {
-      os << "            " << d_interval_uval[k] << endl;
+      os << "            " << d_interval_uval[k] << std::endl;
    }
-   os << "   Boundary condition data " << endl;
+   os << "   Boundary condition data " << std::endl;
 
    if (d_dim == tbox::Dimension(2)) {
       for (j = 0; j < static_cast<int>(d_scalar_bdry_edge_conds.size()); ++j) {
          os << "       d_scalar_bdry_edge_conds[" << j << "] = "
-            << d_scalar_bdry_edge_conds[j] << endl;
+            << d_scalar_bdry_edge_conds[j] << std::endl;
          if (d_scalar_bdry_edge_conds[j] == BdryCond::DIRICHLET) {
             os << "         d_bdry_edge_uval[" << j << "] = "
-               << d_bdry_edge_uval[j] << endl;
+               << d_bdry_edge_uval[j] << std::endl;
          }
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_scalar_bdry_node_conds.size()); ++j) {
          os << "       d_scalar_bdry_node_conds[" << j << "] = "
-            << d_scalar_bdry_node_conds[j] << endl;
+            << d_scalar_bdry_node_conds[j] << std::endl;
          os << "       d_node_bdry_edge[" << j << "] = "
-            << d_node_bdry_edge[j] << endl;
+            << d_node_bdry_edge[j] << std::endl;
       }
    }
    if (d_dim == tbox::Dimension(3)) {
       for (j = 0; j < static_cast<int>(d_scalar_bdry_face_conds.size()); ++j) {
          os << "       d_scalar_bdry_face_conds[" << j << "] = "
-            << d_scalar_bdry_face_conds[j] << endl;
+            << d_scalar_bdry_face_conds[j] << std::endl;
          if (d_scalar_bdry_face_conds[j] == BdryCond::DIRICHLET) {
             os << "         d_bdry_face_uval[" << j << "] = "
-               << d_bdry_face_uval[j] << endl;
+               << d_bdry_face_uval[j] << std::endl;
          }
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_scalar_bdry_edge_conds.size()); ++j) {
          os << "       d_scalar_bdry_edge_conds[" << j << "] = "
-            << d_scalar_bdry_edge_conds[j] << endl;
+            << d_scalar_bdry_edge_conds[j] << std::endl;
          os << "       d_edge_bdry_face[" << j << "] = "
-            << d_edge_bdry_face[j] << endl;
+            << d_edge_bdry_face[j] << std::endl;
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_scalar_bdry_node_conds.size()); ++j) {
          os << "       d_scalar_bdry_node_conds[" << j << "] = "
-            << d_scalar_bdry_node_conds[j] << endl;
+            << d_scalar_bdry_node_conds[j] << std::endl;
          os << "       d_node_bdry_face[" << j << "] = "
-            << d_node_bdry_face[j] << endl;
+            << d_node_bdry_face[j] << std::endl;
       }
    }
 
-   os << "   Refinement criteria parameters " << endl;
+   os << "   Refinement criteria parameters " << std::endl;
 
    for (j = 0; j < static_cast<int>(d_refinement_criteria.size()); ++j) {
       os << "       d_refinement_criteria[" << j << "] = "
-         << d_refinement_criteria[j] << endl;
+         << d_refinement_criteria[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_dev_tol.size()); ++j) {
       os << "       d_dev_tol[" << j << "] = "
-         << d_dev_tol[j] << endl;
+         << d_dev_tol[j] << std::endl;
    }
    for (j = 0; j < static_cast<int>(d_dev.size()); ++j) {
       os << "       d_dev[" << j << "] = "
-         << d_dev[j] << endl;
+         << d_dev[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_dev_time_max.size()); ++j) {
       os << "       d_dev_time_max[" << j << "] = "
-         << d_dev_time_max[j] << endl;
+         << d_dev_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_dev_time_min.size()); ++j) {
       os << "       d_dev_time_min[" << j << "] = "
-         << d_dev_time_min[j] << endl;
+         << d_dev_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_grad_tol.size()); ++j) {
       os << "       d_grad_tol[" << j << "] = "
-         << d_grad_tol[j] << endl;
+         << d_grad_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_grad_time_max.size()); ++j) {
       os << "       d_grad_time_max[" << j << "] = "
-         << d_grad_time_max[j] << endl;
+         << d_grad_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_grad_time_min.size()); ++j) {
       os << "       d_grad_time_min[" << j << "] = "
-         << d_grad_time_min[j] << endl;
+         << d_grad_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_shock_onset.size()); ++j) {
       os << "       d_shock_onset[" << j << "] = "
-         << d_shock_onset[j] << endl;
+         << d_shock_onset[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_shock_tol.size()); ++j) {
       os << "       d_shock_tol[" << j << "] = "
-         << d_shock_tol[j] << endl;
+         << d_shock_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_shock_time_max.size()); ++j) {
       os << "       d_shock_time_max[" << j << "] = "
-         << d_shock_time_max[j] << endl;
+         << d_shock_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_shock_time_min.size()); ++j) {
       os << "       d_shock_time_min[" << j << "] = "
-         << d_shock_time_min[j] << endl;
+         << d_shock_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_rich_tol.size()); ++j) {
       os << "       d_rich_tol[" << j << "] = "
-         << d_rich_tol[j] << endl;
+         << d_rich_tol[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_rich_time_max.size()); ++j) {
       os << "       d_rich_time_max[" << j << "] = "
-         << d_rich_time_max[j] << endl;
+         << d_rich_time_max[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
    for (j = 0; j < static_cast<int>(d_rich_time_min.size()); ++j) {
       os << "       d_rich_time_min[" << j << "] = "
-         << d_rich_time_min[j] << endl;
+         << d_rich_time_min[j] << std::endl;
    }
-   os << endl;
+   os << std::endl;
 
 }
 
@@ -2507,7 +2506,7 @@ void MblkLinAdv::getFromInput(
           (d_godunov_order != 4)) {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "`godunov_order' in input must be 1, 2, or 4." << endl);
+                          << "`godunov_order' in input must be 1, 2, or 4." << std::endl);
       }
    } else {
       d_godunov_order = db->getIntegerWithDefault("d_godunov_order",
@@ -2521,7 +2520,7 @@ void MblkLinAdv::getFromInput(
          TBOX_ERROR(
             d_object_name << ": "
                           << "`corner_transport' in input must be either string"
-                          << " 'CORNER_TRANSPORT_1' or 'CORNER_TRANSPORT_2'." << endl);
+                          << " 'CORNER_TRANSPORT_1' or 'CORNER_TRANSPORT_2'." << std::endl);
       }
    } else {
       d_corner_transport = db->getStringWithDefault("corner_transport",
@@ -2540,7 +2539,7 @@ void MblkLinAdv::getFromInput(
          TBOX_WARNING(
             d_object_name << ": "
                           << "No key `refine_criteria' found in data for"
-                          << " RefinementData. No refinement will occur." << endl);
+                          << " RefinementData. No refinement will occur." << std::endl);
       }
 
       std::vector<string> ref_keys_defined(num_keys);
@@ -2561,7 +2560,7 @@ void MblkLinAdv::getFromInput(
                   d_object_name << ": "
                                 << "Unknown refinement criteria: "
                                 << error_key
-                                << "\nin input." << endl);
+                                << "\nin input." << std::endl);
             } else {
                error_db = refine_db->getDatabase(error_key);
                ref_keys_defined[def_key_cnt] = error_key;
@@ -2576,7 +2575,7 @@ void MblkLinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `dev_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("uval_dev")) {
@@ -2585,7 +2584,7 @@ void MblkLinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `uval_dev' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -2612,7 +2611,7 @@ void MblkLinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `grad_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -2639,7 +2638,7 @@ void MblkLinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `shock_onset' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("shock_tol")) {
@@ -2648,7 +2647,7 @@ void MblkLinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `shock_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -2675,7 +2674,7 @@ void MblkLinAdv::getFromInput(
                   TBOX_ERROR(
                      d_object_name << ": "
                                    << "No key `rich_tol' found in data for "
-                                   << error_key << endl);
+                                   << error_key << std::endl);
                }
 
                if (error_db->keyExists("time_max")) {
@@ -2708,13 +2707,13 @@ void MblkLinAdv::getFromInput(
          TBOX_ERROR(
             d_object_name << ": "
                           << "`data_problem' value not found in input."
-                          << endl);
+                          << std::endl);
       }
 
       if (!db->keyExists("Initial_data")) {
          TBOX_ERROR(
             d_object_name << ": "
-                          << "No `Initial_data' database found in input." << endl);
+                          << "No `Initial_data' database found in input." << std::endl);
       }
       std::shared_ptr<tbox::Database> init_data_db(
          db->getDatabase("Initial_data"));
@@ -2728,28 +2727,28 @@ void MblkLinAdv::getFromInput(
          } else {
             TBOX_ERROR(
                d_object_name << ": "
-                             << "`radius' input required for SPHERE problem." << endl);
+                             << "`radius' input required for SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("center")) {
             init_data_db->getDoubleArray("center", d_center, d_dim.getValue());
          } else {
             TBOX_ERROR(
                d_object_name << ": "
-                             << "`center' input required for SPHERE problem." << endl);
+                             << "`center' input required for SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("uval_inside")) {
             d_uval_inside = init_data_db->getDouble("uval_inside");
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`uval_inside' input required for "
-                                     << "SPHERE problem." << endl);
+                                     << "SPHERE problem." << std::endl);
          }
          if (init_data_db->keyExists("uval_outside")) {
             d_uval_outside = init_data_db->getDouble("uval_outside");
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`uval_outside' input required for "
-                                     << "SPHERE problem." << endl);
+                                     << "SPHERE problem." << std::endl);
          }
 
          found_problem_data = true;
@@ -2769,7 +2768,7 @@ void MblkLinAdv::getFromInput(
                TBOX_ERROR(
                   d_object_name << ": `PIECEWISE_CONSTANT_Y' "
                                 << "problem invalid in 1 dimension."
-                                << endl);
+                                << std::endl);
             }
          }
 
@@ -2777,7 +2776,7 @@ void MblkLinAdv::getFromInput(
             if (d_dim < tbox::Dimension(3)) {
                TBOX_ERROR(
                   d_object_name << ": `PIECEWISE_CONSTANT_Z' "
-                                << "problem invalid in 1 or 2 dimensions." << endl);
+                                << "problem invalid in 1 or 2 dimensions." << std::endl);
             }
          }
 
@@ -2788,7 +2787,7 @@ void MblkLinAdv::getFromInput(
          } else {
             TBOX_ERROR(d_object_name << ": "
                                      << "`front_position' input required for "
-                                     << d_data_problem << " problem." << endl);
+                                     << d_data_problem << " problem." << std::endl);
          }
 
          d_number_of_intervals =
@@ -2815,7 +2814,7 @@ void MblkLinAdv::getFromInput(
                } else {
                   TBOX_ERROR(d_object_name << ": "
                                            << "`uval' data missing in input for key = "
-                                           << init_data_keys[nkey] << endl);
+                                           << init_data_keys[nkey] << std::endl);
                }
                ++i;
 
@@ -2838,7 +2837,7 @@ void MblkLinAdv::getFromInput(
             } else {
                TBOX_ERROR(
                   d_object_name << ": "
-                                << "`frequency' input required for SINE problem." << endl);
+                                << "`frequency' input required for SINE problem." << std::endl);
             }
          }
 
@@ -2847,7 +2846,7 @@ void MblkLinAdv::getFromInput(
                d_object_name << ": "
                              << "Insufficient interval data given in input"
                              << " for PIECEWISE_CONSTANT_*problem."
-                             << endl);
+                             << std::endl);
          }
 
          found_problem_data = true;
@@ -2856,7 +2855,7 @@ void MblkLinAdv::getFromInput(
       if (!found_problem_data) {
          TBOX_ERROR(d_object_name << ": "
                                   << "`Initial_data' database found in input."
-                                  << " But bad data supplied." << endl);
+                                  << " But bad data supplied." << std::endl);
       }
 
    } // if !is_from_restart read in problem data
@@ -2873,7 +2872,7 @@ void MblkLinAdv::getFromInput(
     */
    if ((d_grid_geometry->getNumberBlocks() > 1) && (num_per_dirs > 0)) {
       TBOX_ERROR(d_object_name << ": cannot have periodic BCs when there"
-                               << "\nare multiple blocks." << endl);
+                               << "\nare multiple blocks." << std::endl);
    }
 
    if (db->keyExists("Boundary_data")) {
@@ -2900,7 +2899,7 @@ void MblkLinAdv::getFromInput(
    } else {
       TBOX_ERROR(
          d_object_name << ": "
-                       << "Key data `Boundary_data' not found in input. " << endl);
+                       << "Key data `Boundary_data' not found in input. " << std::endl);
    }
 
 }
@@ -3137,7 +3136,7 @@ void MblkLinAdv::readStateDataEntry(
    } else {
       TBOX_ERROR(d_object_name << ": "
                                << "`uval' entry missing from " << db_name
-                               << " input database. " << endl);
+                               << " input database. " << std::endl);
    }
 
 }

--- a/source/test/performance/multiblock/MblkLinAdv.h
+++ b/source/test/performance/multiblock/MblkLinAdv.h
@@ -29,7 +29,6 @@
 #include <string>
 #include <vector>
 #include <memory>
-using namespace std;
 #define included_String
 #include "SAMRAI/hier/TimeInterpolateOperator.h"
 #include "SAMRAI/hier/VariableContext.h"

--- a/source/test/performance/multiblock/SkeletonOutersideDoubleWeightedAverage.C
+++ b/source/test/performance/multiblock/SkeletonOutersideDoubleWeightedAverage.C
@@ -221,7 +221,7 @@ void SkeletonOutersideDoubleWeightedAverage::coarsen(
                cdata->getPointer(2, i, d));
          } else {
             TBOX_ERROR("SkeletonOutersideDoubleWeightedAverage error...\n"
-               << "d_dim > 3 not supported." << endl);
+               << "d_dim > 3 not supported." << std::endl);
          }
       }
    }

--- a/source/test/performance/multiblock/SkeletonOutersideDoubleWeightedAverage.h
+++ b/source/test/performance/multiblock/SkeletonOutersideDoubleWeightedAverage.h
@@ -23,7 +23,6 @@
 #include "SAMRAI/hier/CoarsenOperator.h"
 
 
-using namespace std;
 using namespace SAMRAI;
 
 /**

--- a/source/test/performance/multiblock/main.C
+++ b/source/test/performance/multiblock/main.C
@@ -14,7 +14,6 @@
 #include <cstdlib>
 #include <string>
 #include <fstream>
-using namespace std;
 
 #ifndef _MSC_VER
 #include <unistd.h>
@@ -180,7 +179,7 @@ int main(
                     << "<restart dir> <restore number> [options]\n"
                     << "  options:\n"
                     << "  none at this time"
-                    << endl;
+                    << std::endl;
          tbox::SAMRAI_MPI::abort();
          return -1;
       } else {
@@ -193,9 +192,9 @@ int main(
          }
       }
 
-      tbox::plog << "input_filename = " << input_filename << endl;
-      tbox::plog << "restart_read_dirname = " << restart_read_dirname << endl;
-      tbox::plog << "restore_num = " << restore_num << endl;
+      tbox::plog << "input_filename = " << input_filename << std::endl;
+      tbox::plog << "restart_read_dirname = " << restart_read_dirname << std::endl;
+      tbox::plog << "restore_num = " << restore_num << std::endl;
 
       /*
        * Create input database and parse all data in input file.
@@ -284,7 +283,7 @@ int main(
             TBOX_ERROR("main(): "
                << "\nviz_dump_dirname is null ... "
                << "\nThis must be specified for use with VisIt"
-               << endl);
+               << std::endl);
          }
          if (main_db->keyExists("visit_number_procs_per_file")) {
             visit_number_procs_per_file =
@@ -434,13 +433,13 @@ int main(
        */
 
       tbox::plog << "\nCheck input data and variables before simulation:"
-                 << endl;
-      tbox::plog << "Input database..." << endl;
+                 << std::endl;
+      tbox::plog << "Input database..." << std::endl;
       input_db->printClassData(tbox::plog);
-      tbox::plog << "\nVariable database..." << endl;
+      tbox::plog << "\nVariable database..." << std::endl;
       hier::VariableDatabase::getDatabase()->printClassData(tbox::plog);
 
-      tbox::plog << "\nCheck Linear Advection data... " << endl;
+      tbox::plog << "\nCheck Linear Advection data... " << std::endl;
       linear_advection_model->printClassData(tbox::plog);
 
       if (viz_dump_data) {
@@ -468,10 +467,10 @@ int main(
          iteration_num = time_integrator->getIntegratorStep() + 1;
 
          if ((iteration_num - 1) % 25 == 0) {
-            tbox::pout << "+++++++++++++++++++++++++++++++++++++++++" << endl;
+            tbox::pout << "+++++++++++++++++++++++++++++++++++++++++" << std::endl;
             tbox::pout << "At begining of timestep # " << iteration_num - 1
-                       << endl;
-            tbox::pout << "Simulation time is " << loop_time << endl;
+                       << std::endl;
+            tbox::pout << "Simulation time is " << loop_time << std::endl;
          }
 
          double dt_new = time_integrator->advanceHierarchy(dt_now);
@@ -480,9 +479,9 @@ int main(
          dt_now = dt_new;
 
          if ((iteration_num - 1) % 25 == 0) {
-            tbox::pout << "At end of timestep # " << iteration_num - 1 << endl;
-            tbox::pout << "Simulation time is " << loop_time << endl;
-            tbox::pout << "+++++++++++++++++++++++++++++++++++++++++" << endl;
+            tbox::pout << "At end of timestep # " << iteration_num - 1 << std::endl;
+            tbox::pout << "Simulation time is " << loop_time << std::endl;
+            tbox::pout << "+++++++++++++++++++++++++++++++++++++++++" << std::endl;
          }
 
          /*
@@ -559,7 +558,7 @@ int main(
    tbox::SAMRAIManager::finalize();
    tbox::SAMRAI_MPI::finalize();
 
-   tbox::pout << "\nPASSED:  MblkLinAdv" << endl;
+   tbox::pout << "\nPASSED:  MblkLinAdv" << std::endl;
 
    return 0;
 }

--- a/source/test/restartdb/database_tests.C
+++ b/source/test/restartdb/database_tests.C
@@ -34,7 +34,7 @@ void writeTestData(
 {
    if (!db) {
       tbox::perr << "FAILED: - Test #0-write: database to write to is null"
-                 << endl;
+                 << std::endl;
       tbox::SAMRAI_MPI::abort();
    }
 
@@ -57,26 +57,26 @@ void writeTestData(
    NULL_USE(defaultdb);
 
    if (!arraydb) {
-      tbox::perr << "FAILED: - Test #1a-write: `arraydb' is null" << endl;
+      tbox::perr << "FAILED: - Test #1a-write: `arraydb' is null" << std::endl;
       tbox::SAMRAI_MPI::abort();
    }
    if (!scalardb) {
-      tbox::perr << "FAILED: - Test #1b-write: `scalardb' is null" << endl;
+      tbox::perr << "FAILED: - Test #1b-write: `scalardb' is null" << std::endl;
       tbox::SAMRAI_MPI::abort();
    }
    if (!scalardb_empty) {
       tbox::perr << "FAILED: - Test #1c-write: `scalardb_empty' is null"
-                 << endl;
+                 << std::endl;
       tbox::SAMRAI_MPI::abort();
    }
    if (!scalardb_full) {
       tbox::perr << "FAILED: - Test #1d-write: `scalardb_full' is null"
-                 << endl;
+                 << std::endl;
       tbox::SAMRAI_MPI::abort();
    }
    if (!vectordb) {
       tbox::perr << "FAILED: - Test #1e-write: `vectordb' is null"
-                 << endl;
+                 << std::endl;
       tbox::SAMRAI_MPI::abort();
    }
 
@@ -101,7 +101,7 @@ void writeTestData(
    arraydb_intArray[3] = arraydb_intArray3;
    arraydb_intArray[4] = arraydb_intArray4;
 
-   std::vector<string> arraydb_stringArray(3);
+   std::vector<std::string> arraydb_stringArray(3);
    arraydb_stringArray[0] = arraydb_stringArray0;
    arraydb_stringArray[1] = arraydb_stringArray1;
    arraydb_stringArray[2] = arraydb_stringArray2;
@@ -182,12 +182,12 @@ void readTestData(
  */
 void testDatabaseContents(
    std::shared_ptr<tbox::Database> db,
-   const string& tag)
+   const std::string& tag)
 {
 
    if (!db) {
       tbox::perr << "FAILED: - Test #0-" << tag
-                 << ": database to read from is null" << endl;
+                 << ": database to read from is null" << std::endl;
       ++number_of_failures;
    }
 
@@ -207,42 +207,42 @@ void testDatabaseContents(
 
    if (!arraydb) {
       tbox::perr << "FAILED: - Test #1a-" << tag
-                 << ": `arraydb' is null" << endl;
+                 << ": `arraydb' is null" << std::endl;
       ++number_of_failures;
    }
    if (!scalardb) {
       tbox::perr << "FAILED: - Test #1b-" << tag
-                 << ": `scalardb' is null" << endl;
+                 << ": `scalardb' is null" << std::endl;
       ++number_of_failures;
    }
    if (!scalardb_empty) {
       tbox::perr << "FAILED: - Test #1c-" << tag
-                 << ": `scalardb_empty' is null" << endl;
+                 << ": `scalardb_empty' is null" << std::endl;
       ++number_of_failures;
    }
    if (!scalardb_full) {
       tbox::perr << "FAILED: - Test #1d-" << tag
-                 << ": `scalardb_full' is null" << endl;
+                 << ": `scalardb_full' is null" << std::endl;
       ++number_of_failures;
    }
 
    if (!vectordb) {
       tbox::perr << "FAILED: - Test #1e-" << tag
-                 << ": `vectordb' is null" << endl;
+                 << ": `vectordb' is null" << std::endl;
       ++number_of_failures;
    }
 
-   std::vector<string> dbkeys = db->getAllKeys();
-   std::vector<string> arraydbkeys = arraydb->getAllKeys();
-   std::vector<string> scalardbkeys = scalardb->getAllKeys();
-   std::vector<string> scalardb_emptykeys = scalardb_empty->getAllKeys();
-   std::vector<string> scalardb_fullkeys = scalardb_full->getAllKeys();
+   std::vector<std::string> dbkeys = db->getAllKeys();
+   std::vector<std::string> arraydbkeys = arraydb->getAllKeys();
+   std::vector<std::string> scalardbkeys = scalardb->getAllKeys();
+   std::vector<std::string> scalardb_emptykeys = scalardb_empty->getAllKeys();
+   std::vector<std::string> scalardb_fullkeys = scalardb_full->getAllKeys();
 
    size_t i, nkeys;
 
    if (dbkeys.size() != 7) {
       tbox::perr << "FAILED: - Test #2a-" << tag
-                 << ": # `db' keys wrong" << endl;
+                 << ": # `db' keys wrong" << std::endl;
       ++number_of_failures;
    }
    nkeys = arraydbkeys.size();
@@ -255,34 +255,34 @@ void testDatabaseContents(
       for (i = 0; i < nkeys; ++i) {
          tbox::pout << "\n\t\t" << i << ": '" << arraydbkeys[i] << "'";
       }
-      tbox::pout << endl;
+      tbox::pout << std::endl;
    }
    if (scalardbkeys.size() != 5) {
       tbox::perr << "FAILED: - Test #2c-" << tag
-                 << ": # `scalardb' keys wrong" << endl;
+                 << ": # `scalardb' keys wrong" << std::endl;
       ++number_of_failures;
    }
    if (scalardb_emptykeys.size() != 0) {
       tbox::perr << "FAILED: - Test #2d-" << tag
-                 << ": # `scalardb_empty' keys wrong" << endl;
+                 << ": # `scalardb_empty' keys wrong" << std::endl;
       ++number_of_failures;
    }
    if (scalardb_fullkeys.size() != 8) {
       tbox::perr << "FAILED: - Test #2e-" << tag
-                 << ": `scalardb_full' size is wrong" << endl
-                 << " returned : " << scalardb_fullkeys.size() << endl
-                 << " expected : " << 8 << endl;
+                 << ": `scalardb_full' size is wrong" << std::endl
+                 << " returned : " << scalardb_fullkeys.size() << std::endl
+                 << " expected : " << 8 << std::endl;
       ++number_of_failures;
    }
 
    if (!db->isDatabase("Array Entries")) {
       tbox::perr << "FAILED: - #3a-" << tag
-                 << ": `Array Entries' not a database" << endl;
+                 << ": `Array Entries' not a database" << std::endl;
       ++number_of_failures;
    }
    if (!db->isDatabase("Scalar Entries")) {
       tbox::perr << "FAILED: - #3b-" << tag
-                 << ": `Scalar Entries' not a database" << endl;
+                 << ": `Scalar Entries' not a database" << std::endl;
       ++number_of_failures;
    }
    float tdb_float_val = db->getFloat("float_val");
@@ -290,7 +290,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #3c-" << tag
                  << ": `RestartTester' database"
                  << "\n   Returned `float_val' = " << tdb_float_val
-                 << "  , Expected = " << db_float_val << endl;
+                 << "  , Expected = " << db_float_val << std::endl;
       ++number_of_failures;
    }
    int tdb_int_val = db->getInteger("int_val");
@@ -298,7 +298,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #3d-" << tag
                  << ": `RestartTester' database"
                  << "\n   Returned `int_val' = " << tdb_int_val
-                 << "  , Expected = " << db_int_val << endl;
+                 << "  , Expected = " << db_int_val << std::endl;
       ++number_of_failures;
    }
 
@@ -323,7 +323,7 @@ void testDatabaseContents(
    arraydb_intArray[3] = arraydb_intArray3;
    arraydb_intArray[4] = arraydb_intArray4;
 
-   std::vector<string> arraydb_stringArray(3);
+   std::vector<std::string> arraydb_stringArray(3);
    arraydb_stringArray[0] = arraydb_stringArray0;
    arraydb_stringArray[1] = arraydb_stringArray1;
    arraydb_stringArray[2] = arraydb_stringArray2;
@@ -361,7 +361,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #4a-" << tag
                  << ": `Array Entries' database"
                  << "\n   Returned `ComplexArray' size = " << tsize
-                 << "  , Expected = " << arraydb_dcomplexArray.size() << endl;
+                 << "  , Expected = " << arraydb_dcomplexArray.size() << std::endl;
       ++number_of_failures;
    }
    for (i = 0; i < tsize; ++i) {
@@ -369,7 +369,7 @@ void testDatabaseContents(
          tbox::perr << "FAILED: - Test #4b-" << tag
                     << ": `Array Entries' database"
                     << "\n   `ComplexArray' entry " << i << " incorrect"
-                    << endl;
+                    << std::endl;
          ++number_of_failures;
       }
    }
@@ -379,7 +379,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #4c-" << tag
                  << ": `Array Entries' database"
                  << "\n   Returned `BoolArray' size = " << tsize
-                 << "  , Expected = " << arraydb_boolArray.size() << endl;
+                 << "  , Expected = " << arraydb_boolArray.size() << std::endl;
       ++number_of_failures;
    }
    for (i = 0; i < tsize; ++i) {
@@ -388,7 +388,7 @@ void testDatabaseContents(
                     << ": `Array Entries' database"
                     << "\n   `BoolArray' entry " << i << " incorrect"
                     << "\n   " << tarraydb_boolArray[i] << " should be "
-                    << arraydb_boolArray[i] << endl;
+                    << arraydb_boolArray[i] << std::endl;
          ++number_of_failures;
       }
    }
@@ -398,32 +398,32 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #4e-" << tag
                  << ": `Array Entries' database"
                  << "\n   Returned `IntArray' size = " << tsize
-                 << "  , Expected = " << arraydb_intArray.size() << endl;
+                 << "  , Expected = " << arraydb_intArray.size() << std::endl;
       ++number_of_failures;
    }
    for (i = 0; i < tsize; ++i) {
       if (tarraydb_intArray[i] != arraydb_intArray[i]) {
          tbox::perr << "FAILED: - Test #4f-" << tag
                     << ": `Array Entries' database"
-                    << "\n   `IntArray' entry " << i << " incorrect" << endl;
+                    << "\n   `IntArray' entry " << i << " incorrect" << std::endl;
          ++number_of_failures;
       }
    }
-   std::vector<string> tarraydb_stringArray =
+   std::vector<std::string> tarraydb_stringArray =
       arraydb->getStringVector("StringArray");
    tsize = tarraydb_stringArray.size();
    if (tsize != arraydb_stringArray.size()) {
       tbox::perr << "FAILED: - Test #4g-" << tag
                  << ": `Array Entries' database"
                  << "\n   Returned `StringArray' size = " << tsize
-                 << "  , Expected = " << arraydb_stringArray[i] << endl;
+                 << "  , Expected = " << arraydb_stringArray[i] << std::endl;
       ++number_of_failures;
    }
    for (i = 0; i < tsize; ++i) {
       if (tarraydb_stringArray[i] != arraydb_stringArray[i]) {
          tbox::perr << "FAILED: - Test #4h-" << tag
                     << ": `Array Entries' database"
-                    << "\n   `StringArray' entry " << i << " incorrect" << endl;
+                    << "\n   `StringArray' entry " << i << " incorrect" << std::endl;
          ++number_of_failures;
       }
    }
@@ -434,7 +434,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #4i-" << tag
                  << ": `Array Entries' database"
                  << "\n   Returned `FloatArray' size = " << tsize
-                 << "  , Expected = " << arraydb_floatArray.size() << endl;
+                 << "  , Expected = " << arraydb_floatArray.size() << std::endl;
       ++number_of_failures;
    }
    for (i = 0; i < tsize; ++i) {
@@ -442,7 +442,7 @@ void testDatabaseContents(
              arraydb_floatArray[i])) {
          tbox::perr << "FAILED: - Test #4j-" << tag
                     << ": `Array Entries' database"
-                    << "\n   `FloatArray' entry " << i << " incorrect" << endl;
+                    << "\n   `FloatArray' entry " << i << " incorrect" << std::endl;
          ++number_of_failures;
       }
    }
@@ -454,7 +454,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #4k.b-" << tag
                  << ": `Array Entries' database"
                  << "\n   Returned `DoubleArray' size = " << tsize
-                 << "  , Expected = " << arraydb_doubleArray.size() << endl;
+                 << "  , Expected = " << arraydb_doubleArray.size() << std::endl;
       ++number_of_failures;
    }
    for (i = 0; i < tsize; ++i) {
@@ -462,7 +462,7 @@ void testDatabaseContents(
              arraydb_doubleArray[i])) {
          tbox::perr << "FAILED: - Test #4l-" << tag
                     << ": `Array Entries' database"
-                    << "\n   `DoubleArray' entry " << i << " incorrect" << endl;
+                    << "\n   `DoubleArray' entry " << i << " incorrect" << std::endl;
          ++number_of_failures;
       }
    }
@@ -472,14 +472,14 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #4m-" << tag
                  << ": `Array Entries' database"
                  << "\n   Returned `CharArray' size = " << tsize
-                 << "  , Expected = " << arraydb_charArray.size() << endl;
+                 << "  , Expected = " << arraydb_charArray.size() << std::endl;
       ++number_of_failures;
    }
    for (i = 0; i < tsize; ++i) {
       if (tarraydb_charArray[i] != arraydb_charArray[i]) {
          tbox::perr << "FAILED: - Test #4l-" << tag
                     << ": `Array Entries' database"
-                    << "\n   `CharArray' entry " << i << " incorrect" << endl;
+                    << "\n   `CharArray' entry " << i << " incorrect" << std::endl;
          ++number_of_failures;
       }
    }
@@ -490,26 +490,26 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #4o-" << tag
                  << ": `Array Entries' database"
                  << "\n   Returned `BoxArray' size = " << tsize
-                 << "  , Expected = " << arraydb_boxArray.size() << endl;
+                 << "  , Expected = " << arraydb_boxArray.size() << std::endl;
       ++number_of_failures;
    }
    for (i = 0; i < tsize; ++i) {
       if (!(tarraydb_boxVector[i] == arraydb_boxArray[i])) {
          tbox::perr << "FAILED: - Test #4p-" << tag
                     << ": `Array Entries' database"
-                    << "\n   `BoxArray' entry " << i << " incorrect" << endl;
+                    << "\n   `BoxArray' entry " << i << " incorrect" << std::endl;
          ++number_of_failures;
       }
    }
 
    if (!scalardb->isDatabase("Empty")) {
       tbox::perr << "FAILED: - #5a-" << tag
-                 << ": `Empty' not a database" << endl;
+                 << ": `Empty' not a database" << std::endl;
       ++number_of_failures;
    }
    if (!scalardb->isDatabase("Full")) {
       tbox::perr << "FAILED: - #5b-" << tag
-                 << ": `Full' not a database" << endl;
+                 << ": `Full' not a database" << std::endl;
       ++number_of_failures;
    }
    float tscalardb_float1 = scalardb->getFloat("float1");
@@ -518,7 +518,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #5c-" << tag
                  << ": `Scalar Entries' database"
                  << "\n   Returned `float1' = " << tscalardb_float1
-                 << "  , Expected = " << scalardb_float1 << endl;
+                 << "  , Expected = " << scalardb_float1 << std::endl;
       ++number_of_failures;
    }
    float tscalardb_float2 = scalardb->getFloat("float2");
@@ -527,7 +527,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #5d-" << tag
                  << ": `Scalar Entries' database"
                  << "\n   Returned `float2' = " << tscalardb_float2
-                 << "  , Expected = " << scalardb_float2 << endl;
+                 << "  , Expected = " << scalardb_float2 << std::endl;
       ++number_of_failures;
    }
    float tscalardb_float3 = scalardb->getFloat("float3");
@@ -536,7 +536,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #5e-" << tag
                  << ": `Scalar Entries' database"
                  << "\n   Returned `float3' = " << tscalardb_float3
-                 << "  , Expected = " << scalardb_float3 << endl;
+                 << "  , Expected = " << scalardb_float3 << std::endl;
       ++number_of_failures;
    }
 
@@ -549,7 +549,7 @@ void testDatabaseContents(
                  << ": `Full' database"
                  << "\n   Returned `thisDouble' = "
                  << tscalardb_full_thisDouble
-                 << "  , Expected = " << scalardb_full_thisDouble << endl;
+                 << "  , Expected = " << scalardb_full_thisDouble << std::endl;
       ++number_of_failures;
    }
    dcomplex tscalardb_full_thisComplex =
@@ -559,7 +559,7 @@ void testDatabaseContents(
                  << ": `Full' database"
                  << "\n   Returned `thisComplex' = "
                  << tscalardb_full_thisComplex
-                 << "  , Expected = " << scalardb_full_thisComplex << endl;
+                 << "  , Expected = " << scalardb_full_thisComplex << std::endl;
       ++number_of_failures;
    }
    int tscalardb_full_thisInt = scalardb_full->getInteger("thisInt");
@@ -567,7 +567,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #6c-" << tag
                  << ": `Full' database"
                  << "\n   Returned `thisInt' = " << tscalardb_full_thisInt
-                 << "  , Expected = " << scalardb_full_thisInt << endl;
+                 << "  , Expected = " << scalardb_full_thisInt << std::endl;
       ++number_of_failures;
    }
    float tscalardb_full_thisFloat = scalardb_full->getFloat("thisFloat");
@@ -576,7 +576,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #6d-" << tag
                  << ": `Full' database"
                  << "\n   Returned `thisFloat' = " << tscalardb_full_thisFloat
-                 << "  , Expected = " << scalardb_full_thisFloat << endl;
+                 << "  , Expected = " << scalardb_full_thisFloat << std::endl;
       ++number_of_failures;
    }
    bool tscalardb_full_thisBool = scalardb_full->getBool("thisBool");
@@ -584,16 +584,16 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #6e-" << tag
                  << ": `Full' database"
                  << "\n   Returned `thisBool' = " << tscalardb_full_thisBool
-                 << "  , Expected = " << scalardb_full_thisBool << endl;
+                 << "  , Expected = " << scalardb_full_thisBool << std::endl;
       ++number_of_failures;
    }
-   string tscalardb_full_thisString = scalardb_full->getString("thisString");
+   std::string tscalardb_full_thisString = scalardb_full->getString("thisString");
    if (tscalardb_full_thisString != scalardb_full_thisString) {
       tbox::perr << "FAILED: - Test #6f-" << tag
                  << ": `Full' database"
                  << "\n   Returned `thisString' = "
                  << tscalardb_full_thisString
-                 << "  , Expected = " << scalardb_full_thisString << endl;
+                 << "  , Expected = " << scalardb_full_thisString << std::endl;
       ++number_of_failures;
    }
    char tscalardb_full_thisChar = scalardb_full->getChar("thisChar");
@@ -601,7 +601,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #6g-" << tag
                  << ": `Full' database"
                  << "\n   Returned `thisChar' = " << tscalardb_full_thisChar
-                 << "  , Expected = " << scalardb_full_thisChar << endl;
+                 << "  , Expected = " << scalardb_full_thisChar << std::endl;
       ++number_of_failures;
    }
    tbox::DatabaseBox tscalardb_full_thisBox =
@@ -610,7 +610,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #6h-" << tag
                  << ": `Full' database"
                  << "\n   Returned `thisBox' does not match Expected value"
-                 << endl;
+                 << std::endl;
       ++number_of_failures;
    }
 
@@ -624,7 +624,7 @@ void testDatabaseContents(
                  << ": `Full' database"
                  << "\n   Returned `Name with spaces' = "
                  << tscalardb_full_thisDouble
-                 << "  , Expected = " << scalardb_full_thisDouble << endl;
+                 << "  , Expected = " << scalardb_full_thisDouble << std::endl;
       ++number_of_failures;
    }
 
@@ -635,7 +635,7 @@ void testDatabaseContents(
                  << ": `Full' database"
                  << "\n   Returned `Name-with-dashes' = "
                  << tscalardb_full_thisDouble
-                 << "  , Expected = " << scalardb_full_thisDouble << endl;
+                 << "  , Expected = " << scalardb_full_thisDouble << std::endl;
       ++number_of_failures;
    }
 
@@ -645,7 +645,7 @@ void testDatabaseContents(
                  << ": `Full' database"
                  << "\n   Returned `Name-with-!@#$%^&*()_+-=' = "
                  << tscalardb_full_thisDouble
-                 << "  , Expected = " << scalardb_full_thisDouble << endl;
+                 << "  , Expected = " << scalardb_full_thisDouble << std::endl;
       ++number_of_failures;
    }
 
@@ -660,7 +660,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #7a-" << tag
                  << ": `getArraySize'"
                  << "\n   Returned size = " << tsize
-                 << "  , Expected = " << actual_size << endl;
+                 << "  , Expected = " << actual_size << std::endl;
       ++number_of_failures;
    }
 
@@ -670,7 +670,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #7b-" << tag
                  << ": `getArraySize'"
                  << "\n   Returned size = " << tsize
-                 << "  , Expected = " << actual_size << endl;
+                 << "  , Expected = " << actual_size << std::endl;
       ++number_of_failures;
    }
 
@@ -680,7 +680,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #7c-" << tag
                  << ": `getArraySize'"
                  << "\n   Returned size = " << tsize
-                 << "  , Expected = " << actual_size << endl;
+                 << "  , Expected = " << actual_size << std::endl;
       ++number_of_failures;
    }
 
@@ -690,7 +690,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #7d-" << tag
                  << ": `getArraySize'"
                  << "\n   Returned size = " << tsize
-                 << "  , Expected = " << actual_size << endl;
+                 << "  , Expected = " << actual_size << std::endl;
       ++number_of_failures;
    }
 
@@ -700,7 +700,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #7e-" << tag
                  << ": `getArraySize'"
                  << "\n   Returned size = " << tsize
-                 << "  , Expected = " << actual_size << endl;
+                 << "  , Expected = " << actual_size << std::endl;
       ++number_of_failures;
    }
 
@@ -710,7 +710,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #7f-" << tag
                  << ": `getArraySize'"
                  << "\n   Returned size = " << tsize
-                 << "  , Expected = " << actual_size << endl;
+                 << "  , Expected = " << actual_size << std::endl;
       ++number_of_failures;
    }
 
@@ -720,7 +720,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #7g-" << tag
                  << ": `getArraySize'"
                  << "\n   Returned size = " << tsize
-                 << "  , Expected = " << actual_size << endl;
+                 << "  , Expected = " << actual_size << std::endl;
       ++number_of_failures;
    }
 
@@ -730,7 +730,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #7h-" << tag
                  << ": `getArraySize'"
                  << "\n   Returned size = " << tsize
-                 << "  , Expected = " << actual_size << endl;
+                 << "  , Expected = " << actual_size << std::endl;
       ++number_of_failures;
    }
 
@@ -740,7 +740,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #7i-" << tag
                  << ": `getArraySize'"
                  << "\n   Returned size = " << tsize
-                 << "  , Expected = " << actual_size << endl;
+                 << "  , Expected = " << actual_size << std::endl;
       ++number_of_failures;
    }
 
@@ -751,7 +751,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #8a-" << tag
                  << ": `keyExists'"
                  << "\n   Returned false "
-                 << "  , Expected = true " << endl;
+                 << "  , Expected = true " << std::endl;
       ++number_of_failures;
    }
 
@@ -759,56 +759,56 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #8b-" << tag
                  << ": `keyExists'"
                  << "\n   Returned false "
-                 << "  , Expected = true " << endl;
+                 << "  , Expected = true " << std::endl;
       ++number_of_failures;
    }
    if (!arraydb->keyExists("IntArray")) {
       tbox::perr << "FAILED: - Test #8c-" << tag
                  << ": `keyExists'"
                  << "\n   Returned false "
-                 << "  , Expected = true " << endl;
+                 << "  , Expected = true " << std::endl;
       ++number_of_failures;
    }
    if (!arraydb->keyExists("StringArray")) {
       tbox::perr << "FAILED: - Test #8d-" << tag
                  << ": `keyExists'"
                  << "\n   Returned false "
-                 << "  , Expected = true " << endl;
+                 << "  , Expected = true " << std::endl;
       ++number_of_failures;
    }
    if (!arraydb->keyExists("FloatArray")) {
       tbox::perr << "FAILED: - Test #8d-" << tag
                  << ": `keyExists'"
                  << "\n   Returned false "
-                 << "  , Expected = true " << endl;
+                 << "  , Expected = true " << std::endl;
       ++number_of_failures;
    }
    if (!arraydb->keyExists("DoubleArray")) {
       tbox::perr << "FAILED: - Test #8f-" << tag
                  << ": `keyExists'"
                  << "\n   Returned false "
-                 << "  , Expected = true " << endl;
+                 << "  , Expected = true " << std::endl;
       ++number_of_failures;
    }
    if (!arraydb->keyExists("CharArray")) {
       tbox::perr << "FAILED: - Test #8g-" << tag
                  << ": `keyExists'"
                  << "\n   Returned false "
-                 << "  , Expected = true " << endl;
+                 << "  , Expected = true " << std::endl;
       ++number_of_failures;
    }
    if (!arraydb->keyExists("BoxArray")) {
       tbox::perr << "FAILED: - Test #8h-" << tag
                  << ": `keyExists'"
                  << "\n   Returned false "
-                 << "  , Expected = true " << endl;
+                 << "  , Expected = true " << std::endl;
       ++number_of_failures;
    }
    if (!db->keyExists("Array Entries")) {
       tbox::perr << "FAILED: - Test #8i-" << tag
                  << ": `keyExists'"
                  << "\n   Returned false "
-                 << "  , Expected = true " << endl;
+                 << "  , Expected = true " << std::endl;
       ++number_of_failures;
    }
 
@@ -819,7 +819,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #10-" << tag
                  << ": `keyExists'"
                  << "\n   Returned true "
-                 << "  , Expected false " << endl;
+                 << "  , Expected false " << std::endl;
       ++number_of_failures;
    }
 
@@ -830,7 +830,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #11a-" << tag
                  << ": `isComplex'"
                  << "\n   Returned false "
-                 << "  , Expected = true " << endl;
+                 << "  , Expected = true " << std::endl;
       ++number_of_failures;
    }
 
@@ -838,56 +838,56 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #11b-" << tag
                  << ": `isBool'"
                  << "\n   Returned false "
-                 << "  , Expected = true " << endl;
+                 << "  , Expected = true " << std::endl;
       ++number_of_failures;
    }
    if (!arraydb->isInteger("IntArray")) {
       tbox::perr << "FAILED: - Test #11c-" << tag
                  << ": `isInteger'"
                  << "\n   Returned false "
-                 << "  , Expected = true " << endl;
+                 << "  , Expected = true " << std::endl;
       ++number_of_failures;
    }
    if (!arraydb->isString("StringArray")) {
       tbox::perr << "FAILED: - Test #11d-" << tag
                  << ": `isString'"
                  << "\n   Returned false "
-                 << "  , Expected = true " << endl;
+                 << "  , Expected = true " << std::endl;
       ++number_of_failures;
    }
    if (!arraydb->isFloat("FloatArray")) {
       tbox::perr << "FAILED: - Test #11d-" << tag
                  << ": `isFloat'"
                  << "\n   Returned false "
-                 << "  , Expected = true " << endl;
+                 << "  , Expected = true " << std::endl;
       ++number_of_failures;
    }
    if (!arraydb->isDouble("DoubleArray")) {
       tbox::perr << "FAILED: - Test #11f-" << tag
                  << ": `isDouble'"
                  << "\n   Returned false "
-                 << "  , Expected = true " << endl;
+                 << "  , Expected = true " << std::endl;
       ++number_of_failures;
    }
    if (!arraydb->isChar("CharArray")) {
       tbox::perr << "FAILED: - Test #11g-" << tag
                  << ": `isChar'"
                  << "\n   Returned false "
-                 << "  , Expected = true " << endl;
+                 << "  , Expected = true " << std::endl;
       ++number_of_failures;
    }
    if (!arraydb->isDatabaseBox("BoxArray")) {
       tbox::perr << "FAILED: - Test #11h-" << tag
                  << ": `isBox'"
                  << "\n   Returned false "
-                 << "  , Expected = true " << endl;
+                 << "  , Expected = true " << std::endl;
       ++number_of_failures;
    }
    if (!db->isDatabase("Array Entries")) {
       tbox::perr << "FAILED: - Test #11i-" << tag
                  << ": `isDatabase'"
                  << "\n   Returned false "
-                 << "  , Expected = true " << endl;
+                 << "  , Expected = true " << std::endl;
       ++number_of_failures;
    }
 
@@ -898,7 +898,7 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #12a-" << tag
                  << ": `isComplex'"
                  << "\n   Returned true "
-                 << "  , Expected false " << endl;
+                 << "  , Expected false " << std::endl;
       ++number_of_failures;
    }
 
@@ -906,56 +906,56 @@ void testDatabaseContents(
       tbox::perr << "FAILED: - Test #12b-" << tag
                  << ": `isBool'"
                  << "\n   Returned true "
-                 << "  , Expected false " << endl;
+                 << "  , Expected false " << std::endl;
       ++number_of_failures;
    }
    if (arraydb->isInteger("nonIntArray")) {
       tbox::perr << "FAILED: - Test #12c-" << tag
                  << ": `isInteger'"
                  << "\n   Returned true "
-                 << "  , Expected false " << endl;
+                 << "  , Expected false " << std::endl;
       ++number_of_failures;
    }
    if (arraydb->isString("nonStringArray")) {
       tbox::perr << "FAILED: - Test #12d-" << tag
                  << ": `isString'"
                  << "\n   Returned true "
-                 << "  , Expected false " << endl;
+                 << "  , Expected false " << std::endl;
       ++number_of_failures;
    }
    if (arraydb->isFloat("nonFloatArray")) {
       tbox::perr << "FAILED: - Test #12e-" << tag
                  << ": `isFloat'"
                  << "\n   Returned true "
-                 << "  , Expected false " << endl;
+                 << "  , Expected false " << std::endl;
       ++number_of_failures;
    }
    if (arraydb->isDouble("nonDoubleArray")) {
       tbox::perr << "FAILED: - Test #12f-" << tag
                  << ": `isDouble'"
                  << "\n   Returned true "
-                 << "  , Expected false " << endl;
+                 << "  , Expected false " << std::endl;
       ++number_of_failures;
    }
    if (arraydb->isChar("nonCharArray")) {
       tbox::perr << "FAILED: - Test #12g-" << tag
                  << ": `isChar'"
                  << "\n   Returned true "
-                 << "  , Expected false " << endl;
+                 << "  , Expected false " << std::endl;
       ++number_of_failures;
    }
    if (arraydb->isDatabaseBox("nonBoxArray")) {
       tbox::perr << "FAILED: - Test #12h-" << tag
                  << ": `isBox'"
                  << "\n   Returned true "
-                 << "  , Expected false " << endl;
+                 << "  , Expected false " << std::endl;
       ++number_of_failures;
    }
    if (db->isDatabase("nonArray Entries")) {
       tbox::perr << "FAILED: - Test #12i-" << tag
                  << ": `isDatabase'"
                  << "\n   Returned true "
-                 << "  , Expected false " << endl;
+                 << "  , Expected false " << std::endl;
       ++number_of_failures;
    }
 
@@ -966,52 +966,52 @@ void testDatabaseContents(
     */
    if (arraydb->getArrayType("ComplexArray") != tbox::Database::COMPLEX) {
       tbox::perr << "FAILED: - Test #13a-" << tag
-                 << ": `getArrayType returned the wrong type" << endl;
+                 << ": `getArrayType returned the wrong type" << std::endl;
       ++number_of_failures;
    }
    if (arraydb->getArrayType("BoolArray") != tbox::Database::BOOL) {
       tbox::perr << "FAILED: - Test #13b-" << tag
-                 << ": `getArrayType returned the wrong type" << endl;
+                 << ": `getArrayType returned the wrong type" << std::endl;
       ++number_of_failures;
    }
    if (arraydb->getArrayType("IntArray") != tbox::Database::INT) {
       tbox::perr << "FAILED: - Test #13c-" << tag
-                 << ": `getArrayType returned the wrong type" << endl;
+                 << ": `getArrayType returned the wrong type" << std::endl;
       ++number_of_failures;
    }
    if (arraydb->getArrayType("StringArray") != tbox::Database::STRING) {
       tbox::perr << "FAILED: - Test #13d-" << tag
-                 << ": `getArrayType returned the wrong type" << endl;
+                 << ": `getArrayType returned the wrong type" << std::endl;
       ++number_of_failures;
    }
    if (arraydb->getArrayType("FloatArray") != tbox::Database::FLOAT) {
       tbox::perr << "FAILED: - Test #13e-" << tag
-                 << ": `getArrayType returned the wrong type" << endl;
+                 << ": `getArrayType returned the wrong type" << std::endl;
       ++number_of_failures;
    }
    if (arraydb->getArrayType("DoubleArray") != tbox::Database::DOUBLE) {
       tbox::perr << "FAILED: - Test #13f-" << tag
-                 << ": `getArrayType returned the wrong type" << endl;
+                 << ": `getArrayType returned the wrong type" << std::endl;
       ++number_of_failures;
    }
    if (arraydb->getArrayType("CharArray") != tbox::Database::CHAR) {
       tbox::perr << "FAILED: - Test #13g-" << tag
-                 << ": `getArrayType returned the wrong type" << endl;
+                 << ": `getArrayType returned the wrong type" << std::endl;
       ++number_of_failures;
    }
    if (arraydb->getArrayType("BoxArray") != tbox::Database::BOX) {
       tbox::perr << "FAILED: - Test #13h-" << tag
-                 << ": `getArrayType returned the wrong type" << endl;
+                 << ": `getArrayType returned the wrong type" << std::endl;
       ++number_of_failures;
    }
    if (db->getArrayType("Array Entries") != tbox::Database::DATABASE) {
       tbox::perr << "FAILED: - Test #13i-" << tag
-                 << ": `getArrayType returned the wrong type" << endl;
+                 << ": `getArrayType returned the wrong type" << std::endl;
       ++number_of_failures;
    }
    if (db->getArrayType("NonEntries") != tbox::Database::INVALID) {
       tbox::perr << "FAILED: - Test #13j-" << tag
-                 << ": `getArrayType returned the wrong type" << endl;
+                 << ": `getArrayType returned the wrong type" << std::endl;
       ++number_of_failures;
    }
 
@@ -1026,10 +1026,10 @@ void testDatabaseContents(
          test_scalar_complex);
    if (tscalardb_full_thisComplex != scalardb_full_thisComplex) {
       tbox::perr << "FAILED: - Test #14a-" << tag
-                 << ": `Full' database" << endl
+                 << ": `Full' database" << std::endl
                  << "   Returned `thisComplex' = "
                  << tscalardb_full_thisComplex
-                 << "  , Expected = " << scalardb_full_thisComplex << endl;
+                 << "  , Expected = " << scalardb_full_thisComplex << std::endl;
       ++number_of_failures;
    }
    bool test_scalar_bool(false);
@@ -1037,9 +1037,9 @@ void testDatabaseContents(
          test_scalar_bool);
    if (tscalardb_full_thisBool != scalardb_full_thisBool) {
       tbox::perr << "FAILED: - Test #14b-" << tag
-                 << ": `Full' database" << endl
+                 << ": `Full' database" << std::endl
                  << "   Returned `thisBool' = " << tscalardb_full_thisBool
-                 << "  , Expected = " << scalardb_full_thisBool << endl;
+                 << "  , Expected = " << scalardb_full_thisBool << std::endl;
       ++number_of_failures;
    }
    int test_scalar_int(-9);
@@ -1047,19 +1047,19 @@ void testDatabaseContents(
          test_scalar_int);
    if (tscalardb_full_thisInt != scalardb_full_thisInt) {
       tbox::perr << "FAILED: - Test #14c-" << tag
-                 << ": `Full' database" << endl
+                 << ": `Full' database" << std::endl
                  << "   Returned `thisInt' = " << tscalardb_full_thisInt
-                 << "  , Expected = " << scalardb_full_thisInt << endl;
+                 << "  , Expected = " << scalardb_full_thisInt << std::endl;
       ++number_of_failures;
    }
-   string test_scalar_string("A fake string");
+   std::string test_scalar_string("A fake string");
    tscalardb_full_thisString = scalardb_full->getStringWithDefault("thisString",
          test_scalar_string);
    if (tscalardb_full_thisString != scalardb_full_thisString) {
       tbox::perr << "FAILED: - Test #14d-" << tag
-                 << ": `Full' database" << endl
+                 << ": `Full' database" << std::endl
                  << "   Returned `thisString' = " << tscalardb_full_thisString
-                 << "  , Expected = " << scalardb_full_thisString << endl;
+                 << "  , Expected = " << scalardb_full_thisString << std::endl;
       ++number_of_failures;
    }
    float test_scalar_float(-9.0);
@@ -1068,9 +1068,9 @@ void testDatabaseContents(
    if (!tbox::MathUtilities<float>::equalEps(tscalardb_full_thisFloat,
           scalardb_full_thisFloat)) {
       tbox::perr << "FAILED: - Test #14e-" << tag
-                 << ": `Full' database" << endl
+                 << ": `Full' database" << std::endl
                  << "   Returned `thisFloat' = " << tscalardb_full_thisFloat
-                 << "  , Expected = " << scalardb_full_thisFloat << endl;
+                 << "  , Expected = " << scalardb_full_thisFloat << std::endl;
       ++number_of_failures;
    }
    double test_scalar_double(-9.0);
@@ -1079,9 +1079,9 @@ void testDatabaseContents(
    if (!tbox::MathUtilities<double>::equalEps(tscalardb_full_thisDouble,
           scalardb_full_thisDouble)) {
       tbox::perr << "FAILED: - Test #14f-" << tag
-                 << ": `Full' database" << endl
+                 << ": `Full' database" << std::endl
                  << "   Returned `thisDouble' = " << tscalardb_full_thisDouble
-                 << "  , Expected = " << scalardb_full_thisDouble << endl;
+                 << "  , Expected = " << scalardb_full_thisDouble << std::endl;
       ++number_of_failures;
    }
    char test_scalar_char('h');
@@ -1089,9 +1089,9 @@ void testDatabaseContents(
          test_scalar_char);
    if (tscalardb_full_thisChar != scalardb_full_thisChar) {
       tbox::perr << "FAILED: - Test #14h-" << tag
-                 << ": `Full' database" << endl
+                 << ": `Full' database" << std::endl
                  << "   Returned `thisChar' = " << tscalardb_full_thisChar
-                 << "  , Expected = " << scalardb_full_thisChar << endl;
+                 << "  , Expected = " << scalardb_full_thisChar << std::endl;
       ++number_of_failures;
    }
 
@@ -1099,19 +1099,19 @@ void testDatabaseContents(
          test_scalar_complex);
    if (tscalardb_full_thisComplex != test_scalar_complex) {
       tbox::perr << "FAILED: - Test #15a-" << tag
-                 << ": `Full' database" << endl
+                 << ": `Full' database" << std::endl
                  << "   Returned `thisComplex' = "
                  << tscalardb_full_thisComplex
-                 << "  , Expected = " << test_scalar_complex << endl;
+                 << "  , Expected = " << test_scalar_complex << std::endl;
       ++number_of_failures;
    }
    tscalardb_full_thisBool = defaultdb->getBoolWithDefault("bogusBool",
          test_scalar_bool);
    if (tscalardb_full_thisBool != test_scalar_bool) {
       tbox::perr << "FAILED: - Test #15b-" << tag
-                 << ": `Full' database" << endl
+                 << ": `Full' database" << std::endl
                  << "   Returned `thisBool' = " << tscalardb_full_thisBool
-                 << "  , Expected = " << test_scalar_bool << endl;
+                 << "  , Expected = " << test_scalar_bool << std::endl;
       ++number_of_failures;
    }
 
@@ -1119,18 +1119,18 @@ void testDatabaseContents(
          test_scalar_int);
    if (tscalardb_full_thisInt != test_scalar_int) {
       tbox::perr << "FAILED: - Test #15c-" << tag
-                 << ": `Full' database" << endl
+                 << ": `Full' database" << std::endl
                  << "   Returned `thisInt' = " << tscalardb_full_thisInt
-                 << "  , Expected = " << test_scalar_int << endl;
+                 << "  , Expected = " << test_scalar_int << std::endl;
       ++number_of_failures;
    }
    tscalardb_full_thisString = defaultdb->getStringWithDefault("bogusString",
          test_scalar_string);
    if (tscalardb_full_thisString != test_scalar_string) {
       tbox::perr << "FAILED: - Test #15d-" << tag
-                 << ": `Full' database" << endl
+                 << ": `Full' database" << std::endl
                  << "   Returned `thisString' = " << tscalardb_full_thisString
-                 << "  , Expected = " << test_scalar_string << endl;
+                 << "  , Expected = " << test_scalar_string << std::endl;
       ++number_of_failures;
    }
    tscalardb_full_thisFloat = defaultdb->getFloatWithDefault("bogusFloat",
@@ -1138,9 +1138,9 @@ void testDatabaseContents(
    if (!tbox::MathUtilities<float>::equalEps(tscalardb_full_thisFloat,
           test_scalar_float)) {
       tbox::perr << "FAILED: - Test #15e-" << tag
-                 << ": `Full' database" << endl
+                 << ": `Full' database" << std::endl
                  << "   Returned `thisFloat' = " << tscalardb_full_thisFloat
-                 << "  , Expected = " << test_scalar_float << endl;
+                 << "  , Expected = " << test_scalar_float << std::endl;
       ++number_of_failures;
    }
    tscalardb_full_thisDouble = defaultdb->getDoubleWithDefault("bogusDouble",
@@ -1148,18 +1148,18 @@ void testDatabaseContents(
    if (!tbox::MathUtilities<double>::equalEps(tscalardb_full_thisDouble,
           test_scalar_double)) {
       tbox::perr << "FAILED: - Test #15f-" << tag
-                 << ": `Full' database" << endl
+                 << ": `Full' database" << std::endl
                  << "   Returned `thisDouble' = " << tscalardb_full_thisDouble
-                 << "  , Expected = " << test_scalar_double << endl;
+                 << "  , Expected = " << test_scalar_double << std::endl;
       ++number_of_failures;
    }
    tscalardb_full_thisChar = defaultdb->getCharWithDefault("bogusChar",
          test_scalar_char);
    if (tscalardb_full_thisChar != test_scalar_char) {
       tbox::perr << "FAILED: - Test #15h-" << tag
-                 << ": `Full' database" << endl
+                 << ": `Full' database" << std::endl
                  << "   Returned `thisChar' = " << tscalardb_full_thisChar
-                 << "  , Expected = " << test_scalar_char << endl;
+                 << "  , Expected = " << test_scalar_char << std::endl;
       ++number_of_failures;
    }
 
@@ -1172,18 +1172,18 @@ void testDatabaseContents(
 
    if (vector_IntVector[0] != intVector1) {
       tbox::perr << "FAILED: - Test #16a-" << tag
-                 << ": stl::vector<IntVector> did not restore correctly" << endl
+                 << ": stl::vector<IntVector> did not restore correctly" << std::endl
                  << "   Returned `IntVector' = " << vector_IntVector[0]
-                 << "  , Expected = " << intVector1 << endl;
+                 << "  , Expected = " << intVector1 << std::endl;
       ++number_of_failures;
 
    }
 
    if (vector_IntVector[1] != intVector2) {
       tbox::perr << "FAILED: - Test #16b-" << tag
-                 << ": stl::vector<IntVector> did not restore correctly" << endl
+                 << ": stl::vector<IntVector> did not restore correctly" << std::endl
                  << "   Returned `IntVector' = " << vector_IntVector[1]
-                 << "  , Expected = " << intVector2 << endl;
+                 << "  , Expected = " << intVector2 << std::endl;
       ++number_of_failures;
    }
 

--- a/source/test/restartdb/database_tests.h
+++ b/source/test/restartdb/database_tests.h
@@ -20,7 +20,6 @@
 #include <string>
 #include <memory>
 
-using namespace std;
 using namespace SAMRAI;
 
 // Number of (non-abortive) failures.
@@ -53,4 +52,4 @@ readTestData(
 void
 testDatabaseContents(
    std::shared_ptr<tbox::Database> db,
-   const string& tag);
+   const std::string& tag);

--- a/source/test/restartdb/database_values.h
+++ b/source/test/restartdb/database_values.h
@@ -21,7 +21,6 @@
 
 #include <string>
 
-using namespace std;
 using namespace SAMRAI;
 
 // Number of (non-abortive) failures.
@@ -41,9 +40,9 @@ int arraydb_intArray1 = 1;
 int arraydb_intArray2 = 2;
 int arraydb_intArray3 = 3;
 int arraydb_intArray4 = 4;
-string arraydb_stringArray0 = "This is 1 test.";
-string arraydb_stringArray1 = "This is 2nd test.";
-string arraydb_stringArray2 = "This is a long 3rd test.";
+std::string arraydb_stringArray0 = "This is 1 test.";
+std::string arraydb_stringArray1 = "This is 2nd test.";
+std::string arraydb_stringArray2 = "This is a long 3rd test.";
 float arraydb_floatArray0 = 0 * 1.2;
 float arraydb_floatArray1 = (float)(1 * 1.2);
 float arraydb_floatArray2 = (float)(2 * 1.2);
@@ -69,7 +68,7 @@ dcomplex scalardb_full_thisComplex = dcomplex(2.3, 4.5);
 int scalardb_full_thisInt = 89;
 float scalardb_full_thisFloat = (float)9.9;
 bool scalardb_full_thisBool = true;
-string scalardb_full_thisString = "This is a test.";
+std::string scalardb_full_thisString = "This is a test.";
 char scalardb_full_thisChar = 'q';
 int ilo[3] = { 0, 0, 0 };
 int ihi[3] = { 1, 1, 1 };

--- a/source/test/restartdb/mainHDF5.C
+++ b/source/test/restartdb/mainHDF5.C
@@ -21,7 +21,6 @@
 #include <string>
 #include <memory>
 
-using namespace std;
 using namespace SAMRAI;
 
 #include "database_tests.h"
@@ -78,21 +77,21 @@ int main(
 
 #ifdef HAVE_HDF5
 
-      tbox::plog << "\n--- HDF5 database tests BEGIN ---" << endl;
+      tbox::plog << "\n--- HDF5 database tests BEGIN ---" << std::endl;
 
       tbox::RestartManager* restart_manager = tbox::RestartManager::getManager();
 
       RestartTester hdf_tester;
 
-      tbox::plog << "\n--- HDF5 write database tests BEGIN ---" << endl;
+      tbox::plog << "\n--- HDF5 write database tests BEGIN ---" << std::endl;
 
       setupTestData();
 
       restart_manager->writeRestartFile("test_dir", 0);
 
-      tbox::plog << "\n--- HDF5 write database tests END ---" << endl;
+      tbox::plog << "\n--- HDF5 write database tests END ---" << std::endl;
 
-      tbox::plog << "\n--- HDF5 read database tests BEGIN ---" << endl;
+      tbox::plog << "\n--- HDF5 read database tests BEGIN ---" << std::endl;
 
       restart_manager->closeRestartFile();
 
@@ -104,14 +103,14 @@ int main(
 
       restart_manager->closeRestartFile();
 
-      tbox::plog << "\n--- HDF5 read database tests END ---" << endl;
+      tbox::plog << "\n--- HDF5 read database tests END ---" << std::endl;
 
-      tbox::plog << "\n--- HDF5 database tests END ---" << endl;
+      tbox::plog << "\n--- HDF5 database tests END ---" << std::endl;
 
 #endif
 
       if (number_of_failures == 0) {
-         tbox::pout << "\nPASSED:  HDF5" << endl;
+         tbox::pout << "\nPASSED:  HDF5" << std::endl;
       }
    }
 

--- a/source/test/restartdb/mainHDF5AppFileOpen.C
+++ b/source/test/restartdb/mainHDF5AppFileOpen.C
@@ -21,7 +21,6 @@
 #include <string>
 #include <memory>
 
-using namespace std;
 using namespace SAMRAI;
 
 #include "database_tests.h"
@@ -78,13 +77,13 @@ int main(
 
 #ifdef HAVE_HDF5
 
-      tbox::plog << "\n--- HDF5 database tests BEGIN ---" << endl;
+      tbox::plog << "\n--- HDF5 database tests BEGIN ---" << std::endl;
 
       tbox::RestartManager* restart_manager = tbox::RestartManager::getManager();
 
       RestartTester hdf_tester;
 
-      tbox::plog << "\n--- HDF5 write database tests BEGIN ---" << endl;
+      tbox::plog << "\n--- HDF5 write database tests BEGIN ---" << std::endl;
 
       setupTestData();
 
@@ -109,9 +108,9 @@ int main(
 
       restart_manager->writeRestartToDatabase();
 
-      tbox::plog << "\n--- HDF5 write database tests END ---" << endl;
+      tbox::plog << "\n--- HDF5 write database tests END ---" << std::endl;
 
-      tbox::plog << "\n--- HDF5 read database tests BEGIN ---" << endl;
+      tbox::plog << "\n--- HDF5 read database tests BEGIN ---" << std::endl;
 
       database->close();
 
@@ -138,14 +137,14 @@ int main(
 
       H5Fclose(file_id);
 
-      tbox::plog << "\n--- HDF5 read database tests END ---" << endl;
+      tbox::plog << "\n--- HDF5 read database tests END ---" << std::endl;
 
-      tbox::plog << "\n--- HDF5 database tests END ---" << endl;
+      tbox::plog << "\n--- HDF5 database tests END ---" << std::endl;
 
 #endif
 
       if (number_of_failures == 0) {
-         tbox::pout << "\nPASSED:  HDF5" << endl;
+         tbox::pout << "\nPASSED:  HDF5" << std::endl;
       }
    }
 

--- a/source/test/restartdb/mainMemory.C
+++ b/source/test/restartdb/mainMemory.C
@@ -21,7 +21,6 @@
 #include <string>
 #include <memory>
 
-using namespace std;
 using namespace SAMRAI;
 
 #include "database_tests.h"
@@ -75,13 +74,13 @@ int main(
 
       tbox::PIO::logAllNodes("Memorytest.log");
 
-      tbox::plog << "\n--- Memory database tests BEGIN ---" << endl;
+      tbox::plog << "\n--- Memory database tests BEGIN ---" << std::endl;
 
       tbox::RestartManager* restart_manager = tbox::RestartManager::getManager();
 
       RestartTester memory_tester;
 
-      tbox::plog << "\n--- Memory write database tests BEGIN ---" << endl;
+      tbox::plog << "\n--- Memory write database tests BEGIN ---" << std::endl;
 
       setupTestData();
 
@@ -92,9 +91,9 @@ int main(
 
       restart_manager->writeRestartToDatabase();
 
-      tbox::plog << "\n--- Memory write database tests END ---" << endl;
+      tbox::plog << "\n--- Memory write database tests END ---" << std::endl;
 
-      tbox::plog << "\n--- Memory read database tests BEGIN ---" << endl;
+      tbox::plog << "\n--- Memory read database tests BEGIN ---" << std::endl;
 
       // In this test just read the database stored in memory that
       // was just created.
@@ -102,12 +101,12 @@ int main(
 
       database->close();
 
-      tbox::plog << "\n--- Memory read database tests END ---" << endl;
+      tbox::plog << "\n--- Memory read database tests END ---" << std::endl;
 
-      tbox::plog << "\n--- Memory database tests END ---" << endl;
+      tbox::plog << "\n--- Memory database tests END ---" << std::endl;
 
       if (number_of_failures == 0) {
-         tbox::pout << "\nPASSED:  Memory" << endl;
+         tbox::pout << "\nPASSED:  Memory" << std::endl;
       }
    }
 

--- a/source/test/restartdb/mainSilo.C
+++ b/source/test/restartdb/mainSilo.C
@@ -21,7 +21,6 @@
 #include <string>
 #include <memory>
 
-using namespace std;
 using namespace SAMRAI;
 
 #include "database_tests.h"
@@ -78,13 +77,13 @@ int main(
 
 #ifdef HAVE_SILO
 
-      tbox::plog << "\n--- Silo database tests BEGIN ---" << endl;
+      tbox::plog << "\n--- Silo database tests BEGIN ---" << std::endl;
 
       tbox::RestartManager* restart_manager = tbox::RestartManager::getManager();
 
       RestartTester silo_tester;
 
-      tbox::plog << "\n--- Silo write database tests BEGIN ---" << endl;
+      tbox::plog << "\n--- Silo write database tests BEGIN ---" << std::endl;
 
       setupTestData();
 
@@ -101,9 +100,9 @@ int main(
 
       database->close();
 
-      tbox::plog << "\n--- Silo write database tests END ---" << endl;
+      tbox::plog << "\n--- Silo write database tests END ---" << std::endl;
 
-      tbox::plog << "\n--- Silo read database tests BEGIN ---" << endl;
+      tbox::plog << "\n--- Silo read database tests BEGIN ---" << std::endl;
 
       database.reset(new tbox::SiloDatabase("SAMRAI Restart"));
 
@@ -117,14 +116,14 @@ int main(
 
       database->close();
 
-      tbox::plog << "\n--- Silo read database tests END ---" << endl;
+      tbox::plog << "\n--- Silo read database tests END ---" << std::endl;
 
-      tbox::plog << "\n--- Silo database tests END ---" << endl;
+      tbox::plog << "\n--- Silo database tests END ---" << std::endl;
 
 #endif
 
       if (number_of_failures == 0) {
-         tbox::pout << "\nPASSED:  Silo" << endl;
+         tbox::pout << "\nPASSED:  Silo" << std::endl;
       }
    }
 

--- a/source/test/restartdb/mainSiloAppFileOpen.C
+++ b/source/test/restartdb/mainSiloAppFileOpen.C
@@ -21,7 +21,6 @@
 #include <string>
 #include <memory>
 
-using namespace std;
 using namespace SAMRAI;
 
 #include "database_tests.h"
@@ -78,13 +77,13 @@ int main(
 
 #ifdef HAVE_SILO
 
-      tbox::plog << "\n--- Silo database tests BEGIN ---" << endl;
+      tbox::plog << "\n--- Silo database tests BEGIN ---" << std::endl;
 
       tbox::RestartManager* restart_manager = tbox::RestartManager::getManager();
 
       RestartTester silo_tester;
 
-      tbox::plog << "\n--- Silo write database tests BEGIN ---" << endl;
+      tbox::plog << "\n--- Silo write database tests BEGIN ---" << std::endl;
 
       setupTestData();
 
@@ -105,9 +104,9 @@ int main(
 
       DBClose(silo_file);
 
-      tbox::plog << "\n--- Silo write database tests END ---" << endl;
+      tbox::plog << "\n--- Silo write database tests END ---" << std::endl;
 
-      tbox::plog << "\n--- Silo read database tests BEGIN ---" << endl;
+      tbox::plog << "\n--- Silo read database tests BEGIN ---" << std::endl;
 
       database.reset(new tbox::SiloDatabase("SAMRAI Restart"));
       silo_file = DBOpen(name.c_str(), DB_UNKNOWN, DB_READ);
@@ -122,14 +121,14 @@ int main(
 
       DBClose(silo_file);
 
-      tbox::plog << "\n--- Silo read database tests END ---" << endl;
+      tbox::plog << "\n--- Silo read database tests END ---" << std::endl;
 
-      tbox::plog << "\n--- Silo database tests END ---" << endl;
+      tbox::plog << "\n--- Silo database tests END ---" << std::endl;
 
 #endif
 
       if (number_of_failures == 0) {
-         tbox::pout << "\nPASSED:  Silo" << endl;
+         tbox::pout << "\nPASSED:  Silo" << std::endl;
       }
    }
 

--- a/source/test/sundials/CVODEModel.C
+++ b/source/test/sundials/CVODEModel.C
@@ -101,7 +101,7 @@ void SAMRAI_F77_FUNC(setneufluxvalues3d, SETNEUFLUXVALUES3D) (
  ************************************************************************/
 
 CVODEModel::CVODEModel(
-   const string& object_name,
+   const std::string& object_name,
    const Dimension& dim,
    std::shared_ptr<CellPoissonFACSolver> fac_solver,
    std::shared_ptr<Database> input_db,
@@ -503,7 +503,7 @@ CVODEModel::setPhysicalBoundaryConditions(
 
    }
 
-//    plog << "----Boundary Conditions "  << endl;
+//    plog << "----Boundary Conditions "  << std::endl;
 //    soln_data->print(soln_data->getGhostBox());
 
 }
@@ -600,7 +600,7 @@ CVODEModel::evaluateRHSFunction(
       pout << "\t\tEval RHS: "
            << "\n   \t\t\ttime = " << time
            << "\n   \t\t\ty_maxnorm = " << y_samvect->maxNorm()
-           << endl;
+           << std::endl;
    }
 
    /*
@@ -1079,7 +1079,7 @@ int CVODEModel::CVSpgmrPrecondSolve(
            << "\n   \t\t\tz_maxnorm = " << z_samvect->maxNorm()
            << "\n   \t\t\tr_l2norm = " << r_samvect->L2Norm()
            << "\n   \t\t\tr_maxnorm = " << r_samvect->maxNorm()
-           << endl;
+           << std::endl;
    }
    /*
     * Set paramemters in the FAC solver.  It solves the system Az=r.
@@ -1105,11 +1105,11 @@ int CVODEModel::CVSpgmrPrecondSolve(
       double avg_convergence, final_convergence;
       d_FAC_solver->getConvergenceFactors(avg_convergence, final_convergence);
       pout << "   \t\t\tFinal Residual Norm: "
-           << d_FAC_solver->getResidualNorm() << endl;
+           << d_FAC_solver->getResidualNorm() << std::endl;
       pout << "   \t\t\tFinal Convergence Error: "
-           << final_convergence << endl;
+           << final_convergence << std::endl;
       pout << "   \t\t\tFinal Convergence Rate: "
-           << avg_convergence << endl;
+           << avg_convergence << std::endl;
    }
 
    /******************************************************************
@@ -1147,7 +1147,7 @@ int CVODEModel::CVSpgmrPrecondSolve(
            << "\n   \t\t\tz_maxnorm = " << z_samvect->maxNorm()
            << "\n   \t\t\tResidual Norm: " << d_FAC_solver->getResidualNorm()
            << "\n   \t\t\tConvergence Error: " << final_convergence
-           << endl;
+           << std::endl;
    }
 
    if (converge != true) {
@@ -1340,7 +1340,7 @@ CVODEModel::getFromInput(
    } else {
       TBOX_WARNING(
          d_object_name << ": "
-                       << "Key data `Boundary_data' not found in input. " << endl);
+                       << "Key data `Boundary_data' not found in input. " << std::endl);
    }
 
 #ifdef USE_FAC_PRECONDITIONER
@@ -1435,7 +1435,7 @@ void CVODEModel::getFromRestart()
 
 void CVODEModel::readDirichletBoundaryDataEntry(
    const std::shared_ptr<Database>& db,
-   string& db_name,
+   std::string& db_name,
    int bdry_location_index)
 {
    TBOX_ASSERT(db);
@@ -1456,7 +1456,7 @@ void CVODEModel::readDirichletBoundaryDataEntry(
 
 void CVODEModel::readNeumannBoundaryDataEntry(
    const std::shared_ptr<Database>& db,
-   string& db_name,
+   std::string& db_name,
    int bdry_location_index)
 {
    TBOX_ASSERT(db);
@@ -1477,7 +1477,7 @@ void CVODEModel::readNeumannBoundaryDataEntry(
 
 void CVODEModel::readStateDataEntry(
    std::shared_ptr<Database> db,
-   const string& db_name,
+   const std::string& db_name,
    int array_indx,
    std::vector<double>& val)
 {
@@ -1491,7 +1491,7 @@ void CVODEModel::readStateDataEntry(
    } else {
       TBOX_ERROR(d_object_name << ": "
                                << "`val' entry missing from " << db_name
-                               << " input database. " << endl);
+                               << " input database. " << std::endl);
    }
 
 }
@@ -1504,59 +1504,59 @@ void CVODEModel::readStateDataEntry(
  */
 
 void CVODEModel::printClassData(
-   ostream& os) const
+   std::ostream& os) const
 {
    fflush(stdout);
    int j;
 
-   os << "ptr CVODEModel = " << (CVODEModel *)this << endl;
+   os << "ptr CVODEModel = " << (CVODEModel *)this << std::endl;
 
-   os << "d_object_name = " << d_object_name << endl;
+   os << "d_object_name = " << d_object_name << std::endl;
 
-   os << "d_soln_cur_id = " << d_soln_cur_id << endl;
-   os << "d_soln_scr_id = " << d_soln_scr_id << endl;
+   os << "d_soln_cur_id = " << d_soln_cur_id << std::endl;
+   os << "d_soln_scr_id = " << d_soln_scr_id << std::endl;
 
-   os << "d_initial_value = " << d_initial_value << endl;
+   os << "d_initial_value = " << d_initial_value << std::endl;
 
-   os << "Boundary Condition data..." << endl;
+   os << "Boundary Condition data..." << std::endl;
    if (d_dim == Dimension(2)) {
       for (j = 0; j < static_cast<int>(d_scalar_bdry_edge_conds.size()); ++j) {
          os << "       d_scalar_bdry_edge_conds[" << j << "] = "
-            << d_scalar_bdry_edge_conds[j] << endl;
+            << d_scalar_bdry_edge_conds[j] << std::endl;
          if (d_scalar_bdry_edge_conds[j] == BdryCond::DIRICHLET) {
             os << "         d_bdry_edge_val[" << j << "] = "
-               << d_bdry_edge_val[j] << endl;
+               << d_bdry_edge_val[j] << std::endl;
          }
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_scalar_bdry_node_conds.size()); ++j) {
          os << "       d_scalar_bdry_node_conds[" << j << "] = "
-            << d_scalar_bdry_node_conds[j] << endl;
+            << d_scalar_bdry_node_conds[j] << std::endl;
          os << "       d_node_bdry_edge[" << j << "] = "
-            << d_node_bdry_edge[j] << endl;
+            << d_node_bdry_edge[j] << std::endl;
       }
    } else if (d_dim == Dimension(3)) {
       for (j = 0; j < static_cast<int>(d_scalar_bdry_face_conds.size()); ++j) {
          os << "       d_scalar_bdry_face_conds[" << j << "] = "
-            << d_scalar_bdry_face_conds[j] << endl;
+            << d_scalar_bdry_face_conds[j] << std::endl;
          if (d_scalar_bdry_face_conds[j] == BdryCond::DIRICHLET) {
             os << "         d_bdry_face_val[" << j << "] = "
-               << d_bdry_face_val[j] << endl;
+               << d_bdry_face_val[j] << std::endl;
          }
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_scalar_bdry_edge_conds.size()); ++j) {
          os << "       d_scalar_bdry_edge_conds[" << j << "] = "
-            << d_scalar_bdry_edge_conds[j] << endl;
+            << d_scalar_bdry_edge_conds[j] << std::endl;
          os << "       d_edge_bdry_face[" << j << "] = "
-            << d_edge_bdry_face[j] << endl;
+            << d_edge_bdry_face[j] << std::endl;
       }
-      os << endl;
+      os << std::endl;
       for (j = 0; j < static_cast<int>(d_scalar_bdry_node_conds.size()); ++j) {
          os << "       d_scalar_bdry_node_conds[" << j << "] = "
-            << d_scalar_bdry_node_conds[j] << endl;
+            << d_scalar_bdry_node_conds[j] << std::endl;
          os << "       d_node_bdry_face[" << j << "] = "
-            << d_node_bdry_face[j] << endl;
+            << d_node_bdry_face[j] << std::endl;
       }
    }
 

--- a/source/test/sundials/CVODEModel.h
+++ b/source/test/sundials/CVODEModel.h
@@ -13,7 +13,6 @@
 #ifndef included_iostream
 #define included_iostream
 #include <iostream>
-using namespace std;
 #endif
 
 #if !defined(HAVE_SUNDIALS) || !defined(HAVE_HYPRE)
@@ -133,7 +132,7 @@ public:
     * Default constructor for CVODEModel.
     */
    CVODEModel(
-      const string& object_name,
+      const std::string& object_name,
       const Dimension& dim,
       std::shared_ptr<CellPoissonFACSolver> fac_solver,
       std::shared_ptr<Database> input_db,
@@ -453,13 +452,13 @@ public:
    void
    readDirichletBoundaryDataEntry(
       const std::shared_ptr<Database>& db,
-      string& db_name,
+      std::string& db_name,
       int bdry_location_index);
 
    void
    readNeumannBoundaryDataEntry(
       const std::shared_ptr<Database>& db,
-      string& db_name,
+      std::string& db_name,
       int bdry_location_index);
 
    /**
@@ -467,7 +466,7 @@ public:
     */
    void
    printClassData(
-      ostream& os) const;
+      std::ostream& os) const;
 
 private:
    /*
@@ -490,7 +489,7 @@ private:
    void
    readStateDataEntry(
       std::shared_ptr<Database> db,
-      const string& db_name,
+      const std::string& db_name,
       int array_indx,
       std::vector<double>& uval);
 
@@ -498,7 +497,7 @@ private:
     * Object name used for error/warning reporting and as a label
     * for restart database entries.
     */
-   string d_object_name;
+   std::string d_object_name;
 
    const Dimension d_dim;
 

--- a/source/test/sundials/main.C
+++ b/source/test/sundials/main.C
@@ -16,9 +16,7 @@
 #include <fstream>
 #include <memory>
 
-using namespace std;
 
-using namespace std;
 
 #ifndef _MSC_VER
 #include <unistd.h>
@@ -109,16 +107,16 @@ int main(
 #if !defined(HAVE_SUNDIALS) || !defined(HAVE_HYPRE)
       tbox::pout << "Library compiled WITHOUT CVODE -and- HYPRE...\n"
                  << "SAMRAI was not configured with one, or both, of "
-                 << "these packages.  Cannot run this example." << endl;
+                 << "these packages.  Cannot run this example." << std::endl;
 #else
 
       /*
        * Process command line arguments.
        */
-      string input_filename;
+      std::string input_filename;
 
       if (argc != 2) {
-         tbox::pout << "USAGE:  " << argv[0] << " <input filename> " << endl;
+         tbox::pout << "USAGE:  " << argv[0] << " <input filename> " << std::endl;
          exit(-1);
       } else {
          input_filename = argv[1];
@@ -350,13 +348,13 @@ int main(
          std::shared_ptr<hier::PatchHierarchy> init_hierarchy(
             y_init->getPatchHierarchy());
 
-         tbox::pout << "Initial solution vector y() at initial time: " << endl;
+         tbox::pout << "Initial solution vector y() at initial time: " << std::endl;
          int ln;
-         tbox::pout << "y(" << init_time << "): " << endl;
+         tbox::pout << "y(" << init_time << "): " << std::endl;
          for (ln = 0; ln < init_hierarchy->getNumberOfLevels(); ++ln) {
             std::shared_ptr<hier::PatchLevel> level(
                init_hierarchy->getPatchLevel(ln));
-            tbox::plog << "level = " << ln << endl;
+            tbox::plog << "level = " << ln << std::endl;
 
             for (hier::PatchLevel::iterator p(level->begin());
                  p != level->end(); ++p) {
@@ -375,10 +373,10 @@ int main(
        * Compute maxNorm and L1Norm of initial vector
        */
       if (solution_logging) {
-         tbox::pout << "\n\nBefore solve..." << endl;
-         tbox::pout << "Max Norm of y()= " << y_init->maxNorm() << endl;
-         tbox::pout << "L1 Norm of y()= " << y_init->L1Norm() << endl;
-         tbox::pout << "L2 Norm of y()= " << y_init->L2Norm() << endl;
+         tbox::pout << "\n\nBefore solve..." << std::endl;
+         tbox::pout << "Max Norm of y()= " << y_init->maxNorm() << std::endl;
+         tbox::pout << "L1 Norm of y()= " << y_init->L1Norm() << std::endl;
+         tbox::pout << "L2 Norm of y()= " << y_init->L2Norm() << std::endl;
       }
 
       /**************************************************************************
@@ -404,7 +402,7 @@ int main(
           * Perform CVODE solve to the requested interval time.
           */
          t_cvode_solve->start();
-         tbox::plog << "return code = " << cvode_solver->solve() << endl;
+         tbox::plog << "return code = " << cvode_solver->solve() << std::endl;
          t_cvode_solve->stop();
          double actual_time =
             cvode_solver->getActualFinalValueOfIndependentVariable();
@@ -431,13 +429,13 @@ int main(
           * Write solution (if desired).
           */
          if (solution_logging) {
-            tbox::plog << "y(" << final_time << "): " << endl << endl;
+            tbox::plog << "y(" << final_time << "): " << std::endl << std::endl;
             t_log_dump->start();
             for (int ln = 0; ln < result_hierarchy->getNumberOfLevels();
                  ++ln) {
                std::shared_ptr<hier::PatchLevel> level(
                   result_hierarchy->getPatchLevel(ln));
-               tbox::plog << "level = " << ln << endl;
+               tbox::plog << "level = " << ln << std::endl;
 
                for (hier::PatchLevel::iterator p(level->begin());
                     p != level->end(); ++p) {
@@ -469,32 +467,32 @@ int main(
       int correct_precond_solves = main_db->getInteger("correct_precond_solves");
 
       if (counters[0] == correct_rhs_evals) {
-         tbox::plog << "Test 0: Number RHS evals CORRECT" << endl;
+         tbox::plog << "Test 0: Number RHS evals CORRECT" << std::endl;
       } else {
-         tbox::perr << "Test 0 FAILED: Number RHS evals INCORRECT" << endl;
+         tbox::perr << "Test 0 FAILED: Number RHS evals INCORRECT" << std::endl;
          tbox::perr << "Correct Number RHS evals:  " << correct_rhs_evals
-                    << endl;
-         tbox::perr << "Number RHS evals computed: " << counters[0] << endl;
+                    << std::endl;
+         tbox::perr << "Number RHS evals computed: " << counters[0] << std::endl;
       }
 
       if (counters[1] == correct_precond_setups) {
-         tbox::plog << "Test 1: Number precond setups CORRECT" << endl;
+         tbox::plog << "Test 1: Number precond setups CORRECT" << std::endl;
       } else {
-         tbox::perr << "Test 1 FAILED: Number precond setups INCORRECT" << endl;
+         tbox::perr << "Test 1 FAILED: Number precond setups INCORRECT" << std::endl;
          tbox::perr << "Correct number precond setups:  "
-                    << correct_precond_setups << endl;
+                    << correct_precond_setups << std::endl;
          tbox::perr << "Number precond setups computed: " << counters[1]
-                    << endl;
+                    << std::endl;
       }
 
       if (counters[2] == correct_precond_solves) {
-         tbox::plog << "Test 2: Number precond solves CORRECT" << endl;
+         tbox::plog << "Test 2: Number precond solves CORRECT" << std::endl;
       } else {
-         tbox::perr << "Test 2 FAILED: Number precond solves INCORRECT" << endl;
+         tbox::perr << "Test 2 FAILED: Number precond solves INCORRECT" << std::endl;
          tbox::perr << "Correct number precond solves:  "
-                    << correct_precond_solves << endl;
+                    << correct_precond_solves << std::endl;
          tbox::perr << "Number precond solves computed: " << counters[2]
-                    << endl;
+                    << std::endl;
       }
 #endif
 
@@ -503,7 +501,7 @@ int main(
                     << "\n\tTotal number of RHS evaluations = " << counters[0]
                     << "\n\tTotal number of precond setups = " << counters[1]
                     << "\n\tTotal number of precond solves = " << counters[2]
-                    << endl;
+                    << std::endl;
 
          /*
           * Write out timestep sequence information
@@ -512,7 +510,7 @@ int main(
                     << "  time                   \t"
                     << "  Max Norm  \t"
                     << "  L1 Norm  \t"
-                    << "  L2 Norm  " << endl;
+                    << "  L2 Norm  " << std::endl;
 
          for (interval = 0; interval < num_print_intervals; ++interval) {
             tbox::pout.precision(18);
@@ -520,7 +518,7 @@ int main(
             tbox::pout.precision(6);
             tbox::pout << "  " << maxnorm[interval] << "  \t"
                        << "  " << l1norm[interval] << "  \t"
-                       << "  " << l2norm[interval] << endl;
+                       << "  " << l2norm[interval] << std::endl;
          }
       }
 
@@ -546,7 +544,7 @@ int main(
 
 #endif // HAVE_SUNDIALS
 
-      tbox::pout << "\nPASSED:  cvode" << endl;
+      tbox::pout << "\nPASSED:  cvode" << std::endl;
 
    }
 

--- a/source/test/testlib/MblkHyperbolicLevelIntegrator.C
+++ b/source/test/testlib/MblkHyperbolicLevelIntegrator.C
@@ -14,7 +14,6 @@
 #include <stdlib.h>
 #include <fstream>
 #include <string>
-using namespace std;
 
 #include "SAMRAI/tbox/RestartManager.h"
 #include "SAMRAI/hier/PatchDataRestartManager.h"
@@ -130,7 +129,7 @@ using namespace algs;
  */
 
 MblkHyperbolicLevelIntegrator::MblkHyperbolicLevelIntegrator(
-   const string& object_name,
+   const std::string& object_name,
    const tbox::Dimension& dim,
    const std::shared_ptr<tbox::Database> input_db,
    MblkHyperbolicPatchStrategy* patch_strategy,
@@ -651,7 +650,7 @@ MblkHyperbolicLevelIntegrator::initializeLevelIntegrator(
        (gridding_alg->getTagAndInitializeStrategy()->getErrorCoarsenRatio() > 3)) {
       TBOX_ERROR("MblkHyperbolicLevelIntegrator::initializeLevelIntegrator "
          << "error...\n" << "   object name = " << d_object_name
-         << "   gridding algorithm has bad error coarsen ratio" << endl);
+         << "   gridding algorithm has bad error coarsen ratio" << std::endl);
    }
 
    if ((gridding_alg->getTagAndInitializeStrategy()->everUsesTimeIntegration()) &&
@@ -1134,7 +1133,7 @@ MblkHyperbolicLevelIntegrator::advanceLevel(
                TBOX_ERROR(
                   d_object_name << ":  "
                                 << "Attempt to fill new ghost data for timestep"
-                                << "computation, but schedule not defined." << endl);
+                                << "computation, but schedule not defined." << std::endl);
             }
 
             d_patch_strategy->setDataContext(d_scratch);
@@ -1891,7 +1890,7 @@ void MblkHyperbolicLevelIntegrator::registerVariable(
                   d_object_name << ":  "
                                 << "Attempt to register FaceVariable when "
                                 << "SideVariable already registered."
-                                << endl);
+                                << std::endl);
             }
 
             d_flux_is_face = true;
@@ -1902,7 +1901,7 @@ void MblkHyperbolicLevelIntegrator::registerVariable(
                   d_object_name << ":  "
                                 << "Attempt to register SideVariable when "
                                 << "FaceVariable already registered."
-                                << endl);
+                                << std::endl);
             }
 
             d_flux_is_face = false;
@@ -1910,7 +1909,7 @@ void MblkHyperbolicLevelIntegrator::registerVariable(
          } else {
             TBOX_ERROR(
                d_object_name << ":  "
-                             << "Flux is neither face- or side-centered." << endl);
+                             << "Flux is neither face- or side-centered." << std::endl);
          }
 
          d_flux_variables.push_back(var);
@@ -1921,9 +1920,9 @@ void MblkHyperbolicLevelIntegrator::registerVariable(
 
          d_flux_var_data.setFlag(scr_id);
 
-         string var_name = var->getName();
-         string fs_suffix = "_fluxsum";
-         string fsum_name = var_name;
+         std::string var_name = var->getName();
+         std::string fs_suffix = "_fluxsum";
+         std::string fsum_name = var_name;
          fsum_name += fs_suffix;
 
          std::shared_ptr<hier::Variable> fluxsum;
@@ -1979,7 +1978,7 @@ void MblkHyperbolicLevelIntegrator::registerVariable(
          TBOX_ERROR(
             d_object_name << ":  "
                           << "unknown HYP_VAR_TYPE = " << h_v_type
-                          << endl);
+                          << std::endl);
 
       }
 
@@ -2325,22 +2324,22 @@ void MblkHyperbolicLevelIntegrator::copyTimeDependentData(
  */
 
 void MblkHyperbolicLevelIntegrator::printClassData(
-   ostream& os) const
+   std::ostream& os) const
 {
-   os << "\nMblkHyperbolicLevelIntegrator::printClassData..." << endl;
+   os << "\nMblkHyperbolicLevelIntegrator::printClassData..." << std::endl;
    os << "MblkHyperbolicLevelIntegrator: this = "
-      << (MblkHyperbolicLevelIntegrator *)this << endl;
-   os << "d_object_name = " << d_object_name << endl;
+      << (MblkHyperbolicLevelIntegrator *)this << std::endl;
+   os << "d_object_name = " << d_object_name << std::endl;
    os << "d_cfl = " << d_cfl << "\n"
-      << "d_cfl_init = " << d_cfl_init << endl;
+      << "d_cfl_init = " << d_cfl_init << std::endl;
    os << "d_lag_dt_computation = " << d_lag_dt_computation << "\n"
       << "d_use_ghosts_for_dt = "
-      << d_use_ghosts_for_dt << endl;
+      << d_use_ghosts_for_dt << std::endl;
    os << "d_patch_strategy = "
-      << (MblkHyperbolicPatchStrategy *)d_patch_strategy << endl;
+      << (MblkHyperbolicPatchStrategy *)d_patch_strategy << std::endl;
    os
    << "NOTE: Not printing variable arrays, ComponentSelectors, communication schedules, etc."
-   << endl;
+   << std::endl;
 }
 
 /*
@@ -2421,7 +2420,7 @@ void MblkHyperbolicLevelIntegrator::getFromInput(
             d_object_name << ":  "
                           << "Key data `use_ghosts_to_compute_dt' not found in input."
                           << "  Using default value "
-                          << d_use_ghosts_for_dt << endl);
+                          << d_use_ghosts_for_dt << std::endl);
       }
    }
 
@@ -2455,7 +2454,7 @@ void MblkHyperbolicLevelIntegrator::getFromRestart()
 
    if (!root_db->isDatabase(d_object_name)) {
       TBOX_ERROR("Restart database corresponding to "
-         << d_object_name << " not found in restart file" << endl);
+         << d_object_name << " not found in restart file" << std::endl);
    }
    std::shared_ptr<tbox::Database> db(root_db->getDatabase(d_object_name));
 
@@ -2463,7 +2462,7 @@ void MblkHyperbolicLevelIntegrator::getFromRestart()
    if (ver != ALGS_HYPERBOLIC_LEVEL_INTEGRATOR_VERSION) {
       TBOX_ERROR(d_object_name << ":  "
                                << "Restart file version different "
-                               << "than class version." << endl);
+                               << "than class version." << std::endl);
    }
 
    d_cfl = db->getDouble("d_cfl");

--- a/source/test/testlib/MblkHyperbolicPatchStrategy.C
+++ b/source/test/testlib/MblkHyperbolicPatchStrategy.C
@@ -12,7 +12,6 @@
 
 #include "SAMRAI/tbox/Utilities.h"
 
-using namespace std;
 using namespace SAMRAI;
 
 MblkHyperbolicPatchStrategy::MblkHyperbolicPatchStrategy(
@@ -50,7 +49,7 @@ void MblkHyperbolicPatchStrategy::tagGradientDetectorCells(
    TBOX_WARNING("MblkHyperbolicPatchStrategy::tagGradientDetectorCells()"
       << "\nNo class supplies a concrete implementation for "
       << "\nthis method.  The default abstract method (which "
-      << "\ndoes no cell tagging) is executed" << endl);
+      << "\ndoes no cell tagging) is executed" << std::endl);
 }
 
 void MblkHyperbolicPatchStrategy::tagRichardsonExtrapolationCells(
@@ -79,5 +78,5 @@ void MblkHyperbolicPatchStrategy::tagRichardsonExtrapolationCells(
       "MblkHyperbolicPatchStrategy::tagRichardsonExtrapolationCells()"
       << "\nNo class supplies a concrete implementation for "
       << "\nthis method.  The default abstract method (which "
-      << "\ndoes no cell tagging) is executed" << endl);
+      << "\ndoes no cell tagging) is executed" << std::endl);
 }

--- a/source/test/testlib/SkeletonBoundaryUtilities2.C
+++ b/source/test/testlib/SkeletonBoundaryUtilities2.C
@@ -65,7 +65,6 @@ void SAMRAI_F77_FUNC(getskelnodebdry2d, GETSKELNODEBDRY2D) (
 
 }
 
-using namespace std;
 using namespace SAMRAI;
 using namespace appu;
 
@@ -142,7 +141,7 @@ void SkeletonBoundaryUtilities2::getFromInput(
  */
 
 void SkeletonBoundaryUtilities2::fillEdgeBoundaryData(
-   const string& varname,
+   const std::string& varname,
    std::shared_ptr<pdat::CellData<double> >& vardata,
    const hier::Patch& patch,
    const hier::IntVector& ghost_fill_width,
@@ -219,7 +218,7 @@ void SkeletonBoundaryUtilities2::fillEdgeBoundaryData(
  */
 
 void SkeletonBoundaryUtilities2::fillNodeBoundaryData(
-   const string& varname,
+   const std::string& varname,
    std::shared_ptr<pdat::CellData<double> >& vardata,
    const hier::Patch& patch,
    const hier::IntVector& ghost_fill_width,
@@ -328,7 +327,7 @@ int SkeletonBoundaryUtilities2::getEdgeLocationForNodeBdry(
          TBOX_ERROR("Unknown node boundary condition type = "
             << node_btype << " passed to \n"
             << "SkeletonBoundaryUtilities2::getEdgeLocationForNodeBdry"
-            << endl);
+            << std::endl);
       }
    }
 
@@ -337,7 +336,7 @@ int SkeletonBoundaryUtilities2::getEdgeLocationForNodeBdry(
          << node_btype << " and node location = " << node_loc
          << "\n passed to "
          << "SkeletonBoundaryUtilities2::getEdgeLocationForNodeBdry"
-         << " are inconsistant." << endl);
+         << " are inconsistant." << std::endl);
    }
 
    return ret_edge;
@@ -359,7 +358,7 @@ int SkeletonBoundaryUtilities2::getEdgeLocationForNodeBdry(
  */
 
 int SkeletonBoundaryUtilities2::checkBdryData(
-   const string& varname,
+   const std::string& varname,
    const hier::Patch& patch,
    int data_id,
    int depth,
@@ -384,7 +383,7 @@ int SkeletonBoundaryUtilities2::checkBdryData(
          patch.getPatchData(data_id)));
    TBOX_ASSERT(vardata);
 
-   string bdry_type_str;
+   std::string bdry_type_str;
    if (btype == Bdry::EDGE2D) {
       bdry_type_str = "EDGE";
    } else if (btype == Bdry::NODE2D) {
@@ -393,14 +392,14 @@ int SkeletonBoundaryUtilities2::checkBdryData(
       TBOX_ERROR(
          "Unknown btype " << btype
                           << " passed to SkeletonBoundaryUtilities2::checkBdryData()! "
-                          << endl);
+                          << std::endl);
    }
 
-   tbox::plog << "\n\nCHECKING 2D " << bdry_type_str << " BDRY DATA..." << endl;
-   tbox::plog << "varname = " << varname << " : depth = " << depth << endl;
-   tbox::plog << "bbox = " << bbox.getBox() << endl;
+   tbox::plog << "\n\nCHECKING 2D " << bdry_type_str << " BDRY DATA..." << std::endl;
+   tbox::plog << "varname = " << varname << " : depth = " << depth << std::endl;
+   tbox::plog << "bbox = " << bbox.getBox() << std::endl;
    tbox::plog << "btype, bloc, bcase = "
-              << btype << ", = " << bloc << ", = " << bcase << endl;
+              << btype << ", = " << bloc << ", = " << bcase << std::endl;
 
    tbox::Dimension::dir_t idir;
    double valfact = 0.0, constval = 0.0, dxfact = 0.0;
@@ -428,7 +427,7 @@ int SkeletonBoundaryUtilities2::checkBdryData(
             "Unknown bcase " << bcase
                              << " passed to SkeletonBoundaryUtilities2::checkBdryData()"
                              << "\n for " << bdry_type_str
-                             << " at location " << bloc << endl);
+                             << " at location " << bloc << std::endl);
       }
 
    } else if (btype == Bdry::NODE2D) {
@@ -451,7 +450,7 @@ int SkeletonBoundaryUtilities2::checkBdryData(
             "Unknown bcase " << bcase
                              << " passed to SkeletonBoundaryUtilities2::checkBdryData()"
                              << "\n for " << bdry_type_str
-                             << " at location " << bloc << endl);
+                             << " at location " << bloc << std::endl);
       }
 
    }
@@ -492,7 +491,7 @@ int SkeletonBoundaryUtilities2::checkBdryData(
                                 << " boundary value for " << varname
                                 << " found in cell " << check
                                 << "\n   found = " << (*vardata)(check, depth)
-                                << " : correct = " << offcheckval << endl);
+                                << " : correct = " << offcheckval << std::endl);
          }
          check(idir) += offsign;
       }
@@ -526,7 +525,7 @@ void SkeletonBoundaryUtilities2::read2dBdryEdges(
 
       for (int s = 0; s < NUM_2D_EDGES; ++s) {
 
-         string bdry_loc_str;
+         std::string bdry_loc_str;
          switch (s) {
             case BdryLoc::XLO: {
                bdry_loc_str = "boundary_edge_xlo";
@@ -563,7 +562,7 @@ void SkeletonBoundaryUtilities2::read2dBdryEdges(
                   input_db->getDatabase(bdry_loc_str));
                if (bdry_loc_db) {
                   if (bdry_loc_db->keyExists("boundary_condition")) {
-                     string bdry_cond_str =
+                     std::string bdry_cond_str =
                         bdry_loc_db->getString("boundary_condition");
                      if (bdry_cond_str == "FLOW") {
                         edge_conds[s] = BdryCond::FLOW;
@@ -577,16 +576,16 @@ void SkeletonBoundaryUtilities2::read2dBdryEdges(
                            s);
                      } else {
                         TBOX_ERROR("Unknown edge boundary string = "
-                           << bdry_cond_str << " found in input." << endl);
+                           << bdry_cond_str << " found in input." << std::endl);
                      }
                   } else {
                      TBOX_ERROR("'boundary_condition' entry missing from "
-                        << bdry_loc_str << " input database." << endl);
+                        << bdry_loc_str << " input database." << std::endl);
                   }
                }
             } else {
                TBOX_ERROR(bdry_loc_str
-                  << " database entry not found in input." << endl);
+                  << " database entry not found in input." << std::endl);
             }
          } // if (need_data_read)
 
@@ -619,7 +618,7 @@ void SkeletonBoundaryUtilities2::read2dBdryNodes(
 
       for (int s = 0; s < NUM_2D_NODES; ++s) {
 
-         string bdry_loc_str;
+         std::string bdry_loc_str;
          switch (s) {
             case NodeBdyLoc2D::XLO_YLO: {
                bdry_loc_str = "boundary_node_xlo_ylo";
@@ -645,7 +644,7 @@ void SkeletonBoundaryUtilities2::read2dBdryNodes(
                input_db->getDatabase(bdry_loc_str));
             if (bdry_loc_db) {
                if (bdry_loc_db->keyExists("boundary_condition")) {
-                  string bdry_cond_str =
+                  std::string bdry_cond_str =
                      bdry_loc_db->getString("boundary_condition");
                   if (bdry_cond_str == "XFLOW") {
                      node_conds[s] = BdryCond::XFLOW;
@@ -661,11 +660,11 @@ void SkeletonBoundaryUtilities2::read2dBdryNodes(
                      node_conds[s] = BdryCond::YDIRICHLET;
                   } else {
                      TBOX_ERROR("Unknown node boundary string = "
-                        << bdry_cond_str << " found in input." << endl);
+                        << bdry_cond_str << " found in input." << std::endl);
                   }
 
-                  string proper_edge;
-                  string proper_edge_data;
+                  std::string proper_edge;
+                  std::string proper_edge_data;
                   bool no_edge_data_found = false;
                   if (bdry_cond_str == "XFLOW" ||
                       bdry_cond_str == "XDIRICHLET" ||
@@ -754,17 +753,17 @@ void SkeletonBoundaryUtilities2::read2dBdryNodes(
                                           << "\n but no "
                                           << proper_edge_data
                                           << " data found for edge "
-                                          << proper_edge << endl);
+                                          << proper_edge << std::endl);
                   }
 
                } else {
                   TBOX_ERROR("'boundary_condition' entry missing from "
-                     << bdry_loc_str << " input database." << endl);
+                     << bdry_loc_str << " input database." << std::endl);
                }
             }
          } else {
             TBOX_ERROR(bdry_loc_str
-               << " database entry not found in input." << endl);
+               << " database entry not found in input." << std::endl);
          }
 
       } // for (int s = 0 ...
@@ -786,7 +785,7 @@ void SkeletonBoundaryUtilities2::get2dBdryDirectionCheckValues(
    int bcase)
 {
 
-   string bdry_type_str;
+   std::string bdry_type_str;
 
    if (btype == Bdry::EDGE2D) {
 
@@ -812,7 +811,7 @@ void SkeletonBoundaryUtilities2::get2dBdryDirectionCheckValues(
                                          <<
             " passed to SkeletonBoundaryUtilities2::checkBdryData()"
                                          << "\n for "
-                                         << bdry_type_str << " boundary " << endl);
+                                         << bdry_type_str << " boundary " << std::endl);
       }
 
    } else if (btype == Bdry::NODE2D) {
@@ -844,7 +843,7 @@ void SkeletonBoundaryUtilities2::get2dBdryDirectionCheckValues(
          "Unknown boundary type " << btype
                                   << " passed to SkeletonBoundaryUtilities2::checkBdryData()"
                                   << "\n for " << bdry_type_str
-                                  << " at location " << bloc << endl);
+                                  << " at location " << bloc << std::endl);
    }
 
 }

--- a/source/test/testlib/SkeletonBoundaryUtilities2.h
+++ b/source/test/testlib/SkeletonBoundaryUtilities2.h
@@ -91,7 +91,6 @@
  * @see appu::BoundaryUtilityStrategy2
  */
 
-using namespace std;
 using namespace SAMRAI;
 using namespace appu;
 
@@ -154,7 +153,7 @@ public:
     */
    static void
    fillEdgeBoundaryData(
-      const string& varname,
+      const std::string& varname,
       std::shared_ptr<pdat::CellData<double> >& vardata,
       const hier::Patch& patch,
       const hier::IntVector& ghost_width_to_fill,
@@ -178,7 +177,7 @@ public:
     */
    static void
    fillNodeBoundaryData(
-      const string& varname,
+      const std::string& varname,
       std::shared_ptr<pdat::CellData<double> >& vardata,
       const hier::Patch& patch,
       const hier::IntVector& ghost_width_to_fill,
@@ -226,7 +225,7 @@ public:
     */
    static int
    checkBdryData(
-      const string& varname,
+      const std::string& varname,
       const hier::Patch& patch,
       int data_id,
       int depth,

--- a/source/test/testlib/SkeletonBoundaryUtilities3.C
+++ b/source/test/testlib/SkeletonBoundaryUtilities3.C
@@ -181,7 +181,7 @@ void SkeletonBoundaryUtilities3::getFromInput(
  */
 
 void SkeletonBoundaryUtilities3::fillFaceBoundaryData(
-   const string& varname,
+   const std::string& varname,
    std::shared_ptr<pdat::CellData<double> >& vardata,
    const hier::Patch& patch,
    const hier::IntVector& ghost_fill_width,
@@ -258,7 +258,7 @@ void SkeletonBoundaryUtilities3::fillFaceBoundaryData(
  */
 
 void SkeletonBoundaryUtilities3::fillEdgeBoundaryData(
-   const string& varname,
+   const std::string& varname,
    std::shared_ptr<pdat::CellData<double> >& vardata,
    const hier::Patch& patch,
    const hier::IntVector& ghost_fill_width,
@@ -337,7 +337,7 @@ void SkeletonBoundaryUtilities3::fillEdgeBoundaryData(
  */
 
 void SkeletonBoundaryUtilities3::fillNodeBoundaryData(
-   const string& varname,
+   const std::string& varname,
    std::shared_ptr<pdat::CellData<double> >& vardata,
    const hier::Patch& patch,
    const hier::IntVector& ghost_fill_width,
@@ -471,7 +471,7 @@ int SkeletonBoundaryUtilities3::getFaceLocationForEdgeBdry(
          TBOX_ERROR("Unknown edge boundary condition type = "
             << edge_btype << " passed to \n"
             << "SkeletonBoundaryUtilities3::getFaceLocationForEdgeBdry"
-            << endl);
+            << std::endl);
       }
    }
 
@@ -480,7 +480,7 @@ int SkeletonBoundaryUtilities3::getFaceLocationForEdgeBdry(
          << edge_btype << " and edge location = " << edge_loc
          << "\n passed to "
          << "SkeletonBoundaryUtilities3::getFaceLocationForEdgeBdry"
-         << " are inconsistant." << endl);
+         << " are inconsistant." << std::endl);
    }
 
    return ret_face;
@@ -554,7 +554,7 @@ int SkeletonBoundaryUtilities3::getFaceLocationForNodeBdry(
          TBOX_ERROR("Unknown node boundary condition type = "
             << node_btype << " passed to \n"
             << "SkeletonBoundaryUtilities3::getFaceLocationForNodeBdry"
-            << endl);
+            << std::endl);
       }
    }
 
@@ -563,7 +563,7 @@ int SkeletonBoundaryUtilities3::getFaceLocationForNodeBdry(
          << node_btype << " and node location = " << node_loc
          << "\n passed to "
          << "SkeletonBoundaryUtilities3::getFaceLocationForNodeBdry"
-         << " are inconsistant." << endl);
+         << " are inconsistant." << std::endl);
    }
 
    return ret_face;
@@ -585,7 +585,7 @@ int SkeletonBoundaryUtilities3::getFaceLocationForNodeBdry(
  */
 
 int SkeletonBoundaryUtilities3::checkBdryData(
-   const string& varname,
+   const std::string& varname,
    const hier::Patch& patch,
    int data_id,
    int depth,
@@ -611,7 +611,7 @@ int SkeletonBoundaryUtilities3::checkBdryData(
          patch.getPatchData(data_id)));
    TBOX_ASSERT(vardata);
 
-   string bdry_type_str;
+   std::string bdry_type_str;
    if (btype == Bdry::FACE3D) {
       bdry_type_str = "FACE";
    } else if (btype == Bdry::EDGE3D) {
@@ -622,14 +622,14 @@ int SkeletonBoundaryUtilities3::checkBdryData(
       TBOX_ERROR(
          "Unknown btype " << btype
                           << " passed to SkeletonBoundaryUtilities3::checkBdryData()! "
-                          << endl);
+                          << std::endl);
    }
 
-   tbox::plog << "\n\nCHECKING 3D " << bdry_type_str << " BDRY DATA..." << endl;
-   tbox::plog << "varname = " << varname << " : depth = " << depth << endl;
-   tbox::plog << "bbox = " << bbox.getBox() << endl;
+   tbox::plog << "\n\nCHECKING 3D " << bdry_type_str << " BDRY DATA..." << std::endl;
+   tbox::plog << "varname = " << varname << " : depth = " << depth << std::endl;
+   tbox::plog << "bbox = " << bbox.getBox() << std::endl;
    tbox::plog << "btype, bloc, bcase = "
-              << btype << ", = " << bloc << ", = " << bcase << endl;
+              << btype << ", = " << bloc << ", = " << bcase << std::endl;
 
    tbox::Dimension::dir_t idir;
    double valfact = 0.0, constval = 0.0, dxfact = 0.0;
@@ -657,7 +657,7 @@ int SkeletonBoundaryUtilities3::checkBdryData(
             "Unknown bcase " << bcase
                              << " passed to SkeletonBoundaryUtilities3::checkBdryData()"
                              << "\n for " << bdry_type_str
-                             << " at location " << bloc << endl);
+                             << " at location " << bloc << std::endl);
       }
 
    } else if (btype == Bdry::EDGE3D) {
@@ -682,7 +682,7 @@ int SkeletonBoundaryUtilities3::checkBdryData(
             "Unknown bcase " << bcase
                              << " passed to SkeletonBoundaryUtilities3::checkBdryData()"
                              << "\n for " << bdry_type_str
-                             << " at location " << bloc << endl);
+                             << " at location " << bloc << std::endl);
       }
 
    } else if (btype == Bdry::NODE3D) {
@@ -707,7 +707,7 @@ int SkeletonBoundaryUtilities3::checkBdryData(
             "Unknown bcase " << bcase
                              << " passed to SkeletonBoundaryUtilities3::checkBdryData()"
                              << "\n for " << bdry_type_str
-                             << " at location " << bloc << endl);
+                             << " at location " << bloc << std::endl);
       }
 
    }
@@ -748,7 +748,7 @@ int SkeletonBoundaryUtilities3::checkBdryData(
                                 << " boundary value for " << varname
                                 << " found in cell " << check
                                 << "\n   found = " << (*vardata)(check, depth)
-                                << " : correct = " << offcheckval << endl);
+                                << " : correct = " << offcheckval << std::endl);
          }
          check(idir) += offsign;
       }
@@ -782,7 +782,7 @@ void SkeletonBoundaryUtilities3::read3dBdryFaces(
 
       for (int s = 0; s < NUM_3D_FACES; ++s) {
 
-         string bdry_loc_str;
+         std::string bdry_loc_str;
          switch (s) {
             case BdryLoc::XLO: { bdry_loc_str = "boundary_face_xlo";
                                  break;
@@ -822,7 +822,7 @@ void SkeletonBoundaryUtilities3::read3dBdryFaces(
                   input_db->getDatabase(bdry_loc_str));
                if (bdry_loc_db) {
                   if (bdry_loc_db->keyExists("boundary_condition")) {
-                     string bdry_cond_str =
+                     std::string bdry_cond_str =
                         bdry_loc_db->getString("boundary_condition");
                      if (bdry_cond_str == "FLOW") {
                         face_conds[s] = BdryCond::FLOW;
@@ -842,16 +842,16 @@ void SkeletonBoundaryUtilities3::read3dBdryFaces(
                            s);
                      } else {
                         TBOX_ERROR("Unknown face boundary string = "
-                           << bdry_cond_str << " found in input." << endl);
+                           << bdry_cond_str << " found in input." << std::endl);
                      }
                   } else {
                      TBOX_ERROR("'boundary_condition' entry missing from "
-                        << bdry_loc_str << " input database." << endl);
+                        << bdry_loc_str << " input database." << std::endl);
                   }
                }
             } else {
                TBOX_ERROR(bdry_loc_str
-                  << " database entry not found in input." << endl);
+                  << " database entry not found in input." << std::endl);
             }
          } // if (need_data_read)
 
@@ -884,7 +884,7 @@ void SkeletonBoundaryUtilities3::read3dBdryEdges(
 
       for (int s = 0; s < NUM_3D_EDGES; ++s) {
 
-         string bdry_loc_str;
+         std::string bdry_loc_str;
          switch (s) {
             case EdgeBdyLoc3D::YLO_ZLO: {
                bdry_loc_str = "boundary_edge_ylo_zlo";
@@ -960,7 +960,7 @@ void SkeletonBoundaryUtilities3::read3dBdryEdges(
                   input_db->getDatabase(bdry_loc_str));
                if (bdry_loc_db) {
                   if (bdry_loc_db->keyExists("boundary_condition")) {
-                     string bdry_cond_str =
+                     std::string bdry_cond_str =
                         bdry_loc_db->getString("boundary_condition");
                      if (bdry_cond_str == "XFLOW") {
                         edge_conds[s] = BdryCond::XFLOW;
@@ -988,7 +988,7 @@ void SkeletonBoundaryUtilities3::read3dBdryEdges(
                         edge_conds[s] = BdryCond::ZNEUMANN;
                      } else {
                         TBOX_ERROR("Unknown edge boundary string = "
-                           << bdry_cond_str << " found in input." << endl);
+                           << bdry_cond_str << " found in input." << std::endl);
                      }
 
                      bool ambiguous_type = false;
@@ -1020,11 +1020,11 @@ void SkeletonBoundaryUtilities3::read3dBdryEdges(
                      if (ambiguous_type) {
                         TBOX_ERROR("Ambiguous bdry condition "
                            << bdry_cond_str
-                           << " found for " << bdry_loc_str << endl);
+                           << " found for " << bdry_loc_str << std::endl);
                      }
 
-                     string proper_face;
-                     string proper_face_data;
+                     std::string proper_face;
+                     std::string proper_face_data;
                      bool no_face_data_found = false;
                      if (bdry_cond_str == "XFLOW" ||
                          bdry_cond_str == "XDIRICHLET" ||
@@ -1185,16 +1185,16 @@ void SkeletonBoundaryUtilities3::read3dBdryEdges(
                                              << "\n but no "
                                              << proper_face_data
                                              << " data found for face "
-                                             << proper_face << endl);
+                                             << proper_face << std::endl);
                      }
                   } else {
                      TBOX_ERROR("'boundary_condition' entry missing from "
-                        << bdry_loc_str << " input database." << endl);
+                        << bdry_loc_str << " input database." << std::endl);
                   }
                }
             } else {
                TBOX_ERROR(bdry_loc_str
-                  << " database entry not found in input." << endl);
+                  << " database entry not found in input." << std::endl);
             }
 
          } // if (need_data_read)
@@ -1228,7 +1228,7 @@ void SkeletonBoundaryUtilities3::read3dBdryNodes(
 
       for (int s = 0; s < NUM_3D_NODES; ++s) {
 
-         string bdry_loc_str;
+         std::string bdry_loc_str;
          switch (s) {
             case NodeBdyLoc3D::XLO_YLO_ZLO: {
                bdry_loc_str = "boundary_node_xlo_ylo_zlo";
@@ -1270,7 +1270,7 @@ void SkeletonBoundaryUtilities3::read3dBdryNodes(
                input_db->getDatabase(bdry_loc_str));
             if (bdry_loc_db) {
                if (bdry_loc_db->keyExists("boundary_condition")) {
-                  string bdry_cond_str =
+                  std::string bdry_cond_str =
                      bdry_loc_db->getString("boundary_condition");
                   if (bdry_cond_str == "XFLOW") {
                      node_conds[s] = BdryCond::XFLOW;
@@ -1298,11 +1298,11 @@ void SkeletonBoundaryUtilities3::read3dBdryNodes(
                      node_conds[s] = BdryCond::ZNEUMANN;
                   } else {
                      TBOX_ERROR("Unknown node boundary string = "
-                        << bdry_cond_str << " found in input." << endl);
+                        << bdry_cond_str << " found in input." << std::endl);
                   }
 
-                  string proper_face;
-                  string proper_face_data;
+                  std::string proper_face;
+                  std::string proper_face_data;
                   bool no_face_data_found = false;
                   if (bdry_cond_str == "XFLOW" ||
                       bdry_cond_str == "XDIRICHLET" ||
@@ -1469,17 +1469,17 @@ void SkeletonBoundaryUtilities3::read3dBdryNodes(
                                           << "\n but no "
                                           << proper_face_data
                                           << " data found for face "
-                                          << proper_face << endl);
+                                          << proper_face << std::endl);
                   }
 
                } else {
                   TBOX_ERROR("'boundary_condition' entry missing from "
-                     << bdry_loc_str << " input database." << endl);
+                     << bdry_loc_str << " input database." << std::endl);
                }
             }
          } else {
             TBOX_ERROR(bdry_loc_str
-               << " database entry not found in input." << endl);
+               << " database entry not found in input." << std::endl);
          }
 
       } // for (int s = 0 ...
@@ -1501,7 +1501,7 @@ void SkeletonBoundaryUtilities3::get3dBdryDirectionCheckValues(
    int bcase)
 {
 
-   string bdry_type_str;
+   std::string bdry_type_str;
 
    if (btype == Bdry::FACE3D) {
 
@@ -1534,7 +1534,7 @@ void SkeletonBoundaryUtilities3::get3dBdryDirectionCheckValues(
                                          <<
             " passed to SkeletonBoundaryUtilities3::checkBdryData()"
                                          << "\n for "
-                                         << bdry_type_str << " boundary " << endl);
+                                         << bdry_type_str << " boundary " << std::endl);
       }
 
    } else if (btype == Bdry::EDGE3D) {
@@ -1586,7 +1586,7 @@ void SkeletonBoundaryUtilities3::get3dBdryDirectionCheckValues(
             " passed to SkeletonBoundaryUtilities3::checkBdryData()"
                                          << "\n for " << bdry_type_str
                                          << " at location " << bloc
-                                         << endl);
+                                         << std::endl);
       }
 
    } else if (btype == Bdry::NODE3D) {
@@ -1627,7 +1627,7 @@ void SkeletonBoundaryUtilities3::get3dBdryDirectionCheckValues(
          "Unknown boundary type " << btype
                                   << " passed to SkeletonBoundaryUtilities3::checkBdryData()"
                                   << "\n for " << bdry_type_str
-                                  << " at location " << bloc << endl);
+                                  << " at location " << bloc << std::endl);
    }
 
 }

--- a/source/test/testlib/SkeletonBoundaryUtilities3.h
+++ b/source/test/testlib/SkeletonBoundaryUtilities3.h
@@ -24,7 +24,6 @@
 #include <vector>
 #include <memory>
 
-using namespace std;
 using namespace SAMRAI;
 using namespace appu;
 
@@ -181,7 +180,7 @@ public:
     */
    static void
    fillFaceBoundaryData(
-      const string& varname,
+      const std::string& varname,
       std::shared_ptr<pdat::CellData<double> >& vardata,
       const hier::Patch& patch,
       const hier::IntVector& ghost_width_to_fill,
@@ -205,7 +204,7 @@ public:
     */
    static void
    fillEdgeBoundaryData(
-      const string& varname,
+      const std::string& varname,
       std::shared_ptr<pdat::CellData<double> >& vardata,
       const hier::Patch& patch,
       const hier::IntVector& ghost_width_to_fill,
@@ -229,7 +228,7 @@ public:
     */
    static void
    fillNodeBoundaryData(
-      const string& varname,
+      const std::string& varname,
       std::shared_ptr<pdat::CellData<double> >& vardata,
       const hier::Patch& patch,
       const hier::IntVector& ghost_width_to_fill,
@@ -296,7 +295,7 @@ public:
     */
    static int
    checkBdryData(
-      const string& varname,
+      const std::string& varname,
       const hier::Patch& patch,
       int data_id,
       int depth,

--- a/source/test/testlib/SkeletonCellDoubleConservativeLinearRefine.C
+++ b/source/test/testlib/SkeletonCellDoubleConservativeLinearRefine.C
@@ -227,7 +227,7 @@ void SkeletonCellDoubleConservativeLinearRefine::refine(
             &diff2[0], slope2.getPointer());
       } else {
          TBOX_ERROR("SkeletonCellDoubleConservativeLinearRefine error...\n"
-            << "dimension > 3 not supported." << endl);
+            << "dimension > 3 not supported." << std::endl);
 
       }
    }

--- a/source/test/testlib/SkeletonCellDoubleConservativeLinearRefine.h
+++ b/source/test/testlib/SkeletonCellDoubleConservativeLinearRefine.h
@@ -23,7 +23,6 @@
 #include "SAMRAI/hier/RefineOperator.h"
 
 
-using namespace std;
 using namespace SAMRAI;
 
 /**

--- a/source/test/testlib/SkeletonCellDoubleWeightedAverage.C
+++ b/source/test/testlib/SkeletonCellDoubleWeightedAverage.C
@@ -150,7 +150,7 @@ void SkeletonCellDoubleWeightedAverage::coarsen(
             cdata->getPointer(d));
       } else {
          TBOX_ERROR("SkeletonCellDoubleWeightedAverage error...\n"
-            << "dimension > 3 not supported." << endl);
+            << "dimension > 3 not supported." << std::endl);
 
       }
    }

--- a/source/test/testlib/SkeletonCellDoubleWeightedAverage.h
+++ b/source/test/testlib/SkeletonCellDoubleWeightedAverage.h
@@ -23,7 +23,6 @@
 #include "SAMRAI/hier/CoarsenOperator.h"
 
 
-using namespace std;
 using namespace SAMRAI;
 
 /**

--- a/source/test/timers/main_example.C
+++ b/source/test/timers/main_example.C
@@ -12,7 +12,6 @@
 
 #include <string>
 #include <memory>
-using namespace std;
 
 // Headers for basic SAMRAI objects used in this code.
 #include "SAMRAI/tbox/SAMRAIManager.h"
@@ -36,13 +35,13 @@ int main(
    {
       tbox::PIO::logAllNodes("Timer.log");
 
-      string input_filename;
+      std::string input_filename;
 
       if ((argc != 2)) {
          tbox::pout << "USAGE:  " << argv[0] << " <input filename> "
                     << "  options:\n"
                     << "  none at this time"
-                    << endl;
+                    << std::endl;
          tbox::SAMRAI_MPI::abort();
          return -1;
       }
@@ -68,7 +67,7 @@ int main(
        * to avoid the name lookup cost each time it is called (its only
        * looked up the first time).
        */
-      string name = "main::test";
+      std::string name = "main::test";
       std::shared_ptr<tbox::Timer> timer(
          tbox::TimerManager::getManager()->getTimer(name));
 

--- a/source/test/timers/main_stats.C
+++ b/source/test/timers/main_stats.C
@@ -26,7 +26,6 @@
 #include <string>
 #include <memory>
 
-using namespace std;
 
 using namespace SAMRAI;
 
@@ -49,8 +48,8 @@ int main(
 
       tbox::PIO::logAllNodes("stat.log");
 
-      string input_filename;
-      string restart_dirname;
+      std::string input_filename;
+      std::string restart_dirname;
       int restore_num = 0;
 
       bool is_from_restart = false;
@@ -60,7 +59,7 @@ int main(
                     << "<restart dir> <restore number> [options]\n"
                     << "  options:\n"
                     << "  none at this time"
-                    << endl;
+                    << std::endl;
          tbox::SAMRAI_MPI::abort();
          return -1;
       } else {
@@ -186,18 +185,18 @@ int main(
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #1a: tbox::Statistician::getNumberProcessorStats()\n"
-         << "incorrect number of processor statistics found" << endl;
+         << "incorrect number of processor statistics found" << std::endl;
       } else {
-         tbox::plog << "Test #1a successful" << endl;
+         tbox::plog << "Test #1a successful" << std::endl;
       }
       tval = statistician->getNumberPatchStats();
       if (tval != 3) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #1b: tbox::Statistician::getNumberPatchStats()\n"
-         << "incorrect number of patch statistics found" << endl;
+         << "incorrect number of patch statistics found" << std::endl;
       } else {
-         tbox::plog << "Test #1b successful" << endl;
+         tbox::plog << "Test #1b successful" << std::endl;
       }
 
       // Test #2:
@@ -206,17 +205,17 @@ int main(
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #2a: tbox::Statistician::checkStatisticExists()\n"
-         << "procstat2 added to statistician, but not found" << endl;
+         << "procstat2 added to statistician, but not found" << std::endl;
       } else {
-         tbox::plog << "Test #2a successful" << endl;
+         tbox::plog << "Test #2a successful" << std::endl;
          if (tstat->getName() != "procstat2") {
             ++fail_count;
             tbox::perr
             << "FAILED: - Test #2b: tbox::Statistician::checkStatisticExists()\n"
             << "name of procstat2 does not match statistician entry"
-            << endl;
+            << std::endl;
          } else {
-            tbox::plog << "Test #2b successful" << endl;
+            tbox::plog << "Test #2b successful" << std::endl;
          }
       }
 
@@ -225,16 +224,16 @@ int main(
          tbox::perr
          << "FAILED: - Test #2c: tbox::Statistician::checkStatisticExists()\n"
          << "patchstat1 added to statistician, but not found"
-         << endl;
+         << std::endl;
       } else {
-         tbox::plog << "Test #2c successful" << endl;
+         tbox::plog << "Test #2c successful" << std::endl;
          if (tstat->getName() != "patchstat1") {
             ++fail_count;
             tbox::perr
             << "FAILED: - Test #2d: tbox::Statistician::checkStatisticExists()\n"
-            << "name of patchstat1 does not match statistician entry" << endl;
+            << "name of patchstat1 does not match statistician entry" << std::endl;
          } else {
-            tbox::plog << "Test #2c successful" << endl;
+            tbox::plog << "Test #2c successful" << std::endl;
          }
       }
 
@@ -243,9 +242,9 @@ int main(
          tbox::perr
          << "FAILED: - Test #2e: tbox::Statistician::checkStatisticExists()\n"
          << "wrongly found statistic named dummy in statistician"
-         << endl;
+         << std::endl;
       } else {
-         tbox::plog << "Test #2e successful" << endl;
+         tbox::plog << "Test #2e successful" << std::endl;
       }
       tstat.reset();
 
@@ -256,9 +255,9 @@ int main(
          tbox::perr
          << "FAILED: - Test #3a: tbox::Statistician::getProcStatId()\n"
          << "procstat1 has wrong instance id in statistician"
-         << endl;
+         << std::endl;
       } else {
-         tbox::plog << "Test #3a successful" << endl;
+         tbox::plog << "Test #3a successful" << std::endl;
       }
       if (statistician->getPatchStatId(patchstat2->getName())
           != patchstat2->getInstanceId()) {
@@ -266,41 +265,41 @@ int main(
          tbox::perr
          << "FAILED: - Test #3b: tbox::Statistician::getPatchStatId()\n"
          << "patchstat2 has wrong instance id in statistician"
-         << endl;
+         << std::endl;
       } else {
-         tbox::plog << "Test #3b successful" << endl;
+         tbox::plog << "Test #3b successful" << std::endl;
       }
       if (statistician->getProcStatId(patchstat1->getName()) != -1) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #3c: tbox::Statistician::getProcStatId()\n"
-         << "patchstat1 is not a processor statistic" << endl;
+         << "patchstat1 is not a processor statistic" << std::endl;
       } else {
-         tbox::plog << "Test #3c successful" << endl;
+         tbox::plog << "Test #3c successful" << std::endl;
       }
       if (statistician->getPatchStatId(procstat2->getName()) != -1) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #3d: tbox::Statistician::getPatchStatId()\n"
-         << "procstat2 is not a patch statistic" << endl;
+         << "procstat2 is not a patch statistic" << std::endl;
       } else {
-         tbox::plog << "Test #3d successful" << endl;
+         tbox::plog << "Test #3d successful" << std::endl;
       }
 
       // Test #4:
       if (procstat1->getType() != "PROC_STAT") {
          ++fail_count;
          tbox::perr << "FAILED: - Test #4a: tbox::Statistic::getType()\n"
-                    << "procstat1 returns incorrect type" << endl;
+                    << "procstat1 returns incorrect type" << std::endl;
       } else {
-         tbox::plog << "Test #4a successful" << endl;
+         tbox::plog << "Test #4a successful" << std::endl;
       }
       if (patchstat1->getType() != "PATCH_STAT") {
          ++fail_count;
          tbox::perr << "FAILED: - Test #4b: tbox::Statistic::getType()\n"
-                    << "patchstat1 returns incorrect type" << endl;
+                    << "patchstat1 returns incorrect type" << std::endl;
       } else {
-         tbox::plog << "Test #4b successful" << endl;
+         tbox::plog << "Test #4b successful" << std::endl;
       }
 
       // Test #5:
@@ -317,33 +316,33 @@ int main(
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #5a: tbox::Statistic::getStatSequenceLength()\n"
-         << "procstat1 returns incorrect sequence length" << endl;
+         << "procstat1 returns incorrect sequence length" << std::endl;
       } else {
-         tbox::plog << "Test #5a successful" << endl;
+         tbox::plog << "Test #5a successful" << std::endl;
       }
       if (procstat2->getStatSequenceLength() != procstat2_seqlen) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #5b: tbox::Statistic::getStatSequenceLength()\n"
-         << "procstat2 returns incorrect sequence length" << endl;
+         << "procstat2 returns incorrect sequence length" << std::endl;
       } else {
-         tbox::plog << "Test #5b successful" << endl;
+         tbox::plog << "Test #5b successful" << std::endl;
       }
       if (patchstat1->getStatSequenceLength() != 2) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #5c: tbox::Statistic::getStatSequenceLength()\n"
-         << "patchstat1 returns incorrect sequence length" << endl;
+         << "patchstat1 returns incorrect sequence length" << std::endl;
       } else {
-         tbox::plog << "Test #5c successful" << endl;
+         tbox::plog << "Test #5c successful" << std::endl;
       }
       if (patchstat2->getStatSequenceLength() != 2) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #5d: tbox::Statistic::getStatSequenceLength()\n"
-         << "patchstat2 returns incorrect sequence length" << endl;
+         << "patchstat2 returns incorrect sequence length" << std::endl;
       } else {
-         tbox::plog << "Test #5d successful" << endl;
+         tbox::plog << "Test #5d successful" << std::endl;
       }
 
       statistician->printLocalStatData(tbox::plog);
@@ -368,9 +367,9 @@ int main(
             tbox::perr << "FAILED: - Test #6a: "
                        << "Statistician::getGlobalProcStatSequenceLength()\n"
                        << "incorrect sequence length returned for procstat1"
-                       << endl;
+                       << std::endl;
          } else {
-            tbox::plog << "Test #6a successful" << endl;
+            tbox::plog << "Test #6a successful" << std::endl;
          }
 
          if (statistician->
@@ -380,9 +379,9 @@ int main(
             tbox::perr << "FAILED: - Test #6b: "
                        << "Statistician::getGlobalProcStatSequenceLength()\n"
                        << "incorrect sequence length returned for procstat2"
-                       << endl;
+                       << std::endl;
          } else {
-            tbox::plog << "Test #6b successful" << endl;
+            tbox::plog << "Test #6b successful" << std::endl;
          }
 
          for (i = 0; i < mpi.getSize(); ++i) {
@@ -393,9 +392,9 @@ int main(
                tbox::perr << "FAILED: - Test #6c: "
                           << "Statistician::getGlobalProcStatValue()\n"
                           << "incorrect global data returned for procstat1"
-                          << endl;
+                          << std::endl;
             } else {
-               tbox::plog << "Test #6c successful" << endl;
+               tbox::plog << "Test #6c successful" << std::endl;
             }
          }
          for (i = 0; i < mpi.getSize(); ++i) {
@@ -406,9 +405,9 @@ int main(
                tbox::perr << "FAILED: - Test #6d: "
                           << "Statistician::getGlobalProcStatValue()\n"
                           << "incorrect global data returned for procstat2"
-                          << endl;
+                          << std::endl;
             } else {
-               tbox::plog << "Test #6d successful" << endl;
+               tbox::plog << "Test #6d successful" << std::endl;
             }
          }
 
@@ -419,9 +418,9 @@ int main(
             tbox::perr << "FAILED: - Test #7a: "
                        << "Statistician::getGlobalPatchStatSequenceLength()\n"
                        << "incorrect sequence length returned for patchstat1"
-                       << endl;
+                       << std::endl;
          } else {
-            tbox::plog << "Test #7a successful" << endl;
+            tbox::plog << "Test #7a successful" << std::endl;
          }
 
          int num_patches = mpi.getSize() * 2;
@@ -431,9 +430,9 @@ int main(
             tbox::perr << "FAILED: - Test #7b: "
                        << "Statistician::getGlobalPatchStatNumberPatches()\n"
                        << "incorrect num patches returned for patchstat1"
-                       << endl;
+                       << std::endl;
          } else {
-            tbox::plog << "Test #7b successful" << endl;
+            tbox::plog << "Test #7b successful" << std::endl;
          }
 
          for (i = 0; i < mpi.getSize(); ++i) {
@@ -450,9 +449,9 @@ int main(
                           << "Statistician::getGlobalPatchStatValue()\n"
                           << "incorrect global data returned for patch "
                           << pnum
-                          << "in patchstat1." << endl;
+                          << "in patchstat1." << std::endl;
             } else {
-               tbox::plog << "Test #7e successful" << endl;
+               tbox::plog << "Test #7e successful" << std::endl;
             }
 
          }
@@ -467,9 +466,9 @@ int main(
             tbox::perr << "FAILED: - Test #7c: "
                        << "Statistician::getGlobalPatchStatNumberPatches()\n"
                        << "incorrect num patches returned for patchstat2"
-                       << endl;
+                       << std::endl;
          } else {
-            tbox::plog << "Test #7c successful" << endl;
+            tbox::plog << "Test #7c successful" << std::endl;
          }
 
          for (i = 0; i < mpi.getSize(); ++i) {
@@ -483,9 +482,9 @@ int main(
                tbox::perr << "FAILED: - Test #7d: "
                           << "Statistician::getGlobalPatchStatPatchMapping()\n"
                           << "incorrect mapping for patch " << pnum << "in "
-                          << "patchstat2." << endl;
+                          << "patchstat2." << std::endl;
             } else {
-               tbox::plog << "Test #7d successful" << endl;
+               tbox::plog << "Test #7d successful" << std::endl;
             }
 
          }
@@ -503,9 +502,9 @@ int main(
                           << "Statistician::getGlobalPatchStatValue()\n"
                           << "incorrect global data returned for patch "
                           << pnum
-                          << "in patchstat2." << endl;
+                          << "in patchstat2." << std::endl;
             } else {
-               tbox::plog << "Test #7f successful" << endl;
+               tbox::plog << "Test #7f successful" << std::endl;
             }
 
          }
@@ -525,9 +524,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #8a: "
                        << "Statistician::getGlobalProcStatSum()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #8a successful" << endl;
+            tbox::plog << "Test #8a successful" << std::endl;
          }
          if (!tbox::MathUtilities<double>::equalEps(statistician->
                 getGlobalProcStatSum(
@@ -535,9 +534,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #8b: "
                        << "Statistician::getGlobalProcStatSum()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #8b successful" << endl;
+            tbox::plog << "Test #8b successful" << std::endl;
          }
          if (!tbox::MathUtilities<double>::equalEps(statistician->
                 getGlobalProcStatSum(
@@ -545,9 +544,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #8c: "
                        << "Statistician::getGlobalProcStatSum()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #8c successful" << endl;
+            tbox::plog << "Test #8c successful" << std::endl;
          }
 
          double max0 = 0.;
@@ -559,9 +558,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #8d: "
                        << "Statistician::getGlobalProcStatMax()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #8d successful" << endl;
+            tbox::plog << "Test #8d successful" << std::endl;
          }
          if (!tbox::MathUtilities<double>::equalEps(statistician->
                 getGlobalProcStatMax(
@@ -569,9 +568,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #8e: "
                        << "Statistician::getGlobalProcStatMax()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #8e successful" << endl;
+            tbox::plog << "Test #8e successful" << std::endl;
          }
          if (!tbox::MathUtilities<double>::equalEps(statistician->
                 getGlobalProcStatMax(
@@ -579,9 +578,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #8f: "
                        << "Statistician::getGlobalProcStatMax()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #8f successful" << endl;
+            tbox::plog << "Test #8f successful" << std::endl;
          }
          if (statistician->getGlobalProcStatMaxProcessorId(
                 procstat1->getInstanceId(),
@@ -589,9 +588,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #8g: "
                        << "Statistician::getGlobalProcStatMaxId()\n"
-                       << "returned incorrect ID." << endl;
+                       << "returned incorrect ID." << std::endl;
          } else {
-            tbox::plog << "Test #8g successful" << endl;
+            tbox::plog << "Test #8g successful" << std::endl;
          }
          if (statistician->getGlobalProcStatMaxProcessorId(
                 procstat1->getInstanceId(),
@@ -599,9 +598,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #8h: "
                        << "Statistician::getGlobalProcStatMaxId()\n"
-                       << "returned incorrect ID." << endl;
+                       << "returned incorrect ID." << std::endl;
          } else {
-            tbox::plog << "Test #8h successful" << endl;
+            tbox::plog << "Test #8h successful" << std::endl;
          }
 
          double min0 = 0.;
@@ -613,9 +612,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #8i: "
                        << "Statistician::getGlobalProcStatMin()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #8i successful" << endl;
+            tbox::plog << "Test #8i successful" << std::endl;
          }
          if (!tbox::MathUtilities<double>::equalEps(statistician->
                 getGlobalProcStatMin(
@@ -623,9 +622,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #8j: "
                        << "Statistician::getGlobalProcStatMin()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #8j successful" << endl;
+            tbox::plog << "Test #8j successful" << std::endl;
          }
          if (!tbox::MathUtilities<double>::equalEps(statistician->
                 getGlobalProcStatMin(
@@ -633,32 +632,32 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #8k: "
                        << "Statistician::getGlobalProcStatMin()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #8k successful" << endl;
+            tbox::plog << "Test #8k successful" << std::endl;
          }
 
          if (statistician->getGlobalProcStatMinProcessorId(
                 procstat1->getInstanceId(), 1) != 0) {
             tbox::pout << statistician->getGlobalProcStatMinProcessorId(
-               procstat1->getInstanceId(), 1) << endl;
+               procstat1->getInstanceId(), 1) << std::endl;
             ++fail_count;
             tbox::perr << "FAILED: - Test #8l: "
                        << "Statistician::getGlobalProcStatMinProcessorId()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #8l successful" << endl;
+            tbox::plog << "Test #8l successful" << std::endl;
          }
          if (statistician->getGlobalProcStatMinProcessorId(
                 procstat1->getInstanceId(), 2) != 0) {
             tbox::pout << statistician->getGlobalProcStatMinProcessorId(
-               procstat1->getInstanceId(), 2) << endl;
+               procstat1->getInstanceId(), 2) << std::endl;
             ++fail_count;
             tbox::perr << "FAILED: - Test #8m: "
                        << "Statistician::getGlobalProcStatMinProcessorId()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #8m successful" << endl;
+            tbox::plog << "Test #8m successful" << std::endl;
          }
 
          // Test #9:
@@ -679,9 +678,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #9a: "
                        << "Statistician::getGlobalPatchStatSum()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #9a successful" << endl;
+            tbox::plog << "Test #9a successful" << std::endl;
          }
 
          if (!tbox::MathUtilities<double>::equalEps(statistician->
@@ -690,9 +689,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #9b: "
                        << "Statistician::getGlobalPatchStatSum()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #9b successful" << endl;
+            tbox::plog << "Test #9b successful" << std::endl;
          }
 
          max0 = 0.;
@@ -712,9 +711,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #9c: "
                        << "Statistician::getGlobalPatchStatMax()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #9c successful" << endl;
+            tbox::plog << "Test #9c successful" << std::endl;
          }
 
          if (!tbox::MathUtilities<double>::equalEps(statistician->
@@ -723,9 +722,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #9d: "
                        << "Statistician::getGlobalPatchStatMax()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #9d successful" << endl;
+            tbox::plog << "Test #9d successful" << std::endl;
          }
 
          if (statistician->getGlobalPatchStatMaxPatchId(
@@ -733,9 +732,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #9e: "
                        << "Statistician::getGlobalPatchStatMaxPatchId()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #9e successful" << endl;
+            tbox::plog << "Test #9e successful" << std::endl;
          }
 
          if (statistician->getGlobalPatchStatMaxPatchId(
@@ -743,9 +742,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #9f: "
                        << "Statistician::getGlobalPatchStatMaxPatchId()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #9f successful" << endl;
+            tbox::plog << "Test #9f successful" << std::endl;
          }
 
          min0 = 0.;
@@ -756,9 +755,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #9g: "
                        << "Statistician::getGlobalPatchStatMin()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #9g successful" << endl;
+            tbox::plog << "Test #9g successful" << std::endl;
          }
          if (!tbox::MathUtilities<double>::equalEps(statistician->
                 getGlobalPatchStatMin(
@@ -766,9 +765,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #9h: "
                        << "Statistician::getGlobalPatchStatMin()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #9h successful" << endl;
+            tbox::plog << "Test #9h successful" << std::endl;
          }
 
          if (statistician->getGlobalPatchStatMinPatchId(
@@ -776,18 +775,18 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #9i: "
                        << "Statistician::getGlobalPatchStatMinPatchId()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #9i successful" << endl;
+            tbox::plog << "Test #9i successful" << std::endl;
          }
          if (statistician->getGlobalPatchStatMinPatchId(
                 patchstat2->getInstanceId(), 1) != 0) {
             ++fail_count;
             tbox::perr << "FAILED: - Test #9j: "
                        << "Statistician::getGlobalPatchStatMinPatchId()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #9j successful" << endl;
+            tbox::plog << "Test #9j successful" << std::endl;
          }
 
          // Test #10:
@@ -806,9 +805,9 @@ int main(
                ++fail_count;
                tbox::perr << "FAILED: - Test #10a: "
                           << "Statistician::getGlobalPatchStatProcessorSum()\n"
-                          << "incorrect value returned." << endl;
+                          << "incorrect value returned." << std::endl;
             } else {
-               tbox::plog << "Test #10a successful" << endl;
+               tbox::plog << "Test #10a successful" << std::endl;
             }
             if (!tbox::MathUtilities<double>::equalEps(statistician->
                    getGlobalPatchStatProcessorSum(
@@ -816,9 +815,9 @@ int main(
                ++fail_count;
                tbox::perr << "FAILED: - Test #10b: "
                           << "Statistician::getGlobalPatchStatProcessorSum()\n"
-                          << "incorrect value returned." << endl;
+                          << "incorrect value returned." << std::endl;
             } else {
-               tbox::plog << "Test #10b successful" << endl;
+               tbox::plog << "Test #10b successful" << std::endl;
             }
          }
 
@@ -828,9 +827,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #10c: "
                        << "Statistician::getGlobalPatchStatProcessorSumMax()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #10c successful" << endl;
+            tbox::plog << "Test #10c successful" << std::endl;
          }
          if (!tbox::MathUtilities<double>::equalEps(statistician->
                 getGlobalPatchStatProcessorSumMax(
@@ -838,9 +837,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #10d: "
                        << "Statistician::getGlobalPatchStatProcessorSumMax()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #10d successful" << endl;
+            tbox::plog << "Test #10d successful" << std::endl;
          }
 
          int nnodes = mpi.getSize();
@@ -849,18 +848,18 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #10e: "
                        << "Statistician::getGlobalPatchStatProcessorSumMaxId()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #10e successful" << endl;
+            tbox::plog << "Test #10e successful" << std::endl;
          }
          if (statistician->getGlobalPatchStatProcessorSumMaxId(
                 patchstat2->getInstanceId(), 1) != nnodes - 1) {
             ++fail_count;
             tbox::perr << "FAILED: - Test #10f: "
                        << "Statistician::getGlobalPatchStatProcessorSumMaxId()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #10f successful" << endl;
+            tbox::plog << "Test #10f successful" << std::endl;
          }
 
          min0 = 2.;
@@ -871,9 +870,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #10g: "
                        << "Statistician::getGlobalPatchStatProcessorSumMin()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #10g successful" << endl;
+            tbox::plog << "Test #10g successful" << std::endl;
          }
          if (!tbox::MathUtilities<double>::equalEps(statistician->
                 getGlobalPatchStatProcessorSumMin(
@@ -881,9 +880,9 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #10h: "
                        << "Statistician::getGlobalPatchStatProcessorSumMin()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #10h successful" << endl;
+            tbox::plog << "Test #10h successful" << std::endl;
          }
 
          if (statistician->getGlobalPatchStatProcessorSumMinId(
@@ -891,18 +890,18 @@ int main(
             ++fail_count;
             tbox::perr << "FAILED: - Test #10i: "
                        << "Statistician::getGlobalPatchStatProcessorSumMinId()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #10i successful" << endl;
+            tbox::plog << "Test #10i successful" << std::endl;
          }
          if (statistician->getGlobalPatchStatProcessorSumMinId(
                 patchstat2->getInstanceId(), 1) != 0) {
             ++fail_count;
             tbox::perr << "FAILED: - Test #10j: "
                        << "Statistician::getGlobalPatchStatProcessorSumMinId()\n"
-                       << "incorrect value returned." << endl;
+                       << "incorrect value returned." << std::endl;
          } else {
-            tbox::plog << "Test #10j successful" << endl;
+            tbox::plog << "Test #10j successful" << std::endl;
          }
 
       }
@@ -910,7 +909,7 @@ int main(
       /*
        * We're done.  Write the restart file.
        */
-      string restart_write_dirname = "restart";
+      std::string restart_write_dirname = "restart";
 #ifdef HAVE_HDF5
       int timestep = 0;
       tbox::RestartManager::getManager()->writeRestartFile(
@@ -919,7 +918,7 @@ int main(
 #endif
 
       if (fail_count == 0) {
-         tbox::pout << "\nPASSED:  statstest" << endl;
+         tbox::pout << "\nPASSED:  statstest" << std::endl;
       }
    }
 

--- a/source/test/timers/main_timer.C
+++ b/source/test/timers/main_timer.C
@@ -25,7 +25,6 @@
 #include "SAMRAI/tbox/Utilities.h"
 
 #include <string>
-using namespace std;
 
 // Simple code to check timer overhead
 // Not part of test, but kept here in
@@ -110,8 +109,8 @@ int main(
 
       tbox::PIO::logAllNodes("Timer.log");
 
-      string input_filename;
-      string restart_dirname;
+      std::string input_filename;
+      std::string restart_dirname;
       int restore_num = 0;
 
       bool is_from_restart = false;
@@ -121,7 +120,7 @@ int main(
                     << "<restart dir> <restore number> [options]\n"
                     << "  options:\n"
                     << "  none at this time"
-                    << endl;
+                    << std::endl;
          tbox::SAMRAI_MPI::abort();
          return -1;
       } else {
@@ -323,18 +322,18 @@ int main(
          for (int i = 0; i < tcnt; ++i) {
             mfactor *= 10;
          }
-         string suffix(tbox::Utilities::intToString(mfactor, testit));
+         std::string suffix(tbox::Utilities::intToString(mfactor, testit));
 
-         string t1name("ttest1-" + suffix);
+         std::string t1name("ttest1-" + suffix);
          tarray1[tcnt] = tbox::TimerManager::getManager()->getTimer(t1name,
                true);
 
-         string t2name("ttest2-" + suffix);
+         std::string t2name("ttest2-" + suffix);
          tarray2[tcnt] = tbox::TimerManager::getManager()->getTimer(t2name,
                true);
       }
 
-      tbox::pout << "\n\nEstimate SAMRAI Timer overhead..." << endl;
+      tbox::pout << "\n\nEstimate SAMRAI Timer overhead..." << std::endl;
 
       for (int tcnt = 0; tcnt < testit; ++tcnt) {
 
@@ -356,16 +355,16 @@ int main(
          tbox::pout.precision(16);
          tbox::pout << "\ntcnt, ntest, accesses = "
                     << tcnt << " , " << ntest << " , "
-                    << tarray1[tcnt]->getNumberAccesses() << endl;
-         tbox::pout << "access_time1 = " << access_time1 << endl;
-         tbox::pout << "access_time2 = " << access_time2 << endl;
+                    << tarray1[tcnt]->getNumberAccesses() << std::endl;
+         tbox::pout << "access_time1 = " << access_time1 << std::endl;
+         tbox::pout << "access_time2 = " << access_time2 << std::endl;
          double access_time12 = access_time1 - access_time2;
          double cost12 = access_time12 / static_cast<double>(ntest);
          tbox::pout << "Access time 12 overhead for each Timer: " << cost12
-                    << " sec" << endl;
+                    << " sec" << std::endl;
       }
 
-      tbox::pout << "\n\nEstimate PTimer overhead..." << endl;
+      tbox::pout << "\n\nEstimate PTimer overhead..." << std::endl;
 
       PTimer Ptarray1[testit];
       PTimer Ptarray2[testit];
@@ -390,13 +389,13 @@ int main(
          tbox::pout.precision(16);
          tbox::pout << "\ntcnt, ntest, accesses = "
                     << tcnt << " , " << ntest << " , "
-                    << Ptarray1[tcnt].getNumAccesses() << endl;
-         tbox::pout << "access_time1 = " << access_time1 << endl;
-         tbox::pout << "access_time2 = " << access_time2 << endl;
+                    << Ptarray1[tcnt].getNumAccesses() << std::endl;
+         tbox::pout << "access_time1 = " << access_time1 << std::endl;
+         tbox::pout << "access_time2 = " << access_time2 << std::endl;
          double access_time12 = access_time1 - access_time2;
          double cost12 = access_time12 / static_cast<double>(ntest);
          tbox::pout << "Access time 12 overhead for each Timer: " << cost12
-                    << " sec" << endl;
+                    << " sec" << std::endl;
       }
 
 #endif
@@ -417,7 +416,7 @@ int main(
       delete foo;
 
       if (fail_count == 0) {
-         tbox::pout << "\nPASSED:  timertest" << endl;
+         tbox::pout << "\nPASSED:  timertest" << std::endl;
       }
    }
 

--- a/source/test/transformation/main.C
+++ b/source/test/transformation/main.C
@@ -21,7 +21,6 @@
 #include "SAMRAI/pdat/NodeGeometry.h"
 #include "SAMRAI/pdat/SideGeometry.h"
 
-using namespace std;
 
 using namespace SAMRAI;
 
@@ -73,7 +72,7 @@ int main(
 
          if (!trans_box.isSpatiallyEqual(ref_box)) {
             ++fail_count;
-            tbox::perr << "FAILED: - 2D trivial tranformation" << endl;
+            tbox::perr << "FAILED: - 2D trivial tranformation" << std::endl;
          }
 
          fail_count += testGeometryTransformations(zero_trans, ref_box);
@@ -95,7 +94,7 @@ int main(
 
          if (!trans_box.isSpatiallyEqual(ref_box)) {
             ++fail_count;
-            tbox::perr << "FAILED: - 3D trivial tranformation" << endl;
+            tbox::perr << "FAILED: - 3D trivial tranformation" << std::endl;
          }
 
          fail_count += testGeometryTransformations(zero_trans, ref_box);
@@ -123,7 +122,7 @@ int main(
 
          if (!trans_box.isSpatiallyEqual(ref_box)) {
             ++fail_count;
-            tbox::perr << "FAILED: - 2D shift tranformation" << endl;
+            tbox::perr << "FAILED: - 2D shift tranformation" << std::endl;
          }
 
          fail_count += testGeometryTransformations(shift_trans, ref_box);
@@ -152,7 +151,7 @@ int main(
 
          if (!trans_box.isSpatiallyEqual(ref_box)) {
             ++fail_count;
-            tbox::perr << "FAILED: - 3D shift tranformation" << endl;
+            tbox::perr << "FAILED: - 3D shift tranformation" << std::endl;
          }
 
          fail_count += testGeometryTransformations(shift_trans, ref_box);
@@ -184,7 +183,7 @@ int main(
 
             if (!trans_box.isSpatiallyEqual(ref_box)) {
                ++fail_count;
-               tbox::perr << "FAILED: - 2D rotate/shift transformation" << endl;
+               tbox::perr << "FAILED: - 2D rotate/shift transformation" << std::endl;
             }
 
             fail_count += testGeometryTransformations(trans, ref_box);
@@ -217,7 +216,7 @@ int main(
 
             if (!trans_box.isSpatiallyEqual(ref_box)) {
                ++fail_count;
-               tbox::perr << "FAILED: - 3D rotate/shift transformation" << endl;
+               tbox::perr << "FAILED: - 3D rotate/shift transformation" << std::endl;
             }
 
             fail_count += testGeometryTransformations(trans, ref_box);
@@ -273,7 +272,7 @@ int main(
                trans.transform(trans_box);
                if (!trans_box.isSpatiallyEqual(*cdi)) {
                   ++fail_count;
-                  tbox::perr << "FAILED: - 2D CellOverlap getSourceBoxContainer" << endl;
+                  tbox::perr << "FAILED: - 2D CellOverlap getSourceBoxContainer" << std::endl;
                }
 
                ++cdi;
@@ -310,7 +309,7 @@ int main(
                pdat::NodeGeometry::transform(trans_box, trans);
                if (!trans_box.isSpatiallyEqual(*ndi)) {
                   ++fail_count;
-                  tbox::perr << "FAILED: - 2D NodeOverlap getSourceBoxContainer" << endl;
+                  tbox::perr << "FAILED: - 2D NodeOverlap getSourceBoxContainer" << std::endl;
                }
 
                ++ndi;
@@ -355,7 +354,7 @@ int main(
                   if (!trans_box.isSpatiallyEqual(*sdi) ||
                       test_normal != normal) {
                      ++fail_count;
-                     tbox::perr << "FAILED: - 2D SideOverlap getSourceBoxContainer" << endl;
+                     tbox::perr << "FAILED: - 2D SideOverlap getSourceBoxContainer" << std::endl;
                   }
 
                   ++sdi;
@@ -401,7 +400,7 @@ int main(
                   if (!trans_box.isSpatiallyEqual(*fdi) ||
                       test_normal != normal) {
                      ++fail_count;
-                     tbox::perr << "FAILED: - 2D FaceOverlap getSourceBoxContainer" << endl;
+                     tbox::perr << "FAILED: - 2D FaceOverlap getSourceBoxContainer" << std::endl;
                   }
 
                   ++fdi;
@@ -447,7 +446,7 @@ int main(
                   if (!trans_box.isSpatiallyEqual(*edi) ||
                       test_axis != axis) {
                      ++fail_count;
-                     tbox::perr << "FAILED: - 2D EdgeOverlap getSourceBoxContainer" << endl;
+                     tbox::perr << "FAILED: - 2D EdgeOverlap getSourceBoxContainer" << std::endl;
                   }
 
                   ++edi;
@@ -507,7 +506,7 @@ int main(
                trans.transform(trans_box);
                if (!trans_box.isSpatiallyEqual(*cdi)) {
                   ++fail_count;
-                  tbox::perr << "FAILED: - 3D CellOverlap getSourceBoxContainer" << endl;
+                  tbox::perr << "FAILED: - 3D CellOverlap getSourceBoxContainer" << std::endl;
                }
 
                ++cdi;
@@ -544,7 +543,7 @@ int main(
                pdat::NodeGeometry::transform(trans_box, trans);
                if (!trans_box.isSpatiallyEqual(*ndi)) {
                   ++fail_count;
-                  tbox::perr << "FAILED: - 3D NodeOverlap getSourceBoxContainer" << endl;
+                  tbox::perr << "FAILED: - 3D NodeOverlap getSourceBoxContainer" << std::endl;
                }
 
                ++ndi;
@@ -589,7 +588,7 @@ int main(
                   if (!trans_box.isSpatiallyEqual(*sdi) ||
                       test_normal != normal) {
                      ++fail_count;
-                     tbox::perr << "FAILED: - 3D SideOverlap getSourceBoxContainer" << endl;
+                     tbox::perr << "FAILED: - 3D SideOverlap getSourceBoxContainer" << std::endl;
                   }
 
                   ++sdi;
@@ -635,7 +634,7 @@ int main(
                   if (!trans_box.isSpatiallyEqual(*fdi) ||
                       test_normal != normal) {
                      ++fail_count;
-                     tbox::perr << "FAILED: - 3D FaceOverlap getSourceBoxContainer" << endl;
+                     tbox::perr << "FAILED: - 3D FaceOverlap getSourceBoxContainer" << std::endl;
                   }
 
                   ++fdi;
@@ -681,7 +680,7 @@ int main(
                   if (!trans_box.isSpatiallyEqual(*edi) ||
                       test_axis != axis) {
                      ++fail_count;
-                     tbox::perr << "FAILED: - 3D EdgeOverlap getSourceBoxContainer" << endl;
+                     tbox::perr << "FAILED: - 3D EdgeOverlap getSourceBoxContainer" << std::endl;
                   }
 
                   ++edi;
@@ -734,7 +733,7 @@ int testGeometryTransformations(const hier::Transformation& transformation,
 
    if (trans_cindex != ref_cindex) {
       ++fail_count;
-      tbox::perr << "FAILED: - CellIndex transformation" << endl;
+      tbox::perr << "FAILED: - CellIndex transformation" << std::endl;
    }
 
    /*
@@ -746,7 +745,7 @@ int testGeometryTransformations(const hier::Transformation& transformation,
    pdat::NodeGeometry::transform(trans_node_box, reverse_trans);
    if (!trans_node_box.isSpatiallyEqual(ref_node_box)) {
       ++fail_count;
-      tbox::perr << "FAILED: - Node box transformation" << endl;
+      tbox::perr << "FAILED: - Node box transformation" << std::endl;
    }
 
    pdat::NodeIndex ref_nindex(box.upper(), hier::IntVector::getOne(dim));
@@ -756,7 +755,7 @@ int testGeometryTransformations(const hier::Transformation& transformation,
 
    if (trans_nindex != ref_nindex) {
       ++fail_count;
-      tbox::perr << "FAILED: - NodeIndex transformation" << endl;
+      tbox::perr << "FAILED: - NodeIndex transformation" << std::endl;
    }
 
    /*
@@ -770,7 +769,7 @@ int testGeometryTransformations(const hier::Transformation& transformation,
       pdat::SideGeometry::transform(trans_side_box, direction, reverse_trans);
       if (!trans_side_box.isSpatiallyEqual(ref_side_box)) {
          ++fail_count;
-         tbox::perr << "FAILED: - Side box transformation" << endl;
+         tbox::perr << "FAILED: - Side box transformation" << std::endl;
       }
 
       pdat::SideIndex ref_sindex(box.upper(), d, 0);
@@ -780,7 +779,7 @@ int testGeometryTransformations(const hier::Transformation& transformation,
 
       if (trans_sindex != ref_sindex) {
          ++fail_count;
-         tbox::perr << "FAILED: - SideIndex transformation" << endl;
+         tbox::perr << "FAILED: - SideIndex transformation" << std::endl;
       }
    }
 
@@ -795,7 +794,7 @@ int testGeometryTransformations(const hier::Transformation& transformation,
       pdat::EdgeGeometry::transform(trans_edge_box, direction, reverse_trans);
       if (!trans_edge_box.isSpatiallyEqual(ref_edge_box)) {
          ++fail_count;
-         tbox::perr << "FAILED: - Edge box transformation" << endl;
+         tbox::perr << "FAILED: - Edge box transformation" << std::endl;
       }
 
       pdat::EdgeIndex ref_eindex(box.upper(), d, 0);
@@ -805,7 +804,7 @@ int testGeometryTransformations(const hier::Transformation& transformation,
 
       if (trans_eindex != ref_eindex) {
          ++fail_count;
-         tbox::perr << "FAILED: - EdgeIndex transformation" << endl;
+         tbox::perr << "FAILED: - EdgeIndex transformation" << std::endl;
       }
    }
 
@@ -820,7 +819,7 @@ int testGeometryTransformations(const hier::Transformation& transformation,
       pdat::FaceGeometry::transform(trans_face_box, direction, reverse_trans);
       if (!trans_face_box.isSpatiallyEqual(ref_face_box)) {
          ++fail_count;
-         tbox::perr << "FAILED: - Face box transformation" << endl;
+         tbox::perr << "FAILED: - Face box transformation" << std::endl;
       }
 
       pdat::FaceIndex ref_findex(box.upper(), d, 0);
@@ -830,7 +829,7 @@ int testGeometryTransformations(const hier::Transformation& transformation,
 
       if (trans_findex != ref_findex) {
          ++fail_count;
-         tbox::perr << "FAILED: - FaceIndex transformation" << endl;
+         tbox::perr << "FAILED: - FaceIndex transformation" << std::endl;
       }
    }
 

--- a/source/test/variables/main-var_db.C
+++ b/source/test/variables/main-var_db.C
@@ -27,7 +27,6 @@
 
 #include <string>
 #include <memory>
-using namespace std;
 
 using namespace SAMRAI;
 
@@ -109,39 +108,39 @@ int main(
 
       tbox::plog
       << "\n\nPrintout #1 of hier::Variable tbox::Database (after initial registration)..."
-      << endl;
+      << std::endl;
       var_db->printClassData(tbox::plog);
 
       // Test #1: Check Context functions...
 
       // Test #1a: hier::VariableDatabase::checkContextExists()
       tbox::plog
-      << "Test #1a: hier::VariableDatabase::checkContextExists()..." << endl;
+      << "Test #1a: hier::VariableDatabase::checkContextExists()..." << std::endl;
       if (!var_db->checkContextExists("SCRATCH")) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #1a: hier::VariableDatabase::checkContextExists()\n"
-         << "SCRATCH context added to var_db, but not found" << endl;
+         << "SCRATCH context added to var_db, but not found" << std::endl;
       }
 
       // Test #1b: hier::VariableDatabase::checkContextExists()
       tbox::plog
-      << "Test #1b: hier::VariableDatabase::checkContextExists()..." << endl;
+      << "Test #1b: hier::VariableDatabase::checkContextExists()..." << std::endl;
       if (!var_db->checkContextExists("CURRENT")) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #1b: hier::VariableDatabase::checkContextExists()\n"
-         << "CURRENT context added to var_db, but not found" << endl;
+         << "CURRENT context added to var_db, but not found" << std::endl;
       }
 
       // Test #1c: hier::VariableDatabase::checkContextExists()
       tbox::plog
-      << "Test #1c: hier::VariableDatabase::checkContextExists()..." << endl;
+      << "Test #1c: hier::VariableDatabase::checkContextExists()..." << std::endl;
       if (var_db->checkContextExists("dummy")) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #1c: hier::VariableDatabase::checkContextExists()\n"
-         << "dummy context not added to var_db, but found" << endl;
+         << "dummy context not added to var_db, but found" << std::endl;
       }
 
       // Adding dummy context to variable databse...
@@ -155,84 +154,84 @@ int main(
 
       // Test #1d: hier::VariableDatabase::checkContextExists()
       tbox::plog
-      << "Test #1d: hier::VariableDatabase::checkContextExists()..." << endl;
+      << "Test #1d: hier::VariableDatabase::checkContextExists()..." << std::endl;
       if (!var_db->checkContextExists("dummy")) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #1d: hier::VariableDatabase::checkContextExists()\n"
-         << "dummy context added to var_db, but not found" << endl;
+         << "dummy context added to var_db, but not found" << std::endl;
       }
 
       // Test #2,3: Check hier::Variable functions...
 
       // Test #2a: hier::VariableDatabase::checkVariableExists()
       tbox::plog
-      << "Test #2a: hier::VariableDatabase::checkVariableExists()..." << endl;
+      << "Test #2a: hier::VariableDatabase::checkVariableExists()..." << std::endl;
       if (!var_db->checkVariableExists("uval")) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #2a: hier::VariableDatabase::checkVariableExists()\n"
-         << "uval variable added to var_db, but not found" << endl;
+         << "uval variable added to var_db, but not found" << std::endl;
       }
 
       // Test #2b: hier::VariableDatabase::checkVariableExists()
       tbox::plog
-      << "Test #2b: hier::VariableDatabase::checkVariableExists()..." << endl;
+      << "Test #2b: hier::VariableDatabase::checkVariableExists()..." << std::endl;
       if (!var_db->checkVariableExists("flux")) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #2b: hier::VariableDatabase::checkVariableExists()\n"
-         << "flux variable added to var_db, but not found" << endl;
+         << "flux variable added to var_db, but not found" << std::endl;
       }
 
       // Test #2c: hier::VariableDatabase::checkVariableExists()
       tbox::plog
-      << "Test #2c: hier::VariableDatabase::checkVariableExists()..." << endl;
+      << "Test #2c: hier::VariableDatabase::checkVariableExists()..." << std::endl;
       if (!var_db->checkVariableExists("fluxsum")) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #2c: hier::VariableDatabase::checkVariableExists()\n"
          << "fluxsum variable added to var_db, but not found"
-         << endl;
+         << std::endl;
       }
 
       // Test #2d: hier::VariableDatabase::checkVariableExists()
       tbox::plog
-      << "Test #2d: hier::VariableDatabase::checkVariableExists()..." << endl;
+      << "Test #2d: hier::VariableDatabase::checkVariableExists()..." << std::endl;
       if (var_db->checkVariableExists("dummy")) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #2d: hier::VariableDatabase::checkVariableExists()\n"
-         << "dummy variable not added to var_db, but found" << endl;
+         << "dummy variable not added to var_db, but found" << std::endl;
       }
 
       // Test #3a: hier::VariableDatabase::getVariable()
       tbox::plog << "Test #3a: hier::VariableDatabase::getVariable()..."
-                 << endl;
+                 << std::endl;
       std::shared_ptr<hier::Variable> tvar_uval(var_db->getVariable("uval"));
       if (!tvar_uval) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #3a: hier::VariableDatabase::getVariable()\n"
          << "uval variable added to var_db, but returning NULL"
-         << endl;
+         << std::endl;
       }
 
       // Test #3b: hier::VariableDatabase::getVariable()
       tbox::plog << "Test #3b: hier::VariableDatabase::getVariable()..."
-                 << endl;
+                 << std::endl;
       std::shared_ptr<hier::Variable> tvar_flux(var_db->getVariable("flux"));
       if (!tvar_flux) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #3b: hier::VariableDatabase::getVariable()\n"
          << "flux variable added to var_db, but returning NULL"
-         << endl;
+         << std::endl;
       }
 
       // Test #3c: hier::VariableDatabase::getVariable()
       tbox::plog << "Test #3c: hier::VariableDatabase::getVariable()..."
-                 << endl;
+                 << std::endl;
       std::shared_ptr<hier::Variable> tvar_fluxsum(
          var_db->getVariable("fluxsum"));
       if (!tvar_fluxsum) {
@@ -240,13 +239,13 @@ int main(
          tbox::perr
          << "FAILED: - Test #3c: hier::VariableDatabase::getVariable()\n"
          << "fluxsum variable added to var_db, but returning NULL"
-         << endl;
+         << std::endl;
       }
 
       // Test #3d: hier::VariableDatabase::getVariable()
       tbox::plog << "Test #3d: hier::VariableDatabase::getVariable()..."
-                 << endl;
-      //   tbox::perr << "Attempt to get variable named dummy..." << endl;
+                 << std::endl;
+      //   tbox::perr << "Attempt to get variable named dummy..." << std::endl;
       std::shared_ptr<hier::Variable> tvar_dummy(
          var_db->getVariable("dummy"));
       if (tvar_dummy) {
@@ -254,50 +253,50 @@ int main(
          tbox::perr
          << "FAILED: - Test #3d: hier::VariableDatabase::getVariable()\n"
          << "dummy variable not added to var_db, but not returning NULL"
-         << endl;
+         << std::endl;
       }
 
       // Test #4: Check instance identifier assignments
 
       // Test #4a: hier::Variable::getInstanceIdentifier()
       tbox::plog << "Test #4a: hier::Variable::getInstanceIdentifier()..."
-                 << endl;
+                 << std::endl;
       int uval_id = tvar_uval->getInstanceIdentifier();
       if (uval_id != 0) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #4a: hier::Variable::getInstanceIdentifier()\n"
          << "uval should have id = 0, but has id = " << uval_id
-         << endl;
+         << std::endl;
       }
 
       // Test #4b: hier::Variable::getInstanceIdentifier()
       tbox::plog << "Test #4b: hier::Variable::getInstanceIdentifier()..."
-                 << endl;
+                 << std::endl;
       int flux_id = tvar_flux->getInstanceIdentifier();
       if (flux_id != 1) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #4b: hier::Variable::getInstanceIdentifier()\n"
          << "flux should have id = 1, but has id = " << flux_id
-         << endl;
+         << std::endl;
       }
 
       // Test #4c: hier::Variable::getInstanceIdentifier()
       tbox::plog << "Test #4c: hier::Variable::getInstanceIdentifier()..."
-                 << endl;
+                 << std::endl;
       int fluxsum_id = tvar_fluxsum->getInstanceIdentifier();
       if (fluxsum_id != 2) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #4c: hier::Variable::getInstanceIdentifier()\n"
          << "fluxsum should have id = 2, but has id = "
-         << fluxsum_id << endl;
+         << fluxsum_id << std::endl;
       }
 
       // Test #5: Attempt to register (uval,CURRENT) again
       tbox::plog << "Test #5: Attempt to register (uval,CURRENT) again..."
-                 << endl;
+                 << std::endl;
       std::shared_ptr<hier::VariableContext> tctxt_current(
          var_db->getContext("CURRENT"));
       hier::IntVector tzero_ghosts(dim, 0);
@@ -308,26 +307,26 @@ int main(
          tbox::perr
          << "FAILED: - Test #5: Re-registering a variable and context\n"
          << "Original id = 0 should be returned, but "
-         << ti << "returned" << endl;
+         << ti << "returned" << std::endl;
       }
 
       // Test #6a: hier::VariableDatabase::mapVariableAndContextToIndex()
       tbox::plog
       << "Test #6a: hier::VariableDatabase::mapVariableAndContextToIndex()..."
-      << endl;
+      << std::endl;
       ti = var_db->mapVariableAndContextToIndex(tvar_uval, tctxt_current);
       if (ti != 0) {
          ++fail_count;
          tbox::perr
          << "FAILED: - Test #6a: hier::VariableDatabase::mapVariableAndContextToIndex()\n"
          << "(uval,CURRENT) should be mapped to 0, but is mapped to "
-         << ti << endl;
+         << ti << std::endl;
       }
 
       // Test #6b: hier::VariableDatabase::mapVariableAndContextToIndex()
       tbox::plog
       << "Test #6b: hier::VariableDatabase::mapVariableAndContextToIndex()..."
-      << endl;
+      << std::endl;
       tvar_uval = var_db->getVariable("uval");
       std::shared_ptr<hier::VariableContext> tctxt_scratch(
          var_db->getContext("SCRATCH"));
@@ -337,13 +336,13 @@ int main(
          tbox::perr
          << "FAILED: - Test #6b: hier::VariableDatabase::mapVariableAndContextToIndex()\n"
          << "(uval,SCRATCH) should be mapped to -1, but is mapped to "
-         << ti << endl;
+         << ti << std::endl;
       }
 
       // Test #6c: hier::VariableDatabase::mapVariableAndContextToIndex()
       tbox::plog
       << "Test #6c: hier::VariableDatabase::mapVariableAndContextToIndex()..."
-      << endl;
+      << std::endl;
       std::shared_ptr<pdat::CellVariable<double> > dummy_var(
          new pdat::CellVariable<double>(dim, "dummy", 3));
       tctxt_scratch = var_db->getContext("SCRATCH");
@@ -353,13 +352,13 @@ int main(
          tbox::perr
          << "FAILED: - Test #6c: hier::VariableDatabase::mapVariableAndContextToIndex()\n"
          << "(dummy,SCRATCH) should be mapped to -1, but is mapped to "
-         << ti << endl;
+         << ti << std::endl;
       }
 
       // Test #6d: hier::VariableDatabase::mapVariableAndContextToIndex()
       tbox::plog
       << "Test #6d: hier::VariableDatabase::mapVariableAndContextToIndex()..."
-      << endl;
+      << std::endl;
       tvar_uval = var_db->getVariable("uval");
       std::shared_ptr<hier::VariableContext> tctxt_random(
          new hier::VariableContext("RANDOM"));
@@ -369,18 +368,18 @@ int main(
          tbox::perr
          << "FAILED: - Test #6d: hier::VariableDatabase::mapVariableAndContextToIndex()\n"
          << "(uval,RANDOM) should be mapped to -1, but is mapped to "
-         << ti << endl;
+         << ti << std::endl;
       }
 
       // Test #7a: hier::VariableDatabase::mapIndexToVariableAndContext()
       tbox::plog
       << "Test #7a: hier::VariableDatabase::mapIndexToVariableAndContext()..."
-      << endl;
+      << std::endl;
       int search_id = 2;
       std::shared_ptr<hier::Variable> search_var;
       std::shared_ptr<hier::VariableContext> search_ctxt;
-      string flux_variable("flux");
-      string scratch_variable("SCRATCH");
+      std::string flux_variable("flux");
+      std::string scratch_variable("SCRATCH");
 
       // searching for index = 2
       if (!var_db->mapIndexToVariableAndContext(
@@ -389,34 +388,34 @@ int main(
          tbox::perr
          << "FAILED: - Test #7a.1: hier::VariableDatabase::mapIndexToVariableAndContext()\n"
          << "Problem finding a (variable,context) pair for index = 2"
-         << endl;
+         << std::endl;
          if (search_var->getName() != flux_variable) {
             ++fail_count;
             tbox::perr
             << "FAILED: - Test #7a.2: hier::VariableDatabase::mapIndexToVariableAndContext()\n"
             << "Returned var name should be \"flux\" but is "
-            << search_var->getName() << endl;
+            << search_var->getName() << std::endl;
          }
          if (search_ctxt->getName() != scratch_variable) {
             ++fail_count;
             tbox::perr
             << "FAILED: - Test #7a.3: hier::VariableDatabase::mapIndexToVariableAndContext()\n"
             << "Returned context name should be \"SCRATCH\" but is "
-            << search_ctxt->getName() << endl;
+            << search_ctxt->getName() << std::endl;
          }
 /*      tbox::plog << "Var name = " << tvar->getName() << " = flux?, "
- *      << "Context name = " << tctxt->getName() << " = CURRENT?" << endl;
+ *      << "Context name = " << tctxt->getName() << " = CURRENT?" << std::endl;
  */
 /*   } else {
  *   tbox::plog << "Houston, we have a problem looking for index "
- *   << search_id << endl;
+ *   << search_id << std::endl;
  */
       }
 
       // Test #7b: hier::VariableDatabase::mapIndexToVariableAndContext()
       tbox::plog
       << "Test #7b: hier::VariableDatabase::mapIndexToVariableAndContext()"
-      << endl;
+      << std::endl;
       search_id = 20;
 
       // searching for index = 20
@@ -428,27 +427,27 @@ int main(
          << "Something maps to index = 20 when nothing should.\n"
          << "Variable name: " << search_var->getName() << "\n"
          << "Context name: " << search_ctxt->getName()
-         << endl;
+         << std::endl;
       } else {
 
          if (search_var) {
             ++fail_count;
             tbox::perr
             << "FAILED: - Test #7b.2: hier::VariableDatabase::mapIndexToVariableAndContext()\n"
-            << "search_var should be NULL" << endl;
+            << "search_var should be NULL" << std::endl;
          }
          if (search_ctxt) {
             ++fail_count;
             tbox::perr
             << "FAILED: - Test #7b.3: hier::VariableDatabase::mapIndexToVariableAndContext()\n"
-            << "search_ctxt should be NULL" << endl;
+            << "search_ctxt should be NULL" << std::endl;
          }
 
       }
 
       // Test #7c: hier::VariableDatabase::mapIndexToVariable()
       tbox::plog
-      << "Test #7c: hier::VariableDatabase::mapIndexToVariable()..." << endl;
+      << "Test #7c: hier::VariableDatabase::mapIndexToVariable()..." << std::endl;
       search_id = 2;
 
       // searching for index = 2
@@ -457,19 +456,19 @@ int main(
          tbox::perr
          << "FAILED: - Test #7c.1: hier::VariableDatabase::mapIndexToVariable()\n"
          << "Problem finding a (variable) for index = 2"
-         << endl;
+         << std::endl;
          if (search_var->getName() != flux_variable) {
             ++fail_count;
             tbox::perr
             << "FAILED: - Test #7c.2: hier::VariableDatabase::mapIndexToVariable()\n"
             << "Returned var name should be \"flux\" but is "
-            << search_var->getName() << endl;
+            << search_var->getName() << std::endl;
          }
       }
 
       // Test #7d: hier::VariableDatabase::mapIndexToVariable()
       tbox::plog
-      << "Test #7d: hier::VariableDatabase::mapIndexToVariable()..." << endl;
+      << "Test #7d: hier::VariableDatabase::mapIndexToVariable()..." << std::endl;
       search_id = 20;
 
       // searching for index = 20
@@ -479,14 +478,14 @@ int main(
          << "FAILED: - Test #7d.1: hier::VariableDatabase::mapIndexToVariable()\n"
          << "Something maps to index = 20 when nothing should.\n"
          << "Variable name: " << search_var->getName() << "\n"
-         << endl;
+         << std::endl;
       } else {
 
          if (search_var) {
             ++fail_count;
             tbox::perr
             << "FAILED: - Test #7d.2: hier::VariableDatabase::mapIndexToVariable()\n"
-            << "search_var should be NULL" << endl;
+            << "search_var should be NULL" << std::endl;
          }
 
       }
@@ -502,29 +501,29 @@ int main(
 
       // Test #8a: Checking mapping in variable database
       tbox::plog << "Test #8a: Checking mapping in variable database..."
-                 << endl;
+                 << std::endl;
       if (!var_db->checkVariablePatchDataIndex(uval, uval_current_id)) {
          ++fail_count;
          tbox::perr << "FAILED: - Test #8a: "
                     << "VariableDatabase:checkVariablePatchDataIndex()\n"
                     << "uval should be map to current id in patch descriptor"
-                    << endl;
+                    << std::endl;
       }
       // Test #8b: Checking mapping in variable database
       tbox::plog << "Test #8b: Checking mapping in variable database..."
-                 << endl;
+                 << std::endl;
       if (!var_db->checkVariablePatchDataIndexType(uval, uval_current_id)) {
          ++fail_count;
          tbox::perr << "FAILED: - Test #8b: "
                     << "VariableDatabase:checkVariablePatchDataIndexType()\n"
                     << "uval should be map to current id in patch descriptor"
-                    << endl;
+                    << std::endl;
       }
 
       // Test #8c: Checking restration of existing patch data index...
       tbox::plog
       << "Test #8c: Checking restration of existing patch data index..."
-      << endl;
+      << std::endl;
       int test_id = var_db->registerPatchDataIndex(uval, uval_current_id);
 
       if (test_id != uval_current_id) {
@@ -532,13 +531,13 @@ int main(
          tbox::perr << "FAILED: - Test #8c: "
                     << "VariableDatabase:registerPatchDataIndex()\n"
                     << "re-registering current uval id should return same id"
-                    << endl;
+                    << std::endl;
       }
 
       // Test #8d: Testing registration of new cloned factory to variable...
       tbox::plog
       << "Test #8d: Testing registration of new cloned factory to variable..."
-      << endl;
+      << std::endl;
       int new_id =
          var_db->registerClonedPatchDataIndex(uval, uval_current_id);
 
@@ -546,13 +545,13 @@ int main(
          ++fail_count;
          tbox::perr << "FAILED: - Test #8d: "
                     << "VariableDatabase:registerClonedPatchDataIndex()\n"
-                    << "cloning current uval id return invalid id" << endl;
+                    << "cloning current uval id return invalid id" << std::endl;
       }
 
       // Test #8e: Testing registration of new cloned factory to variable...
       tbox::plog
       << "Test #8e: Testing registration of new cloned factory to variable..."
-      << endl;
+      << std::endl;
       std::shared_ptr<hier::Variable> tvar;
       if (!var_db->mapIndexToVariable(new_id, tvar)
           || (tvar->getName() != "uval")) {
@@ -560,14 +559,14 @@ int main(
          tbox::perr << "FAILED: - Test #8e: "
                     << "VariableDatabase:mapIndexToVariable()\n"
                     << "descriptor id = " << new_id
-                    << " should now map to uval" << endl;
+                    << " should now map to uval" << std::endl;
       }
 
       tbox::plog
       << "\nPrintout #3 of hier::Variable tbox::Database. (after tests 8a-8e"
       << "\n Descriptor index " << new_id
       << " should map to newly-created uval descriptor index)"
-      << endl;
+      << std::endl;
       var_db->printClassData(tbox::plog);
 
       // Test #8f: Testing removal of new variable-descriptor id mapping
@@ -576,7 +575,7 @@ int main(
       tbox::plog
       << "\nPrintout #4 of hier::Variable tbox::Database. (after test 8d"
       << "\n Descriptor index " << new_id
-      << " should no longer be mapped to a variable)..." << endl;
+      << " should no longer be mapped to a variable)..." << std::endl;
       var_db->printClassData(tbox::plog);
 
       tvar.reset();
@@ -585,29 +584,29 @@ int main(
          tbox::perr << "FAILED: - Test #8f: "
                     << "VariableDatabase:removePatchDataIndex()\n"
                     << "descriptor id = " << new_id
-                    << " should no longer map to uval variable" << endl;
+                    << " should no longer map to uval variable" << std::endl;
       }
 
       // Test #8g-h: Testing whether inconsistent mapping is allowed...
       tbox::plog
       << "Test #8g-h: Testing whether inconsistent mapping is allowed..."
-      << endl;
+      << std::endl;
       if (!var_db->checkVariablePatchDataIndex(flux, flux_scratch_id)) {
          ++fail_count;
          tbox::perr << "FAILED: - Test #8g: "
                     << "VariableDatabase:checkVariablePatchDataIndex()\n"
-                    << "flux should be mapped to scratch flux id" << endl;
+                    << "flux should be mapped to scratch flux id" << std::endl;
       }
       if (var_db->checkVariablePatchDataIndex(uval, flux_scratch_id)) {
          ++fail_count;
          tbox::perr << "FAILED: - Test #8h: "
                     << "VariableDatabase:checkVariablePatchDataIndex()\n"
-                    << "uval should not map to scratch flux id" << endl;
+                    << "uval should not map to scratch flux id" << std::endl;
       }
 
       // Test #8i-j: Testing removal of existing descriptor id...
       tbox::plog
-      << "Test #8i-j: Testing removal of existing descriptor id..." << endl;
+      << "Test #8i-j: Testing removal of existing descriptor id..." << std::endl;
       var_db->removePatchDataIndex(flux_scratch_id);
 
       int tindex =
@@ -618,7 +617,7 @@ int main(
          tbox::perr << "FAILED: - Test #8i: "
                     << "VariableDatabase:removePatchDataIndex()\n"
                     << "flux-SCRATCH mapping should no longer be in database"
-                    << endl;
+                    << std::endl;
       }
 
       tvar.reset();
@@ -627,14 +626,14 @@ int main(
          tbox::perr << "FAILED: - Test #8j: "
                     << "VariableDatabase:mapIndexToVariable()\n"
                     << "descriptor id = " << flux_scratch_id
-                    << " should no longer map to flux variable" << endl;
+                    << " should no longer map to flux variable" << std::endl;
       }
 
       tbox::plog
       << "\nPrintout #5 of hier::Variable tbox::Database. (after tests 8e-j\n"
       << "Should be identical to first printout except for the "
       << "\naddition of \n\"dummy\" context and removal of "
-      << "flux scratch variable-context mapping" << endl;
+      << "flux scratch variable-context mapping" << std::endl;
       var_db->printClassData(tbox::plog);
 
       tbox::plog
@@ -652,35 +651,35 @@ int main(
          new pdat::CellVariable<double>("uval", 2));
 
       tbox::plog << "Attempt to add a different variable named uval."
-                 << "This should bomb!!" << endl;
+                 << "This should bomb!!" << std::endl;
       var_db->addVariable(dummy);
 
       // Abort Test #2
       tbox::plog << "Attempt to register uval, CURRENT again w/ wrong ghosts."
-                 << "This should bomb!!" << endl;
+                 << "This should bomb!!" << std::endl;
       tctxt = var_db->getContext("CURRENT");
       tvar = var_db->getVariable("uval");
       g = hier::IntVector(2);
       ti = var_db->registerVariableAndContext(tvar, tctxt, g);
-      tbox::plog << "uval, CURRENT at index = " << ti << endl;
+      tbox::plog << "uval, CURRENT at index = " << ti << std::endl;
 
       // Abort Test #3
       tbox::plog << "Attempt to register uval with fake CURRENT context."
-                 << "This should bomb!!" << endl;
+                 << "This should bomb!!" << std::endl;
       tctxt = new hier::VariableContext("CURRENT");
       tvar = var_db->getVariable("uval");
       g = hier::IntVector(0);
       ti = var_db->registerVariableAndContext(tvar, tctxt, g);
-      tbox::plog << "uval, fake CURRENT at index = " << ti << endl;
+      tbox::plog << "uval, fake CURRENT at index = " << ti << std::endl;
 
       // Abort Test #4
       tbox::plog << "Attempt to map uval to descriptor id for flux."
-                 << "This should bomb!!" << endl;
+                 << "This should bomb!!" << std::endl;
       var_db->addVariablePatchDataIndex(uval, flux_scratch_id);
 #endif
 
       if (fail_count == 0) {
-         tbox::pout << "\nPASSED:  vdbtest" << endl;
+         tbox::pout << "\nPASSED:  vdbtest" << std::endl;
       }
    }
 

--- a/source/test/vector/pvtest.C
+++ b/source/test/vector/pvtest.C
@@ -14,7 +14,6 @@
 #include <stdlib.h>
 #include <string>
 #include <memory>
-using namespace std;
 #define included_String
 #include "SAMRAI/tbox/SAMRAI_MPI.h"
 #include "SAMRAI/tbox/PIO.h"
@@ -973,43 +972,43 @@ int main(
 
       // Print out control volume data and compute integrals...
 
-      tbox::plog << "cell control volume data" << endl;
+      tbox::plog << "cell control volume data" << std::endl;
       cell_ops->printData(cwgt_id, tbox::plog);
-      tbox::plog << "face control volume data" << endl;
+      tbox::plog << "face control volume data" << std::endl;
       face_ops->printData(fwgt_id, tbox::plog);
-      tbox::plog << "node control volume data" << endl;
+      tbox::plog << "node control volume data" << std::endl;
       node_ops->printData(nwgt_id, tbox::plog);
 
       double norm;
-      //pout << "sum of each control volume is " << endl;
+      //pout << "sum of each control volume is " << std::endl;
 
       norm = cell_ops->sumControlVolumes(cvindx[0], cwgt_id);
       if (!tbox::MathUtilities<double>::equalEps(norm, (double)0.5)) {
          ++fail_count;
          tbox::perr << "FAILED: - Test #1, norm != 0.5\n";
       }
-      //pout << "Component 0 : " << norm << " = 0.5?" << endl;
+      //pout << "Component 0 : " << norm << " = 0.5?" << std::endl;
 
       norm = face_ops->sumControlVolumes(fvindx[0], fwgt_id);
       if (!tbox::MathUtilities<double>::equalEps(norm, (double)0.75)) {
          ++fail_count;
          tbox::perr << "FAILED: - Test #2, norm != 0.75\n";
       }
-      //pout << "Component 1 : " << norm << " = 0.75?" << endl;
+      //pout << "Component 1 : " << norm << " = 0.75?" << std::endl;
 
       norm = node_ops->sumControlVolumes(nvindx[0], nwgt_id);
       if (!tbox::MathUtilities<double>::equalEps(norm, (double)0.25)) {
          ++fail_count;
          tbox::perr << "FAILED: - Test #3, norm != 0.25\n";
       }
-      //pout << "Component 2 : " << norm << " = 0.25?" << endl;
+      //pout << "Component 2 : " << norm << " = 0.25?" << std::endl;
 
       norm = node_ops->sumControlVolumes(nvindx[1], nwgt_id);
       if (!tbox::MathUtilities<double>::equalEps(norm, (double)0.25)) {
          ++fail_count;
          tbox::perr << "FAILED: - Test #4, norm != 0.25\n";
       }
-      //pout << "Component 3 : " << norm << " = 0.25?\n" << endl;
+      //pout << "Component 3 : " << norm << " = 0.25?\n" << std::endl;
 
       // Simple tests of SAMRAI vector operations
 
@@ -1037,9 +1036,9 @@ int main(
       double p_norm;
       double l1_norm;
       my_norm = my_vec0->L1Norm();
-      //pout << "L1-norm of my_vec0 is " << norm << " = 6.0?\n" << endl;
+      //pout << "L1-norm of my_vec0 is " << norm << " = 6.0?\n" << std::endl;
       VecNorm(pvec0, NORM_1, &p_norm);
-      //pout << "L1-norm of pvec0 is " << norm << " = 6.0?\n" << endl;
+      //pout << "L1-norm of pvec0 is " << norm << " = 6.0?\n" << std::endl;
       if (!tbox::MathUtilities<double>::equalEps(my_norm, p_norm)) {
          ++fail_count;
          tbox::perr << "FAILED: - Test #5, L1-norm calculation\n";
@@ -1066,7 +1065,7 @@ int main(
          tbox::perr << "FAILED: - Test #8, both norms calculation, L2-norm\n";
       }
       //pout << "Both norms of pvec0: " << both_norms[0] << " and "
-      //                                << both_norms[1] << "\n" << endl;
+      //                                << both_norms[1] << "\n" << std::endl;
 
       // Set fine data in my_vec0 = 3.0
       cell_ops->resetLevels(1, 1);
@@ -1077,7 +1076,7 @@ int main(
       node_ops->setToScalar(nvindx[0], 3.0);
       node_ops->setToScalar(nvindx[1], 3.0);
 
-      tbox::plog << "CHECK my_vec0" << endl;
+      tbox::plog << "CHECK my_vec0" << std::endl;
       my_vec0->print(tbox::plog);
 
       double my_min_val = my_vec0->min();
@@ -1087,7 +1086,7 @@ int main(
       VecMin(pvec0, &dummy1, &p_min_val);
       double min_val;
       VecMin(pvec0, &dummy1, &min_val);
-      tbox::plog << "min of pvec0 is " << min_val << " = 2.0?\n" << endl;
+      tbox::plog << "min of pvec0 is " << min_val << " = 2.0?\n" << std::endl;
       if (!tbox::MathUtilities<double>::equalEps(my_min_val, p_min_val)) {
          ++fail_count;
          tbox::perr << "FAILED: - Test #9, min val calculation\n";
@@ -1177,7 +1176,7 @@ int main(
       }
 
       tbox::plog << "my_vec1 = 0.5 (& bogus values) on L0, = 0.3333 on L1?"
-                 << endl;
+                 << std::endl;
       my_vec1->print(tbox::plog);
 
       double max_val = my_vec1->max();
@@ -1238,7 +1237,7 @@ int main(
       my_vec0->setToScalar(-1.0);
       my_vec0->compareToScalar(my_vec0, 0.4);
       tbox::plog
-      << "my_vec0 = 1.0 on L0 (-1.0 in covered region), = 0.0 pn L1?" << endl;
+      << "my_vec0 = 1.0 on L0 (-1.0 in covered region), = 0.0 pn L1?" << std::endl;
       my_vec0->print(tbox::plog);
 
       int test = my_vec0->testReciprocal(my_vec1);
@@ -1247,7 +1246,7 @@ int main(
       }
 
       tbox::plog
-      << "my_vec0 = 2.0 on L0 (-1.0 in covered region), = 3.0 pn L1?" << endl;
+      << "my_vec0 = 2.0 on L0 (-1.0 in covered region), = 3.0 pn L1?" << std::endl;
       my_vec0->print(tbox::plog);
 
       // NOTE: -1's on face and node components on level 1 are due to fact
@@ -1266,7 +1265,7 @@ int main(
             my_vec2);
 
       tbox::plog
-      << "\n\nPRINTING VARIABLE DATABASE before adding new vector" << endl;
+      << "\n\nPRINTING VARIABLE DATABASE before adding new vector" << std::endl;
       variable_db->printClassData(tbox::plog);
 
       Vec pvec3;
@@ -1287,30 +1286,30 @@ int main(
       }
 
       tbox::plog << "\n\nPRINTING VARIABLE DATABASE after adding new vector"
-                 << endl;
+                 << std::endl;
       variable_db->printClassData(tbox::plog);
 
-      tbox::plog << "pvec3 = Random....?" << endl;
+      tbox::plog << "pvec3 = Random....?" << std::endl;
       VecView(pvec3, 0);
 
       VecSwap(pvec0, pvec3);
       tbox::plog << "After swapping pvec0 and pvec3, pvec0 = Random....?"
-                 << endl;
+                 << std::endl;
       VecView(pvec0, 0);
       tbox::plog
-      << "pvec3 = 2.0 on L0 (-1.0 in covered region), = 3.0 pn L1?" << endl;
+      << "pvec3 = 2.0 on L0 (-1.0 in covered region), = 3.0 pn L1?" << std::endl;
       VecView(pvec3, 0);
 
       VecAXPY(pvec0, four, pvec3);
       tbox::plog
       <<
       "pvec0 = pvec0 + 4.0 * pvec3 = Random + 8.0 on L0 (-3.0 - Random in covered region), = 12.0 + Random on L1?"
-      << endl;
+      << std::endl;
       VecView(pvec0, 0);
 
       VecScale(pvec3, half);
       tbox::plog
-      << "pvec3 = 1.0 on L0 (-0.5 in covered region), = 1.5 pn L1?" << endl;
+      << "pvec3 = 1.0 on L0 (-0.5 in covered region), = 1.5 pn L1?" << std::endl;
       VecView(pvec3, 0);
 
       VecSet(pvec0, one);
@@ -1318,15 +1317,15 @@ int main(
       VecSet(pvec2, three);
 
       VecAXPBY(pvec0, three, half, pvec1);
-      tbox::plog << "pvec0 = 3 * 2 + 0.5 * 1 = 6.5?" << endl;
+      tbox::plog << "pvec0 = 3 * 2 + 0.5 * 1 = 6.5?" << std::endl;
       VecView(pvec0, 0);
 
       VecAYPX(pvec1, twelve, pvec0);
-      tbox::plog << "pvec1 = 6.5 + 12 * 2 = 30.5?" << endl;
+      tbox::plog << "pvec1 = 6.5 + 12 * 2 = 30.5?" << std::endl;
       VecView(pvec1, 0);
 
       VecWAXPY(result, zero, pvec0, pvec0);
-      tbox::plog << "pvec0 = 0 * 6.5 + 6.5 = 6.5?" << endl;
+      tbox::plog << "pvec0 = 0 * 6.5 + 6.5 = 6.5?" << std::endl;
       VecView(result, 0);
 
       // No more tests....Destroy vectors and data...
@@ -1334,7 +1333,7 @@ int main(
       VecDestroy(&pvec3);
 
       tbox::plog
-      << "\n\nPRINTING VARIABLE DATABASE after freeing new vector" << endl;
+      << "\n\nPRINTING VARIABLE DATABASE after freeing new vector" << std::endl;
       variable_db->printClassData(tbox::plog);
 
       // Destroy PETSc vector wrappers
@@ -1378,7 +1377,7 @@ int main(
 #endif
 
       if (fail_count == 0) {
-         tbox::pout << "\nPASSED:  pvtest" << endl;
+         tbox::pout << "\nPASSED:  pvtest" << std::endl;
       }
 
    }

--- a/tools/restart/RedistributedRestartUtility.C
+++ b/tools/restart/RedistributedRestartUtility.C
@@ -28,8 +28,8 @@
  */
 
 void RedistributedRestartUtility::writeRedistributedRestartFiles(
-   const string& output_dirname,
-   const string& input_dirname,
+   const std::string& output_dirname,
+   const std::string& input_dirname,
    const int total_input_files,
    const int total_output_files,
    const std::vector<std::vector<int> >& file_mapping,
@@ -63,12 +63,12 @@ void RedistributedRestartUtility::writeRedistributedRestartFiles(
       int num_files_to_write = (total_input_files < total_output_files) ?
          static_cast<int>(file_mapping[icount].size()) : 1;
 
-      string restore_buf =
+      std::string restore_buf =
          "/restore." + tbox::Utilities::intToString(restore_num, 6);
-      string nodes_buf =
+      std::string nodes_buf =
          "/nodes." + tbox::Utilities::nodeToString(total_output_files);
 
-      string restart_dirname = output_dirname + restore_buf + nodes_buf;
+      std::string restart_dirname = output_dirname + restore_buf + nodes_buf;
 
       //Make the subdirectories if this is the first iteration.
       if (icount == 0) {
@@ -96,10 +96,10 @@ void RedistributedRestartUtility::writeRedistributedRestartFiles(
             }
          }
 
-         string proc_buf =
+         std::string proc_buf =
             "/proc." + tbox::Utilities::processorToString(cur_out_file_id);
 
-         string output_filename = restart_dirname + proc_buf;
+         std::string output_filename = restart_dirname + proc_buf;
 
          output_dbs[i].reset(new tbox::HDFDatabase(output_filename));
 
@@ -120,8 +120,8 @@ void RedistributedRestartUtility::writeRedistributedRestartFiles(
 
       nodes_buf = "/nodes." + tbox::Utilities::nodeToString(total_input_files);
 
-      std::vector<string> input_keys(0);
-      std::vector<string> test_keys(0);
+      std::vector<std::string> input_keys(0);
+      std::vector<std::string> test_keys(0);
       int num_keys = 0;
 
       int input_files_per_proc = total_input_files / nprocs;
@@ -142,10 +142,10 @@ void RedistributedRestartUtility::writeRedistributedRestartFiles(
             cur_in_file_id = file_mapping[icount][i];
          }
 
-         string proc_buf =
+         std::string proc_buf =
             "/proc." + tbox::Utilities::processorToString(cur_in_file_id);
 
-         string restart_filename = input_dirname + restore_buf + nodes_buf
+         std::string restart_filename = input_dirname + restore_buf + nodes_buf
             + proc_buf;
 
          input_dbs[i].reset(new tbox::HDFDatabase(restart_filename));
@@ -205,7 +205,7 @@ void RedistributedRestartUtility::writeRedistributedRestartFiles(
 void RedistributedRestartUtility::readAndWriteRestartData(
    std::vector<std::shared_ptr<tbox::Database> >& output_dbs,
    const std::vector<std::shared_ptr<tbox::Database> >& input_dbs,
-   const string& key,
+   const std::string& key,
    const std::vector<std::vector<int> >* file_mapping,  // = 0
    const int num_files_written, // = -1,
    const int which_file_mapping, // = -1
@@ -345,7 +345,7 @@ void RedistributedRestartUtility::readAndWriteRestartData(
             child_out_dbs[i] = output_dbs[i]->putDatabase(key);
          }
 
-         std::vector<string> child_keys = db->getAllKeys();
+         std::vector<std::string> child_keys = db->getAllKeys();
 
          for (int j = 0; j < static_cast<int>(child_keys.size()); ++j) {
             readAndWriteRestartData(child_out_dbs,
@@ -399,7 +399,7 @@ void RedistributedRestartUtility::readAndWriteRestartData(
 
    } else if (input_dbs[0]->isString(key)) {
 
-      std::vector<string> string_array = input_dbs[0]->getStringVector(key);
+      std::vector<std::string> string_array = input_dbs[0]->getStringVector(key);
 
       for (int i = 0; i < static_cast<int>(output_dbs.size()); ++i) {
          output_dbs[i]->putStringVector(key, string_array);
@@ -447,7 +447,7 @@ void RedistributedRestartUtility::readAndWriteRestartData(
 void RedistributedRestartUtility::readAndWritePatchLevelRestartData(
    std::vector<std::shared_ptr<tbox::Database> >& output_dbs,
    const std::vector<std::shared_ptr<tbox::Database> >& level_in_dbs,
-   const string& key,
+   const std::string& key,
    const int num_files_written,
    const std::vector<int>& input_proc_nums,
    const int total_output_files)
@@ -669,11 +669,11 @@ void RedistributedRestartUtility::readAndWritePatchLevelRestartData(
             }
          }
 
-         string in_patch_name =
+         std::string in_patch_name =
             "level_" + tbox::Utilities::levelToString(level_number)
             + "-patch_" + tbox::Utilities::patchToString(*ilp)
             + "-block_" + tbox::Utilities::blockToString(*ilb);
-         string out_patch_name =
+         std::string out_patch_name =
             "level_" + tbox::Utilities::levelToString(level_number)
             + "-patch_" + tbox::Utilities::patchToString(*olp)
             + "-block_" + tbox::Utilities::blockToString(*olb);
@@ -713,7 +713,7 @@ void RedistributedRestartUtility::readAndWritePatchRestartData(
    const int output_proc)
 {
    //Get the keys in the patch input database.
-   std::vector<string> keys = patch_in_db->getAllKeys();
+   std::vector<std::string> keys = patch_in_db->getAllKeys();
 
    //Place the database on arrays of length 1.
    std::vector<std::shared_ptr<tbox::Database> > in_db_array(1);
@@ -742,7 +742,7 @@ void RedistributedRestartUtility::readAndWritePatchRestartData(
 void RedistributedRestartUtility::readAndWriteBoxLevelRestartData(
    std::vector<std::shared_ptr<tbox::Database> >& output_dbs,
    const std::vector<std::shared_ptr<tbox::Database> >& level_in_dbs,
-   const string& key,
+   const std::string& key,
    const int num_files_written,
    const std::vector<int>& input_proc_nums,
    const int total_output_files)
@@ -768,7 +768,7 @@ void RedistributedRestartUtility::readAndWriteBoxLevelRestartData(
    std::vector<std::vector<int> > ratio;
    int b = 0;
    for ( ; ; ++b ) {   
-      string ratio_name = "d_ratio_" + tbox::Utilities::intToString(b);
+      std::string ratio_name = "d_ratio_" + tbox::Utilities::intToString(b);
       if (level_in_dbs[0]->isInteger(ratio_name)) {
          ratio.push_back(level_in_dbs[0]->getIntegerVector(ratio_name));
       } else {
@@ -780,7 +780,7 @@ void RedistributedRestartUtility::readAndWriteBoxLevelRestartData(
       level_out_dbs[i]->putInteger("HIER_MAPPED_BOX_LEVEL_VERSION", version);
       level_out_dbs[i]->putInteger("dim", dim);
       for (int nb = 0; nb < static_cast<int>(ratio.size()); ++nb) {
-         string ratio_name = "d_ratio_" + tbox::Utilities::intToString(nb);
+         std::string ratio_name = "d_ratio_" + tbox::Utilities::intToString(nb);
          level_out_dbs[i]->putIntegerVector(ratio_name, ratio[nb]);
       }
       level_out_dbs[i]->putInteger("d_nproc", total_output_files);

--- a/tools/restart/RedistributedRestartUtility.h
+++ b/tools/restart/RedistributedRestartUtility.h
@@ -16,7 +16,6 @@
 
 #include <string>
 
-using namespace std;
 using namespace SAMRAI;
 
 /*
@@ -42,8 +41,8 @@ public:
  */
    static void
    writeRedistributedRestartFiles(
-      const string& output_dirname,
-      const string& input_dirname,
+      const std::string& output_dirname,
+      const std::string& input_dirname,
       const int total_input_files,
       const int total_output_files,
       const std::vector<std::vector<int> >& file_mapping,
@@ -68,7 +67,7 @@ private:
    readAndWriteRestartData(
       std::vector<std::shared_ptr<tbox::Database> >& output_dbs,
       const std::vector<std::shared_ptr<tbox::Database> >& input_dbs,
-      const string& key,
+      const std::string& key,
       const std::vector<std::vector<int> >* file_mapping = 0,
       int num_files_written = -1,
       int which_file_mapping = -1,
@@ -84,7 +83,7 @@ private:
    readAndWritePatchLevelRestartData(
       std::vector<std::shared_ptr<tbox::Database> >& output_dbs,
       const std::vector<std::shared_ptr<tbox::Database> >& level_in_dbs,
-      const string& key,
+      const std::string& key,
       const int num_files_written,
       const std::vector<int>& input_proc_nums,
       const int total_output_files);
@@ -98,7 +97,7 @@ private:
    readAndWriteBoxLevelRestartData(
       std::vector<std::shared_ptr<tbox::Database> >& output_dbs,
       const std::vector<std::shared_ptr<tbox::Database> >& level_in_dbs,
-      const string& key,
+      const std::string& key,
       const int num_files_written,
       const std::vector<int>& input_proc_nums,
       const int total_output_files);

--- a/tools/restart/main.C
+++ b/tools/restart/main.C
@@ -39,7 +39,6 @@
 #define NAME_BUFSIZE (32)
 #endif
 
-using namespace std;
 using namespace SAMRAI;
 
 #ifdef _MSC_VER
@@ -142,21 +141,21 @@ int main(
    char* argv[])
 {
 
-   const string slash = "/";
+   const std::string slash = "/";
 
    tbox::SAMRAI_MPI::init(&argc, &argv);
    tbox::SAMRAIManager::initialize();
    tbox::SAMRAIManager::startup();
 
-   string read_dirname;
-   string write_dirname;
+   std::string read_dirname;
+   std::string write_dirname;
    int restore_num = 0;
    int num_output_files = 1;
 
    if ((argc != 5)) {
       tbox::pout << "USAGE:  " << argv[0] << " input-dir "
                  << "output-dir restore-number num-output-files\n"
-                 << endl;
+                 << std::endl;
       exit(-1);
       return -1;
    } else {
@@ -170,7 +169,7 @@ int main(
    const std::string restore_buf =
       "/restore." + tbox::Utilities::intToString(restore_num, 6);
 
-   string restore_dirname;
+   std::string restore_dirname;
    if (read_dirname.compare(0, 1, "/") == 0) {
       restore_dirname = read_dirname + restore_buf;
    } else {
@@ -196,8 +195,8 @@ int main(
          "restore directory should contain restart files for a single run; this probably indicates runs with different number of nodes have been done in in the restart directory");
    }
 
-   string nodes_dirname;
-   string prefix = "nodes.";
+   std::string nodes_dirname;
+   std::string prefix = "nodes.";
    for (int i = 0; i < num_entries; i++) {
       if (strncmp(prefix.c_str(), namelist[i]->d_name, prefix.length()) == 0) {
          nodes_dirname = namelist[i]->d_name;
@@ -209,7 +208,7 @@ int main(
    // Check if nodes_dirname is valid and extract number of processors for the saved run.
    if (nodes_dirname.size() == 13) {
 
-      string int_str = &(nodes_dirname.c_str()[6]);
+      std::string int_str = &(nodes_dirname.c_str()[6]);
 
       num_input_files = atoi(int_str.c_str());
 
@@ -223,7 +222,7 @@ int main(
    }
    free(namelist);
 
-   string full_nodes_dirname = restore_dirname + slash + nodes_dirname;
+   std::string full_nodes_dirname = restore_dirname + slash + nodes_dirname;
    num_entries = scandir(full_nodes_dirname.c_str(), &namelist, 0, 0);
    if (num_entries != num_input_files + 2) {
       TBOX_ERROR(


### PR DESCRIPTION
We have required that std:: be explicitly prefixed wherever standard library symbols are used, but it wasn't consistently enforced.  This can cause some issues when compiling with cuda, so I've cleaned that all up here.