### PR TITLE
Make cmake SILO flags work correctly

### DIFF
--- a/config/SAMRAI_config.h.cmake.in
+++ b/config/SAMRAI_config.h.cmake.in
@@ -142,7 +142,7 @@
 #undef HAVE_PTSCOTCH
 
 /* SILO library is available so use it */
-#undef HAVE_SILO
+#cmakedefine HAVE_SILO
 
 /* HAVE_SSTREAM */
 #undef HAVE_SSTREAM

--- a/source/SAMRAI/tbox/CMakeLists.txt
+++ b/source/SAMRAI/tbox/CMakeLists.txt
@@ -115,6 +115,10 @@ if (HAVE_HDF5)
     list(APPEND tbox_depends_on hdf5)
 endif ()
 
+if (HAVE_SILO)
+    list(APPEND tbox_depends_on SILO)
+endif ()
+
 if (ENABLE_MPI)
   list(APPEND tbox_depends_on mpi)
 endif ()


### PR DESCRIPTION
Enables SILO in the cmake build system.