### PR TITLE
bugfix accounts for src_shift in Raja variant of doArrayDataOperationOnBox

### DIFF
--- a/cmake/SetupCompilers.cmake
+++ b/cmake/SetupCompilers.cmake
@@ -3,7 +3,7 @@ set(CMAKE_Fortran_FORMAT FIXED)
 # Set specific options for CUDA if enabled
 if (ENABLE_RAJA AND ENABLE_CUDA)
   # RAJA requires some experimental features
-  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -arch ${CUDA_ARCH}--expt-extended-lambda --expt-relaxed-constexpr")
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -arch ${CUDA_ARCH} --expt-extended-lambda --expt-relaxed-constexpr")
 endif ()
 
 # TODO Ensure openmp flags are not enabled twice!

--- a/source/SAMRAI/pdat/ArrayDataOperationUtilities.C
+++ b/source/SAMRAI/pdat/ArrayDataOperationUtilities.C
@@ -83,6 +83,7 @@ void ArrayDataOperationUtilities<TYPE, OP>::doArrayDataOperationOnBox(
       + dst_start_depth * dst_offset;
    size_t src_begin = src_box.offset(opbox.lower() - src_shift)
       + src_start_depth * src_offset;
+
 #else
    NULL_USE(src_ptr);
    NULL_USE(dst_ptr);
@@ -102,27 +103,30 @@ void ArrayDataOperationUtilities<TYPE, OP>::doArrayDataOperationOnBox(
       case 1: {
          auto dest = get_view<1>(dst, d);
          auto source = get_const_view<1>(src, d);
-
+         const int shift_i = src_shift[0];
          pdat::parallel_for_all(opbox, [=] SAMRAI_HOST_DEVICE (int i) {
-            op(dest(i), source(i));
+            op(dest(i), source(i-shift_i));
          });
       } break;
 
       case 2: {
          auto dest = get_view<2>(dst, d);
          auto source = get_const_view<2>(src, d);
-
+         const int shift_i = src_shift[0];
+         const int shift_j = src_shift[1];
          pdat::parallel_for_all(opbox, [=] SAMRAI_HOST_DEVICE (int j, int i) {
-            op(dest(i, j), source(i, j));
+            op(dest(i, j), source(i-shift_i, j-shift_j));
          });
       } break;
 
       case 3: {
          auto dest = get_view<3>(dst, d);
          auto source = get_const_view<3>(src, d);
-
+         const int shift_i = src_shift[0];
+         const int shift_j = src_shift[1];
+         const int shift_k = src_shift[2];
          pdat::parallel_for_all(opbox, [=] SAMRAI_HOST_DEVICE (int k, int j, int i) {
-            op(dest(i,j,k), source(i,j,k));
+            op(dest(i,j,k), source(i-shift_i,j-shift_j,k-shift_k));
          });
       } break;
 
@@ -199,8 +203,7 @@ void ArrayDataOperationUtilities<TYPE, OP>::doArrayDataOperationOnBox(
 #endif
 
    }  // d loop over depth indices
-
-}
+} // end doArrayDataOperationOnBox
 
 /*
  *************************************************************************
@@ -310,7 +313,7 @@ void ArrayDataOperationUtilities<TYPE, OP>::doArrayDataBufferOperationOnBox(
                 TBOX_ERROR("Aborting in " __FILE__);
                 break;
      }
-#else
+#else // !HAVE_RAJA
       size_t dat_counter = dat_begin;
       size_t buf_counter = buf_begin;
 
@@ -377,8 +380,9 @@ void ArrayDataOperationUtilities<TYPE, OP>::doArrayDataBufferOperationOnBox(
 
    }  // d loop over depth indices
 
-}
+} // end doArrayDataBufferOperationOnBox
 
-}
-}
+} // namespace pdat
+} // namespace SAMRAI
+
 #endif

--- a/source/test/dataops/CMakeLists.txt
+++ b/source/test/dataops/CMakeLists.txt
@@ -2,135 +2,108 @@ set (indx_dataops_sources
   indx_dataops.C
   SampleIndexData.C)
 
+set(dataops_depends ${SAMRAI_LIBRARIES})
+
+# TODO CMake should resolve this dependency for us...
+if (ENABLE_OPENMP)
+  set(dataops_depends ${dataops_depends} openmp)
+endif ()
+
+if (ENABLE_CUDA)
+  set(dataops_depends ${dataops_depends} cuda)
+endif ()
+
 blt_add_executable(
   NAME indx_dataops
   SOURCES ${indx_dataops_sources}
   DEPENDS_ON
-    SAMRAI_hier
-    SAMRAI_geom
-    SAMRAI_pdat
-    SAMRAI_math
-    SAMRAI_tbox)
+    ${dataops_depends})
+
 
 blt_add_executable(
   NAME cell_patchtest
   SOURCES cell_patchtest.C
   DEPENDS_ON
-    SAMRAI_hier
-    SAMRAI_geom
-    SAMRAI_pdat
-    SAMRAI_math
-    SAMRAI_tbox)
+    ${dataops_depends})
+
 
 blt_add_executable(
   NAME cell_hiertest
   SOURCES cell_hiertest.C
   DEPENDS_ON
-    SAMRAI_hier
-    SAMRAI_geom
-    SAMRAI_pdat
-    SAMRAI_math
-    SAMRAI_tbox)
+    ${dataops_depends})
+
 
 blt_add_executable(
   NAME cell_hiertest3d
   SOURCES cell_hiertest.C
   DEPENDS_ON
-    SAMRAI_hier
-    SAMRAI_geom
-    SAMRAI_pdat
-    SAMRAI_math
-    SAMRAI_tbox)
+    ${dataops_depends})
+
 
 blt_add_executable(
   NAME edge_hiertest
   SOURCES edge_hiertest.C
   DEPENDS_ON
-    SAMRAI_hier
-    SAMRAI_geom
-    SAMRAI_pdat
-    SAMRAI_math
-    SAMRAI_tbox)
+    ${dataops_depends})
+
 
 blt_add_executable(
   NAME face_hiertest
   SOURCES face_hiertest.C
   DEPENDS_ON
-    SAMRAI_hier
-    SAMRAI_geom
-    SAMRAI_pdat
-    SAMRAI_math
-    SAMRAI_tbox)
+    ${dataops_depends})
+
 
 blt_add_executable(
   NAME side_hiertest
   SOURCES side_hiertest.C
   DEPENDS_ON
-    SAMRAI_hier
-    SAMRAI_geom
-    SAMRAI_pdat
-    SAMRAI_math
-    SAMRAI_tbox)
+    ${dataops_depends})
+
 
 blt_add_executable(
   NAME node_hiertest
   SOURCES node_hiertest.C
   DEPENDS_ON
-    SAMRAI_hier
-    SAMRAI_geom
-    SAMRAI_pdat
-    SAMRAI_math
-    SAMRAI_tbox)
+    ${dataops_depends})
+
 
 blt_add_executable(
   NAME cell_cplxtest
   SOURCES cell_cplxtest.C
   DEPENDS_ON
-    SAMRAI_hier
-    SAMRAI_geom
-    SAMRAI_pdat
-    SAMRAI_math
-    SAMRAI_tbox)
+    ${dataops_depends})
+
 
 blt_add_executable(
   NAME edge_cplxtest
   SOURCES edge_cplxtest.C
   DEPENDS_ON
-    SAMRAI_hier
-    SAMRAI_geom
-    SAMRAI_pdat
-    SAMRAI_math
-    SAMRAI_tbox)
+    ${dataops_depends})
+
 
 blt_add_executable(
   NAME node_cplxtest
   SOURCES node_cplxtest.C
   DEPENDS_ON
-    SAMRAI_hier
-    SAMRAI_geom
-    SAMRAI_pdat
-    SAMRAI_math
-    SAMRAI_tbox)
+    ${dataops_depends})
+
 
 blt_add_executable(
   NAME face_cplxtest
   SOURCES face_cplxtest.C
   DEPENDS_ON
-    SAMRAI_hier
-    SAMRAI_geom
-    SAMRAI_pdat
-    SAMRAI_math
-    SAMRAI_tbox)
+    ${dataops_depends})
+
 
 blt_add_executable(
   NAME side_cplxtest
   SOURCES side_cplxtest.C
   DEPENDS_ON
-    SAMRAI_hier
-    SAMRAI_geom
-    SAMRAI_pdat
-    SAMRAI_math
-    SAMRAI_tbox)
+    ${dataops_depends})
+
+
 
 target_compile_definitions(indx_dataops PUBLIC DISPLAY TESTING=1)
 target_compile_definitions(cell_patchtest PUBLIC DISPLAY TESTING=1)
@@ -160,11 +133,11 @@ target_include_directories(node_cplxtest PUBLIC ${PROJECT_SOURCE_DIR}/source/tes
 target_include_directories(face_cplxtest PUBLIC ${PROJECT_SOURCE_DIR}/source/test/dataops)
 target_include_directories(side_cplxtest PUBLIC ${PROJECT_SOURCE_DIR}/source/test/dataops)
 
+
 foreach(dim RANGE 2 ${MAXDIM})
   blt_add_test(
     NAME indx_dataops${dim}
     COMMAND indx_dataops ${dim})
-
   blt_add_test(
     NAME cell_patchtest${dim}
     COMMAND cell_patchtest ${dim})


### PR DESCRIPTION
We need to account for src_shift in the Raja variant of

void ArrayDataOperationUtilities<TYPE, OP>::doArrayDataOperationOnBox(
   ArrayData<TYPE>& dst,
   const ArrayData<TYPE>& src,
   const hier::Box& opbox,
   const hier::IntVector& src_shift,
   unsigned int dst_start_depth,
   unsigned int src_start_depth,
   unsigned int num_depth,
   const OP& op)

In the non-raja variant:

size_t src_begin = src_box.offset(opbox.lower() - src_shift)
      + src_start_depth * src_offset;

Example Fix for 2d variant
      case 2: {
         auto dest = get_view<2>(dst, d);
         auto source = get_const_view<2>(src, d);
         const int shift_i = src_shift[0];
         const int shift_j = src_shift[1];
         pdat::parallel_for_all(opbox, [=] SAMRAI_HOST_DEVICE (int j, int i) {
            op(dest(i, j), source(i-shift_i, j-shift_j));
         });
      } break;

In the long term we'll want a better fix which avoids offset calculation in the kernel

Also modified a couple of cmake related files.
