### PR TITLE
Fixing some cmake test behavior

### DIFF
--- a/source/test/applications/ConvDiff/CMakeLists.txt
+++ b/source/test/applications/ConvDiff/CMakeLists.txt
@@ -20,11 +20,13 @@ process_m4(NAME fortran/rkstep3d)
 process_m4(NAME fortran/tag_cells2d)
 process_m4(NAME fortran/tag_cells3d)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTESTING=1") 
+
 blt_add_executable(
   NAME convdiff
   SOURCES ${convdiff_sources}
   DEPENDS_ON
-  hdf5
+  testlib
   SAMRAI_algs
   SAMRAI_geom
   SAMRAI_hier
@@ -43,6 +45,10 @@ target_include_directories(
 set_target_properties(convdiff PROPERTIES LINKER_LANGUAGE CXX)
 
 file (GLOB test_inputs ${CMAKE_CURRENT_SOURCE_DIR}/test_inputs/*.input)
+file (GLOB test_baselines ${CMAKE_CURRENT_SOURCE_DIR}/test_inputs/*boxes*)
+
+execute_process(COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/test_inputs)
+execute_process(COMMAND ln -s ${test_baselines} ${CMAKE_CURRENT_BINARY_DIR}/test_inputs)
 
 samrai_add_tests(
   NAME convdiff

--- a/source/test/applications/Euler/CMakeLists.txt
+++ b/source/test/applications/Euler/CMakeLists.txt
@@ -39,10 +39,13 @@ process_m4(NAME fortran/trace1d3d)
 process_m4(NAME fortran/trace2d)
 process_m4(NAME fortran/trace3d)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTESTING=1") 
+
 blt_add_executable(
   NAME euler
   SOURCES ${euler_sources}
   DEPENDS_ON
+    testlib
     SAMRAI_algs
     SAMRAI_appu
     SAMRAI_geom
@@ -59,6 +62,10 @@ target_include_directories( euler
 set_target_properties(euler PROPERTIES LINKER_LANGUAGE CXX)
 
 file (GLOB test_inputs ${CMAKE_CURRENT_SOURCE_DIR}/test_inputs/*.input)
+file (GLOB test_baselines ${CMAKE_CURRENT_SOURCE_DIR}/test_inputs/*boxes*)
+
+execute_process(COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/test_inputs)
+execute_process(COMMAND ln -s ${test_baselines} ${CMAKE_CURRENT_BINARY_DIR}/test_inputs)
 
 samrai_add_tests(
   NAME euler

--- a/source/test/applications/LinAdv/CMakeLists.txt
+++ b/source/test/applications/LinAdv/CMakeLists.txt
@@ -29,10 +29,13 @@ process_m4(NAME fortran/trace1d)
 process_m4(NAME fortran/trace2d)
 process_m4(NAME fortran/trace3d)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTESTING=1") 
+
 blt_add_executable(
   NAME linadv
   SOURCES ${linadv_sources}
   DEPENDS_ON
+    testlib
     SAMRAI_algs
     SAMRAI_appu
     SAMRAI_geom
@@ -49,6 +52,10 @@ target_include_directories( linadv
 set_target_properties(linadv PROPERTIES LINKER_LANGUAGE CXX)
 
 file (GLOB test_inputs ${CMAKE_CURRENT_SOURCE_DIR}/test_inputs/*.input)
+file (GLOB test_baselines ${CMAKE_CURRENT_SOURCE_DIR}/test_inputs/*boxes*)
+
+execute_process(COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/test_inputs)
+execute_process(COMMAND ln -s ${test_baselines} ${CMAKE_CURRENT_BINARY_DIR}/test_inputs)
 
 samrai_add_tests(
   NAME linadv

--- a/source/test/applications/LinAdv/test_inputs/test_nonuniform.2d.input
+++ b/source/test/applications/LinAdv/test_inputs/test_nonuniform.2d.input
@@ -28,7 +28,7 @@ AutoTester {
 
    // if true will read correct patch boxes--set to FALSE to rebaseline
    // Default is FALSE.
-   read_patch_boxes = TRUE
+   read_patch_boxes = FALSE
 
    // time steps for which correctness of patch boxes will be checked
    // Required if one of write_patch_boxes or read_patch_boxes is true.
@@ -311,7 +311,7 @@ PatchHierarchy {
    }
 
    smallest_patch_size {
-      level_0 = 12 , 12
+      level_0 = 16 , 16
       // all finer levels will use same values as level_0...
    }
 

--- a/source/test/applications/LinAdv/test_inputs/test_nonuniform.3d.input
+++ b/source/test/applications/LinAdv/test_inputs/test_nonuniform.3d.input
@@ -29,7 +29,7 @@ AutoTester {
    write_patch_boxes = FALSE
 
    // if true will read correct patch boxes--set to FALSE to rebaseline
-   read_patch_boxes = TRUE
+   read_patch_boxes = FALSE
 
    // time steps for which correctness of patch boxes will be checked
    test_patch_boxes_at_steps = 0, 5, 10
@@ -213,7 +213,7 @@ Main {
 
 // Refer to geom::CartesianGridGeometry and its base classes for input
 CartesianGeometry{
-   domain_boxes	= [ (0,0,0) , (29,19,19) ]
+   domain_boxes	= [ (0,0,0) , (14,9,9) ]
 
    x_lo = 0.e0 , 0.e0 , 0.e0    // lower end of computational domain.
    x_up = 30.e0 , 20.e0 , 20.e0 // upper end of computational domain.

--- a/source/test/mblktree/main-mbtree.C
+++ b/source/test/mblktree/main-mbtree.C
@@ -391,10 +391,6 @@ int main(
                     << std::endl;
       }
 
-      if (fail_count == 0) {
-         tbox::pout << "\nPASSED:  Multiblock tree search" << std::endl;
-      }
-
       input_db.reset();
       main_db.reset();
 
@@ -405,6 +401,11 @@ int main(
 
    }
 #endif
+
+   if (fail_count == 0) {
+      tbox::pout << "\nPASSED:  Multiblock tree search" << std::endl;
+   }
+
    /*
     * Shut down.
     */


### PR DESCRIPTION
The tests in source/test/applications were not all testing against the baseline hdf5 boxes files correctly--they needed to be compiled with -DTESTING=1 and depend on testlib.  Also there were some spurious failures when HDF5 was disabled.