### PR TITLE
Enable the debugging macros for cmake Debug builds

### DIFF
--- a/cmake/CMakeConfigureFile.cmake
+++ b/cmake/CMakeConfigureFile.cmake
@@ -17,6 +17,12 @@ if (${ENABLE_BOX_COUNTING})
   set (BOX_TELEMETRY On)
 endif()
 
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set (DEBUG_INITIALIZE_UNDEFINED On)
+  set (DEBUG_CHECK_ASSERTIONS On)
+  set (DEBUG_CHECK_DIM_ASSERTIONS On)
+endif()
+
 #HAVE_CMATH
 check_include_files("math.h" HAVE_CMATH)
 

--- a/config/SAMRAI_config.h.cmake.in
+++ b/config/SAMRAI_config.h.cmake.in
@@ -32,7 +32,7 @@
 #cmakedefine DEBUG_CHECK_DIM_ASSERTIONS
 
 /* Initialize new memory to undefined values in debug mode */
-#undef DEBUG_INITIALIZE_UNDEFINED
+#cmakedefine DEBUG_INITIALIZE_UNDEFINED
 
 /* ENABLE_SAMRAI_TIMERS */
 #cmakedefine ENABLE_SAMRAI_TIMERS

--- a/source/test/MblkLinAdv/CMakeLists.txt
+++ b/source/test/MblkLinAdv/CMakeLists.txt
@@ -6,12 +6,15 @@ set (mblklinadv_sources
 
 set (mblklinadv_depends_on
     testlib
-    SAMRAI_hier
+    SAMRAI_appu
+    SAMRAI_algs
+    SAMRAI_solv
     SAMRAI_geom
     SAMRAI_mesh
+    SAMRAI_math
     SAMRAI_pdat
-    SAMRAI_algs
-    SAMRAI_appu
+    SAMRAI_xfer
+    SAMRAI_hier
     SAMRAI_tbox)
 
 blt_add_executable(


### PR DESCRIPTION
DEBUG_INITIALIZE_UNDEFINED, DEBUG_CHECK_ASSERTIONS, and DEBUG_CHECK_DIM_ASSERTIONS need to be turned on in debug builds in order for cmake debug builds to match the behavior of autoconf debug builds.

This caused one test, MblkLinAdv, to require a reordering of its library dependencies in order to link its executable.  I don't really understand why.