### PR TITLE
Fixing some OpenMP-related bugs

### DIFF
--- a/source/SAMRAI/hier/MappingConnectorAlgorithm.C
+++ b/source/SAMRAI/hier/MappingConnectorAlgorithm.C
@@ -1301,7 +1301,9 @@ MappingConnectorAlgorithm::privateModify_findOverlapsForOneProcess(
    const InvertedNeighborhoodSet& inverted_nbrhd,
    const IntVector& head_refinement_ratio) const
 {
+#ifndef HAVE_OPENMP
    d_object_timers->t_modify_find_overlaps_for_one_process->start();
+#endif
 
    const BoxLevel& old = mapping_connector.getBase();
    const std::shared_ptr<const BaseGridGeometry>& grid_geometry(
@@ -1446,7 +1448,9 @@ MappingConnectorAlgorithm::privateModify_findOverlapsForOneProcess(
       }
    }
 
+#ifndef HAVE_OPENMP
    d_object_timers->t_modify_find_overlaps_for_one_process->stop();
+#endif
 }
 
 /*

--- a/source/SAMRAI/tbox/ParallelBuffer.h
+++ b/source/SAMRAI/tbox/ParallelBuffer.h
@@ -107,7 +107,8 @@ public:
    void
    outputString(
       const std::string& text,
-      const int length);
+      const int length,
+      const bool recursive = false);
 
    /**
     * Synchronize the parallel buffer (called from streambuf).


### PR DESCRIPTION

A mutex call was double-locking due to recursion, and a thread-unsafe timer call was made within a threaded section of code.