### PR TITLE
implicitly declared deprecated

### DIFF
--- a/source/SAMRAI/hier/BoxId.h
+++ b/source/SAMRAI/hier/BoxId.h
@@ -179,6 +179,12 @@ public:
     *
     * All comparison operators use the GlobalId and PeriodicId.
     */
+
+   BoxId&
+   operator = (
+      const BoxId& r) = default;
+
+
    bool
    operator == (
       const BoxId& r) const

--- a/source/SAMRAI/hier/GlobalId.h
+++ b/source/SAMRAI/hier/GlobalId.h
@@ -118,6 +118,10 @@ public:
     * owner values first; if they compare equal, compare the LocalId
     * next.
     */
+   GlobalId&
+   operator = (
+      const GlobalId& r) = default;
+
    bool
    operator == (
       const GlobalId& r) const


### PR DESCRIPTION
GCC 9.2 Werror 

    samrai/source/SAMRAI/hier/Box.h:309:14: error: implicitly-declared ‘SAMRAI::hier::BoxId& 
    SAMRAI::hier::BoxId::operator=(const SAMRAI::hier::BoxId&)’ is deprecated [-Werror=deprecated- 
    copy]



    samrai/source/SAMRAI/hier/BoxId.h:37:7: error: implicitly-declared ‘SAMRAI::hier::GlobalId& 
    SAMRAI::hier::GlobalId::operator=(const SAMRAI::hier::GlobalId&)’ is deprecated [-
    Werror=deprecated-copy]


