### PR TITLE
Add BoxOverlap argument to TimeInterpolateOperator pure virtual

### DIFF
--- a/source/SAMRAI/hier/TimeInterpolateOperator.h
+++ b/source/SAMRAI/hier/TimeInterpolateOperator.h
@@ -90,6 +90,7 @@ public:
    timeInterpolate(
       PatchData& dst_data,
       const Box& where,
+      const BoxOverlap& overlap, 
       const PatchData& src_data_old,
       const PatchData& src_data_new) const = 0;
 

--- a/source/SAMRAI/pdat/CellComplexLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/CellComplexLinearTimeInterpolateOp.C
@@ -83,9 +83,11 @@ void
 CellComplexLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
+   NULL_USE(overlap);
    const tbox::Dimension& dim(where.getDim());
 
    const CellData<dcomplex>* old_dat =

--- a/source/SAMRAI/pdat/CellComplexLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/CellComplexLinearTimeInterpolateOp.h
@@ -66,6 +66,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/CellDoubleLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/CellDoubleLinearTimeInterpolateOp.C
@@ -84,9 +84,11 @@ void
 CellDoubleLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
+   NULL_USE(overlap);
    const tbox::Dimension& dim(where.getDim());
 
    const CellData<double>* old_dat =

--- a/source/SAMRAI/pdat/CellDoubleLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/CellDoubleLinearTimeInterpolateOp.h
@@ -67,6 +67,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/CellFloatLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/CellFloatLinearTimeInterpolateOp.C
@@ -84,9 +84,11 @@ void
 CellFloatLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
+   NULL_USE(overlap);
    const tbox::Dimension& dim(where.getDim());
 
    const CellData<float>* old_dat =

--- a/source/SAMRAI/pdat/CellFloatLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/CellFloatLinearTimeInterpolateOp.h
@@ -67,6 +67,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/EdgeComplexLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/EdgeComplexLinearTimeInterpolateOp.C
@@ -8,7 +8,6 @@
  *
  ************************************************************************/
 #include "SAMRAI/pdat/EdgeComplexLinearTimeInterpolateOp.h"
-#include "SAMRAI/tbox/Complex.h"
 
 #include "SAMRAI/hier/Box.h"
 #include "SAMRAI/hier/Index.h"
@@ -17,7 +16,6 @@
 #include "SAMRAI/tbox/Utilities.h"
 #include "SAMRAI/tbox/MathUtilities.h"
 
-#include <memory>
 
 /*
  *************************************************************************
@@ -121,6 +119,7 @@ void
 EdgeComplexLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
@@ -136,9 +135,6 @@ EdgeComplexLinearTimeInterpolateOp::timeInterpolate(
    TBOX_ASSERT(old_dat != 0);
    TBOX_ASSERT(new_dat != 0);
    TBOX_ASSERT(dst_dat != 0);
-   TBOX_ASSERT((where * old_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * new_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * dst_dat->getGhostBox()).isSpatiallyEqual(where));
    TBOX_ASSERT_OBJDIM_EQUALITY4(dst_data, where, src_data_old, src_data_new);
 
    const hier::Index& old_ilo = old_dat->getGhostBox().lower();
@@ -148,9 +144,6 @@ EdgeComplexLinearTimeInterpolateOp::timeInterpolate(
 
    const hier::Index& dst_ilo = dst_dat->getGhostBox().lower();
    const hier::Index& dst_ihi = dst_dat->getGhostBox().upper();
-
-   const hier::Index& ifirst = where.lower();
-   const hier::Index& ilast = where.upper();
 
    const double old_time = old_dat->getTime();
    const double new_time = new_dat->getTime();
@@ -169,76 +162,121 @@ EdgeComplexLinearTimeInterpolateOp::timeInterpolate(
       tfrac = 0.0;
    }
 
+   std::vector<hier::Box> edge_where(dim.getValue(), hier::Box(dim));
+   std::vector<hier::BoxContainer> ovlp_boxes(dim.getValue());
+
+   const EdgeOverlap* edge_ovlp = CPP_CAST<const EdgeOverlap*>(&overlap);
+   for (int dir = 0; dir < dim.getValue(); ++dir) {
+      edge_where[dir] = EdgeGeometry::toEdgeBox(where, dir);
+      edge_ovlp->getSourceBoxContainer(ovlp_boxes[dir], dir);
+   }
+
    for (int d = 0; d < dst_dat->getDepth(); ++d) {
       if (dim == tbox::Dimension(1)) {
-         SAMRAI_F77_FUNC(lintimeintedgecmplx1d, LINTIMEINTEDGECMPLX1D) (ifirst(0),
-            ilast(0),
-            old_ilo(0), old_ihi(0),
-            new_ilo(0), new_ihi(0),
-            dst_ilo(0), dst_ihi(0),
-            tfrac,
-            old_dat->getPointer(0, d),
-            new_dat->getPointer(0, d),
-            dst_dat->getPointer(0, d));
+         for (auto itr = ovlp_boxes[0].begin();
+              itr != ovlp_boxes[0].end(); ++itr) {
+            hier::Box dest_box((*itr) * edge_where[0]); 
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintedgecmplx1d, LINTIMEINTEDGECMPLX1D) (
+               ifirst(0), ilast(0),
+               old_ilo(0), old_ihi(0),
+               new_ilo(0), new_ihi(0),
+               dst_ilo(0), dst_ihi(0),
+               tfrac,
+               old_dat->getPointer(0, d),
+               new_dat->getPointer(0, d),
+               dst_dat->getPointer(0, d));
+         }
       } else if (dim == tbox::Dimension(2)) {
-         SAMRAI_F77_FUNC(lintimeintedgecmplx2d0, LINTIMEINTEDGECMPLX2D0) (ifirst(0),
-            ifirst(1), ilast(0), ilast(1),
-            old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-            new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-            dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-            tfrac,
-            old_dat->getPointer(0, d),
-            new_dat->getPointer(0, d),
-            dst_dat->getPointer(0, d));
-         SAMRAI_F77_FUNC(lintimeintedgecmplx2d1, LINTIMEINTEDGECMPLX2D1) (ifirst(0),
-            ifirst(1), ilast(0), ilast(1),
-            old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-            new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-            dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-            tfrac,
-            old_dat->getPointer(1, d),
-            new_dat->getPointer(1, d),
-            dst_dat->getPointer(1, d));
+         for (auto itr = ovlp_boxes[0].begin();
+              itr != ovlp_boxes[0].end(); ++itr) {
+            hier::Box dest_box((*itr) * edge_where[0]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintedgecmplx2d0, LINTIMEINTEDGECMPLX2D0) (
+               ifirst(0), ifirst(1), ilast(0), ilast(1),
+               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+               tfrac,
+               old_dat->getPointer(0, d),
+               new_dat->getPointer(0, d),
+               dst_dat->getPointer(0, d));
+         }
+         for (auto itr = ovlp_boxes[1].begin();
+              itr != ovlp_boxes[1].end(); ++itr) {
+            hier::Box dest_box((*itr) * edge_where[1]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintedgecmplx2d1, LINTIMEINTEDGECMPLX2D1) (
+               ifirst(0), ifirst(1), ilast(0), ilast(1),
+               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+               tfrac,
+               old_dat->getPointer(1, d),
+               new_dat->getPointer(1, d),
+               dst_dat->getPointer(1, d));
+         }
       } else if (dim == tbox::Dimension(3)) {
-         SAMRAI_F77_FUNC(lintimeintedgecmplx3d0, LINTIMEINTEDGECMPLX3D0) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(0, d),
-            new_dat->getPointer(0, d),
-            dst_dat->getPointer(0, d));
-         SAMRAI_F77_FUNC(lintimeintedgecmplx3d1, LINTIMEINTEDGECMPLX3D1) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(1, d),
-            new_dat->getPointer(1, d),
-            dst_dat->getPointer(1, d));
-         SAMRAI_F77_FUNC(lintimeintedgecmplx3d2, LINTIMEINTEDGECMPLX3D2) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(2, d),
-            new_dat->getPointer(2, d),
-            dst_dat->getPointer(2, d));
+         for (auto itr = ovlp_boxes[0].begin();
+              itr != ovlp_boxes[0].end(); ++itr) {
+            hier::Box dest_box((*itr) * edge_where[0]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintedgecmplx3d0, LINTIMEINTEDGECMPLX3D0) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(0, d),
+               new_dat->getPointer(0, d),
+               dst_dat->getPointer(0, d));
+         }
+         for (auto itr = ovlp_boxes[1].begin();
+              itr != ovlp_boxes[1].end(); ++itr) {
+            hier::Box dest_box((*itr) * edge_where[1]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintedgecmplx3d1, LINTIMEINTEDGECMPLX3D1) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(1, d),
+               new_dat->getPointer(1, d),
+               dst_dat->getPointer(1, d));
+         }
+         for (auto itr = ovlp_boxes[2].begin();
+              itr != ovlp_boxes[2].end(); ++itr) {
+            hier::Box dest_box((*itr) * edge_where[2]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintedgecmplx3d2, LINTIMEINTEDGECMPLX3D2) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(2, d),
+               new_dat->getPointer(2, d),
+               dst_dat->getPointer(2, d));
+         }
       } else {
          TBOX_ERROR(
             "EdgeComplexLinearTimeInterpolateOp::TimeInterpolate dim > 3 not supported"

--- a/source/SAMRAI/pdat/EdgeComplexLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/EdgeComplexLinearTimeInterpolateOp.h
@@ -67,6 +67,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/EdgeDoubleLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/EdgeDoubleLinearTimeInterpolateOp.C
@@ -16,7 +16,6 @@
 #include "SAMRAI/tbox/Utilities.h"
 #include "SAMRAI/tbox/MathUtilities.h"
 
-#include <memory>
 
 /*
  *************************************************************************
@@ -120,6 +119,7 @@ void
 EdgeDoubleLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
@@ -135,9 +135,6 @@ EdgeDoubleLinearTimeInterpolateOp::timeInterpolate(
    TBOX_ASSERT(old_dat != 0);
    TBOX_ASSERT(new_dat != 0);
    TBOX_ASSERT(dst_dat != 0);
-   TBOX_ASSERT((where * old_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * new_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * dst_dat->getGhostBox()).isSpatiallyEqual(where));
    TBOX_ASSERT_OBJDIM_EQUALITY4(dst_data, where, src_data_old, src_data_new);
 
    const hier::Index& old_ilo = old_dat->getGhostBox().lower();
@@ -147,9 +144,6 @@ EdgeDoubleLinearTimeInterpolateOp::timeInterpolate(
 
    const hier::Index& dst_ilo = dst_dat->getGhostBox().lower();
    const hier::Index& dst_ihi = dst_dat->getGhostBox().upper();
-
-   const hier::Index& ifirst = where.lower();
-   const hier::Index& ilast = where.upper();
 
    const double old_time = old_dat->getTime();
    const double new_time = new_dat->getTime();
@@ -168,76 +162,121 @@ EdgeDoubleLinearTimeInterpolateOp::timeInterpolate(
       tfrac = 0.0;
    }
 
+   std::vector<hier::Box> edge_where(dim.getValue(), hier::Box(dim));
+   std::vector<hier::BoxContainer> ovlp_boxes(dim.getValue());
+
+   const EdgeOverlap* edge_ovlp = CPP_CAST<const EdgeOverlap*>(&overlap);
+   for (int dir = 0; dir < dim.getValue(); ++dir) {
+      edge_where[dir] = EdgeGeometry::toEdgeBox(where, dir);
+      edge_ovlp->getSourceBoxContainer(ovlp_boxes[dir], dir);
+   }
+
    for (int d = 0; d < dst_dat->getDepth(); ++d) {
       if (dim == tbox::Dimension(1)) {
-         SAMRAI_F77_FUNC(lintimeintedgedoub1d, LINTIMEINTEDGEDOUB1D) (ifirst(0),
-            ilast(0),
-            old_ilo(0), old_ihi(0),
-            new_ilo(0), new_ihi(0),
-            dst_ilo(0), dst_ihi(0),
-            tfrac,
-            old_dat->getPointer(0, d),
-            new_dat->getPointer(0, d),
-            dst_dat->getPointer(0, d));
+         for (auto itr = ovlp_boxes[0].begin();
+              itr != ovlp_boxes[0].end(); ++itr) {
+            hier::Box dest_box((*itr) * edge_where[0]); 
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintedgedoub1d, LINTIMEINTEDGEDOUB1D) (
+               ifirst(0), ilast(0),
+               old_ilo(0), old_ihi(0),
+               new_ilo(0), new_ihi(0),
+               dst_ilo(0), dst_ihi(0),
+               tfrac,
+               old_dat->getPointer(0, d),
+               new_dat->getPointer(0, d),
+               dst_dat->getPointer(0, d));
+         }
       } else if (dim == tbox::Dimension(2)) {
-         SAMRAI_F77_FUNC(lintimeintedgedoub2d0, LINTIMEINTEDGEDOUB2D0) (ifirst(0),
-            ifirst(1), ilast(0), ilast(1),
-            old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-            new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-            dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-            tfrac,
-            old_dat->getPointer(0, d),
-            new_dat->getPointer(0, d),
-            dst_dat->getPointer(0, d));
-         SAMRAI_F77_FUNC(lintimeintedgedoub2d1, LINTIMEINTEDGEDOUB2D1) (ifirst(0),
-            ifirst(1), ilast(0), ilast(1),
-            old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-            new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-            dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-            tfrac,
-            old_dat->getPointer(1, d),
-            new_dat->getPointer(1, d),
-            dst_dat->getPointer(1, d));
+         for (auto itr = ovlp_boxes[0].begin();
+              itr != ovlp_boxes[0].end(); ++itr) {
+            hier::Box dest_box((*itr) * edge_where[0]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintedgedoub2d0, LINTIMEINTEDGEDOUB2D0) (
+               ifirst(0), ifirst(1), ilast(0), ilast(1),
+               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+               tfrac,
+               old_dat->getPointer(0, d),
+               new_dat->getPointer(0, d),
+               dst_dat->getPointer(0, d));
+         }
+         for (auto itr = ovlp_boxes[1].begin();
+              itr != ovlp_boxes[1].end(); ++itr) {
+            hier::Box dest_box((*itr) * edge_where[1]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintedgedoub2d1, LINTIMEINTEDGEDOUB2D1) (
+               ifirst(0), ifirst(1), ilast(0), ilast(1),
+               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+               tfrac,
+               old_dat->getPointer(1, d),
+               new_dat->getPointer(1, d),
+               dst_dat->getPointer(1, d));
+         }
       } else if (dim == tbox::Dimension(3)) {
-         SAMRAI_F77_FUNC(lintimeintedgedoub3d0, LINTIMEINTEDGEDOUB3D0) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(0, d),
-            new_dat->getPointer(0, d),
-            dst_dat->getPointer(0, d));
-         SAMRAI_F77_FUNC(lintimeintedgedoub3d1, LINTIMEINTEDGEDOUB3D1) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(1, d),
-            new_dat->getPointer(1, d),
-            dst_dat->getPointer(1, d));
-         SAMRAI_F77_FUNC(lintimeintedgedoub3d2, LINTIMEINTEDGEDOUB3D2) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(2, d),
-            new_dat->getPointer(2, d),
-            dst_dat->getPointer(2, d));
+         for (auto itr = ovlp_boxes[0].begin();
+              itr != ovlp_boxes[0].end(); ++itr) {
+            hier::Box dest_box((*itr) * edge_where[0]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintedgedoub3d0, LINTIMEINTEDGEDOUB3D0) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(0, d),
+               new_dat->getPointer(0, d),
+               dst_dat->getPointer(0, d));
+         }
+         for (auto itr = ovlp_boxes[1].begin();
+              itr != ovlp_boxes[1].end(); ++itr) {
+            hier::Box dest_box((*itr) * edge_where[1]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintedgedoub3d1, LINTIMEINTEDGEDOUB3D1) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(1, d),
+               new_dat->getPointer(1, d),
+               dst_dat->getPointer(1, d));
+         }
+         for (auto itr = ovlp_boxes[2].begin();
+              itr != ovlp_boxes[2].end(); ++itr) {
+            hier::Box dest_box((*itr) * edge_where[2]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintedgedoub3d2, LINTIMEINTEDGEDOUB3D2) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(2, d),
+               new_dat->getPointer(2, d),
+               dst_dat->getPointer(2, d));
+         }
       } else {
          TBOX_ERROR(
             "EdgeDoubleLinearTimeInterpolateOp::TimeInterpolate dim > 3 not supported"

--- a/source/SAMRAI/pdat/EdgeDoubleLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/EdgeDoubleLinearTimeInterpolateOp.h
@@ -67,6 +67,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/EdgeFloatLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/EdgeFloatLinearTimeInterpolateOp.C
@@ -16,7 +16,6 @@
 #include "SAMRAI/tbox/Utilities.h"
 #include "SAMRAI/tbox/MathUtilities.h"
 
-#include <memory>
 
 /*
  *************************************************************************
@@ -120,6 +119,7 @@ void
 EdgeFloatLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
@@ -135,9 +135,6 @@ EdgeFloatLinearTimeInterpolateOp::timeInterpolate(
    TBOX_ASSERT(old_dat != 0);
    TBOX_ASSERT(new_dat != 0);
    TBOX_ASSERT(dst_dat != 0);
-   TBOX_ASSERT((where * old_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * new_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * dst_dat->getGhostBox()).isSpatiallyEqual(where));
    TBOX_ASSERT_OBJDIM_EQUALITY4(dst_data, where, src_data_old, src_data_new);
 
    const hier::Index& old_ilo = old_dat->getGhostBox().lower();
@@ -147,9 +144,6 @@ EdgeFloatLinearTimeInterpolateOp::timeInterpolate(
 
    const hier::Index& dst_ilo = dst_dat->getGhostBox().lower();
    const hier::Index& dst_ihi = dst_dat->getGhostBox().upper();
-
-   const hier::Index& ifirst = where.lower();
-   const hier::Index& ilast = where.upper();
 
    const double old_time = old_dat->getTime();
    const double new_time = new_dat->getTime();
@@ -168,79 +162,124 @@ EdgeFloatLinearTimeInterpolateOp::timeInterpolate(
       tfrac = 0.0;
    }
 
+   std::vector<hier::Box> edge_where(dim.getValue(), hier::Box(dim));
+   std::vector<hier::BoxContainer> ovlp_boxes(dim.getValue());
+
+   const EdgeOverlap* edge_ovlp = CPP_CAST<const EdgeOverlap*>(&overlap);
+   for (int dir = 0; dir < dim.getValue(); ++dir) {
+      edge_where[dir] = EdgeGeometry::toEdgeBox(where, dir);
+      edge_ovlp->getSourceBoxContainer(ovlp_boxes[dir], dir);
+   }
+
    for (int d = 0; d < dst_dat->getDepth(); ++d) {
       if (dim == tbox::Dimension(1)) {
-         SAMRAI_F77_FUNC(lintimeintedgefloat1d, LINTIMEINTEDGEFLOAT1D) (ifirst(0),
-            ilast(0),
-            old_ilo(0), old_ihi(0),
-            new_ilo(0), new_ihi(0),
-            dst_ilo(0), dst_ihi(0),
-            tfrac,
-            old_dat->getPointer(0, d),
-            new_dat->getPointer(0, d),
-            dst_dat->getPointer(0, d));
+         for (auto itr = ovlp_boxes[0].begin();
+              itr != ovlp_boxes[0].end(); ++itr) {
+            hier::Box dest_box((*itr) * edge_where[0]); 
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintedgefloat1d, LINTIMEINTEDGEFLOAT1D) (
+               ifirst(0), ilast(0),
+               old_ilo(0), old_ihi(0),
+               new_ilo(0), new_ihi(0),
+               dst_ilo(0), dst_ihi(0),
+               tfrac,
+               old_dat->getPointer(0, d),
+               new_dat->getPointer(0, d),
+               dst_dat->getPointer(0, d));
+         }
       } else if (dim == tbox::Dimension(2)) {
-         SAMRAI_F77_FUNC(lintimeintedgefloat2d0, LINTIMEINTEDGEFLOAT2D0) (ifirst(0),
-            ifirst(1), ilast(0), ilast(1),
-            old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-            new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-            dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-            tfrac,
-            old_dat->getPointer(0, d),
-            new_dat->getPointer(0, d),
-            dst_dat->getPointer(0, d));
-         SAMRAI_F77_FUNC(lintimeintedgefloat2d1, LINTIMEINTEDGEFLOAT2D1) (ifirst(0),
-            ifirst(1), ilast(0), ilast(1),
-            old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-            new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-            dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-            tfrac,
-            old_dat->getPointer(1, d),
-            new_dat->getPointer(1, d),
-            dst_dat->getPointer(1, d));
+         for (auto itr = ovlp_boxes[0].begin();
+              itr != ovlp_boxes[0].end(); ++itr) {
+            hier::Box dest_box((*itr) * edge_where[0]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintedgefloat2d0, LINTIMEINTEDGEFLOAT2D0) (
+               ifirst(0), ifirst(1), ilast(0), ilast(1),
+               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+               tfrac,
+               old_dat->getPointer(0, d),
+               new_dat->getPointer(0, d),
+               dst_dat->getPointer(0, d));
+         }
+         for (auto itr = ovlp_boxes[1].begin();
+              itr != ovlp_boxes[1].end(); ++itr) {
+            hier::Box dest_box((*itr) * edge_where[1]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintedgefloat2d1, LINTIMEINTEDGEFLOAT2D1) (
+               ifirst(0), ifirst(1), ilast(0), ilast(1),
+               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+               tfrac,
+               old_dat->getPointer(1, d),
+               new_dat->getPointer(1, d),
+               dst_dat->getPointer(1, d));
+         }
       } else if (dim == tbox::Dimension(3)) {
-         SAMRAI_F77_FUNC(lintimeintedgefloat3d0, LINTIMEINTEDGEFLOAT3D0) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(0, d),
-            new_dat->getPointer(0, d),
-            dst_dat->getPointer(0, d));
-         SAMRAI_F77_FUNC(lintimeintedgefloat3d1, LINTIMEINTEDGEFLOAT3D1) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(1, d),
-            new_dat->getPointer(1, d),
-            dst_dat->getPointer(1, d));
-         SAMRAI_F77_FUNC(lintimeintedgefloat3d2, LINTIMEINTEDGEFLOAT3D2) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(2, d),
-            new_dat->getPointer(2, d),
-            dst_dat->getPointer(2, d));
+         for (auto itr = ovlp_boxes[0].begin();
+              itr != ovlp_boxes[0].end(); ++itr) {
+            hier::Box dest_box((*itr) * edge_where[0]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintedgefloat3d0, LINTIMEINTEDGEFLOAT3D0) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(0, d),
+               new_dat->getPointer(0, d),
+               dst_dat->getPointer(0, d));
+         }
+         for (auto itr = ovlp_boxes[1].begin();
+              itr != ovlp_boxes[1].end(); ++itr) {
+            hier::Box dest_box((*itr) * edge_where[1]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintedgefloat3d1, LINTIMEINTEDGEFLOAT3D1) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(1, d),
+               new_dat->getPointer(1, d),
+               dst_dat->getPointer(1, d));
+         }
+         for (auto itr = ovlp_boxes[2].begin();
+              itr != ovlp_boxes[2].end(); ++itr) {
+            hier::Box dest_box((*itr) * edge_where[2]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintedgefloat3d2, LINTIMEINTEDGEFLOAT3D2) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(2, d),
+               new_dat->getPointer(2, d),
+               dst_dat->getPointer(2, d));
+         }
       } else {
          TBOX_ERROR(
-            "EdgeFloatLinearTimeInterpolateOp dim::TimeInterpolate dim > 3 not supported"
+            "EdgeFloatLinearTimeInterpolateOp::TimeInterpolate dim > 3 not supported"
             << std::endl);
       }
    }

--- a/source/SAMRAI/pdat/EdgeFloatLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/EdgeFloatLinearTimeInterpolateOp.h
@@ -67,6 +67,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/FaceComplexLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/FaceComplexLinearTimeInterpolateOp.C
@@ -8,15 +8,14 @@
  *
  ************************************************************************/
 #include "SAMRAI/pdat/FaceComplexLinearTimeInterpolateOp.h"
-#include "SAMRAI/pdat/FaceData.h"
-#include "SAMRAI/pdat/FaceVariable.h"
+
 #include "SAMRAI/hier/Box.h"
 #include "SAMRAI/hier/Index.h"
+#include "SAMRAI/pdat/FaceData.h"
+#include "SAMRAI/pdat/FaceVariable.h"
 #include "SAMRAI/tbox/Utilities.h"
 #include "SAMRAI/tbox/MathUtilities.h"
-#include "SAMRAI/tbox/Complex.h"
 
-#include <memory>
 
 /*
  *************************************************************************
@@ -120,6 +119,7 @@ void
 FaceComplexLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
@@ -135,9 +135,6 @@ FaceComplexLinearTimeInterpolateOp::timeInterpolate(
    TBOX_ASSERT(old_dat != 0);
    TBOX_ASSERT(new_dat != 0);
    TBOX_ASSERT(dst_dat != 0);
-   TBOX_ASSERT((where * old_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * new_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * dst_dat->getGhostBox()).isSpatiallyEqual(where));
    TBOX_ASSERT_OBJDIM_EQUALITY4(dst_data, where, src_data_old, src_data_new);
 
    const hier::Index& old_ilo = old_dat->getGhostBox().lower();
@@ -147,9 +144,6 @@ FaceComplexLinearTimeInterpolateOp::timeInterpolate(
 
    const hier::Index& dst_ilo = dst_dat->getGhostBox().lower();
    const hier::Index& dst_ihi = dst_dat->getGhostBox().upper();
-
-   const hier::Index& ifirst = where.lower();
-   const hier::Index& ilast = where.upper();
 
    const double old_time = old_dat->getTime();
    const double new_time = new_dat->getTime();
@@ -168,76 +162,121 @@ FaceComplexLinearTimeInterpolateOp::timeInterpolate(
       tfrac = 0.0;
    }
 
+   std::vector<hier::Box> face_where(dim.getValue(), hier::Box(dim));
+   std::vector<hier::BoxContainer> ovlp_boxes(dim.getValue());
+
+   const FaceOverlap* face_ovlp = CPP_CAST<const FaceOverlap*>(&overlap);
+   for (int dir = 0; dir < dim.getValue(); ++dir) {
+      face_where[dir] = FaceGeometry::toFaceBox(where, dir);
+      face_ovlp->getSourceBoxContainer(ovlp_boxes[dir], dir);
+   }
+
    for (int d = 0; d < dst_dat->getDepth(); ++d) {
       if (dim == tbox::Dimension(1)) {
-         SAMRAI_F77_FUNC(lintimeintfacecmplx1d, LINTIMEINTFACECMPLX1D) (ifirst(0),
-            ilast(0),
-            old_ilo(0), old_ihi(0),
-            new_ilo(0), new_ihi(0),
-            dst_ilo(0), dst_ihi(0),
-            tfrac,
-            old_dat->getPointer(0, d),
-            new_dat->getPointer(0, d),
-            dst_dat->getPointer(0, d));
+         for (auto itr = ovlp_boxes[0].begin();
+              itr != ovlp_boxes[0].end(); ++itr) {
+            hier::Box dest_box((*itr) * face_where[0]); 
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintfacecmplx1d, LINTIMEINTFACECMPLX1D) (
+               ifirst(0), ilast(0),
+               old_ilo(0), old_ihi(0),
+               new_ilo(0), new_ihi(0),
+               dst_ilo(0), dst_ihi(0),
+               tfrac,
+               old_dat->getPointer(0, d),
+               new_dat->getPointer(0, d),
+               dst_dat->getPointer(0, d));
+         }
       } else if (dim == tbox::Dimension(2)) {
-         SAMRAI_F77_FUNC(lintimeintfacecmplx2d0, LINTIMEINTFACECMPLX2D0) (ifirst(0),
-            ifirst(1), ilast(0), ilast(1),
-            old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-            new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-            dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-            tfrac,
-            old_dat->getPointer(0, d),
-            new_dat->getPointer(0, d),
-            dst_dat->getPointer(0, d));
-         SAMRAI_F77_FUNC(lintimeintfacecmplx2d1, LINTIMEINTFACECMPLX2D1) (ifirst(0),
-            ifirst(1), ilast(0), ilast(1),
-            old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-            new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-            dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-            tfrac,
-            old_dat->getPointer(1, d),
-            new_dat->getPointer(1, d),
-            dst_dat->getPointer(1, d));
+         for (auto itr = ovlp_boxes[0].begin();
+              itr != ovlp_boxes[0].end(); ++itr) {
+            hier::Box dest_box((*itr) * face_where[0]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintfacecmplx2d0, LINTIMEINTFACECMPLX2D0) (
+               ifirst(0), ifirst(1), ilast(0), ilast(1),
+               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+               tfrac,
+               old_dat->getPointer(0, d),
+               new_dat->getPointer(0, d),
+               dst_dat->getPointer(0, d));
+         }
+         for (auto itr = ovlp_boxes[1].begin();
+              itr != ovlp_boxes[1].end(); ++itr) {
+            hier::Box dest_box((*itr) * face_where[1]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintfacecmplx2d1, LINTIMEINTFACECMPLX2D1) (
+               ifirst(0), ifirst(1), ilast(0), ilast(1),
+               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+               tfrac,
+               old_dat->getPointer(1, d),
+               new_dat->getPointer(1, d),
+               dst_dat->getPointer(1, d));
+         }
       } else if (dim == tbox::Dimension(3)) {
-         SAMRAI_F77_FUNC(lintimeintfacecmplx3d0, LINTIMEINTFACECMPLX3D0) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(0, d),
-            new_dat->getPointer(0, d),
-            dst_dat->getPointer(0, d));
-         SAMRAI_F77_FUNC(lintimeintfacecmplx3d1, LINTIMEINTFACECMPLX3D1) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(1, d),
-            new_dat->getPointer(1, d),
-            dst_dat->getPointer(1, d));
-         SAMRAI_F77_FUNC(lintimeintfacecmplx3d2, LINTIMEINTFACECMPLX3D2) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(2, d),
-            new_dat->getPointer(2, d),
-            dst_dat->getPointer(2, d));
+         for (auto itr = ovlp_boxes[0].begin();
+              itr != ovlp_boxes[0].end(); ++itr) {
+            hier::Box dest_box((*itr) * face_where[0]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintfacecmplx3d0, LINTIMEINTFACECMPLX3D0) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(0, d),
+               new_dat->getPointer(0, d),
+               dst_dat->getPointer(0, d));
+         }
+         for (auto itr = ovlp_boxes[1].begin();
+              itr != ovlp_boxes[1].end(); ++itr) {
+            hier::Box dest_box((*itr) * face_where[1]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintfacecmplx3d1, LINTIMEINTFACECMPLX3D1) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(1, d),
+               new_dat->getPointer(1, d),
+               dst_dat->getPointer(1, d));
+         }
+         for (auto itr = ovlp_boxes[2].begin();
+              itr != ovlp_boxes[2].end(); ++itr) {
+            hier::Box dest_box((*itr) * face_where[2]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintfacecmplx3d2, LINTIMEINTFACECMPLX3D2) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(2, d),
+               new_dat->getPointer(2, d),
+               dst_dat->getPointer(2, d));
+         }
       } else {
          TBOX_ERROR(
             "FaceComplexLinearTimeInterpolateOp::TimeInterpolate dim > 3 not supported"

--- a/source/SAMRAI/pdat/FaceComplexLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/FaceComplexLinearTimeInterpolateOp.h
@@ -66,6 +66,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/FaceDoubleLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/FaceDoubleLinearTimeInterpolateOp.C
@@ -16,8 +16,6 @@
 #include "SAMRAI/tbox/Utilities.h"
 #include "SAMRAI/tbox/MathUtilities.h"
 
-#include <memory>
-
 
 /*
  *************************************************************************
@@ -121,6 +119,7 @@ void
 FaceDoubleLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
@@ -136,9 +135,6 @@ FaceDoubleLinearTimeInterpolateOp::timeInterpolate(
    TBOX_ASSERT(old_dat != 0);
    TBOX_ASSERT(new_dat != 0);
    TBOX_ASSERT(dst_dat != 0);
-   TBOX_ASSERT((where * old_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * new_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * dst_dat->getGhostBox()).isSpatiallyEqual(where));
    TBOX_ASSERT_OBJDIM_EQUALITY4(dst_data, where, src_data_old, src_data_new);
 
    const hier::Index& old_ilo = old_dat->getGhostBox().lower();
@@ -148,9 +144,6 @@ FaceDoubleLinearTimeInterpolateOp::timeInterpolate(
 
    const hier::Index& dst_ilo = dst_dat->getGhostBox().lower();
    const hier::Index& dst_ihi = dst_dat->getGhostBox().upper();
-
-   const hier::Index& ifirst = where.lower();
-   const hier::Index& ilast = where.upper();
 
    const double old_time = old_dat->getTime();
    const double new_time = new_dat->getTime();
@@ -169,76 +162,121 @@ FaceDoubleLinearTimeInterpolateOp::timeInterpolate(
       tfrac = 0.0;
    }
 
+   std::vector<hier::Box> face_where(dim.getValue(), hier::Box(dim));
+   std::vector<hier::BoxContainer> ovlp_boxes(dim.getValue());
+
+   const FaceOverlap* face_ovlp = CPP_CAST<const FaceOverlap*>(&overlap);
+   for (int dir = 0; dir < dim.getValue(); ++dir) {
+      face_where[dir] = FaceGeometry::toFaceBox(where, dir);
+      face_ovlp->getSourceBoxContainer(ovlp_boxes[dir], dir);
+   }
+
    for (int d = 0; d < dst_dat->getDepth(); ++d) {
       if (dim == tbox::Dimension(1)) {
-         SAMRAI_F77_FUNC(lintimeintfacedoub1d, LINTIMEINTFACEDOUB1D) (ifirst(0),
-            ilast(0),
-            old_ilo(0), old_ihi(0),
-            new_ilo(0), new_ihi(0),
-            dst_ilo(0), dst_ihi(0),
-            tfrac,
-            old_dat->getPointer(0, d),
-            new_dat->getPointer(0, d),
-            dst_dat->getPointer(0, d));
+         for (auto itr = ovlp_boxes[0].begin();
+              itr != ovlp_boxes[0].end(); ++itr) {
+            hier::Box dest_box((*itr) * face_where[0]); 
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintfacedoub1d, LINTIMEINTFACEDOUB1D) (
+               ifirst(0), ilast(0),
+               old_ilo(0), old_ihi(0),
+               new_ilo(0), new_ihi(0),
+               dst_ilo(0), dst_ihi(0),
+               tfrac,
+               old_dat->getPointer(0, d),
+               new_dat->getPointer(0, d),
+               dst_dat->getPointer(0, d));
+         }
       } else if (dim == tbox::Dimension(2)) {
-         SAMRAI_F77_FUNC(lintimeintfacedoub2d0, LINTIMEINTFACEDOUB2D0) (ifirst(0),
-            ifirst(1), ilast(0), ilast(1),
-            old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-            new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-            dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-            tfrac,
-            old_dat->getPointer(0, d),
-            new_dat->getPointer(0, d),
-            dst_dat->getPointer(0, d));
-         SAMRAI_F77_FUNC(lintimeintfacedoub2d1, LINTIMEINTFACEDOUB2D1) (ifirst(0),
-            ifirst(1), ilast(0), ilast(1),
-            old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-            new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-            dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-            tfrac,
-            old_dat->getPointer(1, d),
-            new_dat->getPointer(1, d),
-            dst_dat->getPointer(1, d));
+         for (auto itr = ovlp_boxes[0].begin();
+              itr != ovlp_boxes[0].end(); ++itr) {
+            hier::Box dest_box((*itr) * face_where[0]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintfacedoub2d0, LINTIMEINTFACEDOUB2D0) (
+               ifirst(0), ifirst(1), ilast(0), ilast(1),
+               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+               tfrac,
+               old_dat->getPointer(0, d),
+               new_dat->getPointer(0, d),
+               dst_dat->getPointer(0, d));
+         }
+         for (auto itr = ovlp_boxes[1].begin();
+              itr != ovlp_boxes[1].end(); ++itr) {
+            hier::Box dest_box((*itr) * face_where[1]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintfacedoub2d1, LINTIMEINTFACEDOUB2D1) (
+               ifirst(0), ifirst(1), ilast(0), ilast(1),
+               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+               tfrac,
+               old_dat->getPointer(1, d),
+               new_dat->getPointer(1, d),
+               dst_dat->getPointer(1, d));
+         }
       } else if (dim == tbox::Dimension(3)) {
-         SAMRAI_F77_FUNC(lintimeintfacedoub3d0, LINTIMEINTFACEDOUB3D0) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(0, d),
-            new_dat->getPointer(0, d),
-            dst_dat->getPointer(0, d));
-         SAMRAI_F77_FUNC(lintimeintfacedoub3d1, LINTIMEINTFACEDOUB3D1) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(1, d),
-            new_dat->getPointer(1, d),
-            dst_dat->getPointer(1, d));
-         SAMRAI_F77_FUNC(lintimeintfacedoub3d2, LINTIMEINTFACEDOUB3D2) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(2, d),
-            new_dat->getPointer(2, d),
-            dst_dat->getPointer(2, d));
+         for (auto itr = ovlp_boxes[0].begin();
+              itr != ovlp_boxes[0].end(); ++itr) {
+            hier::Box dest_box((*itr) * face_where[0]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintfacedoub3d0, LINTIMEINTFACEDOUB3D0) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(0, d),
+               new_dat->getPointer(0, d),
+               dst_dat->getPointer(0, d));
+         }
+         for (auto itr = ovlp_boxes[1].begin();
+              itr != ovlp_boxes[1].end(); ++itr) {
+            hier::Box dest_box((*itr) * face_where[1]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintfacedoub3d1, LINTIMEINTFACEDOUB3D1) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(1, d),
+               new_dat->getPointer(1, d),
+               dst_dat->getPointer(1, d));
+         }
+         for (auto itr = ovlp_boxes[2].begin();
+              itr != ovlp_boxes[2].end(); ++itr) {
+            hier::Box dest_box((*itr) * face_where[2]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintfacedoub3d2, LINTIMEINTFACEDOUB3D2) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(2, d),
+               new_dat->getPointer(2, d),
+               dst_dat->getPointer(2, d));
+         }
       } else {
          TBOX_ERROR(
             "FaceDoubleLinearTimeInterpolateOp::TimeInterpolate dim > 3 not supported"

--- a/source/SAMRAI/pdat/FaceDoubleLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/FaceDoubleLinearTimeInterpolateOp.h
@@ -66,6 +66,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/FaceFloatLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/FaceFloatLinearTimeInterpolateOp.C
@@ -119,6 +119,7 @@ void
 FaceFloatLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
@@ -134,9 +135,6 @@ FaceFloatLinearTimeInterpolateOp::timeInterpolate(
    TBOX_ASSERT(old_dat != 0);
    TBOX_ASSERT(new_dat != 0);
    TBOX_ASSERT(dst_dat != 0);
-   TBOX_ASSERT((where * old_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * new_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * dst_dat->getGhostBox()).isSpatiallyEqual(where));
    TBOX_ASSERT_OBJDIM_EQUALITY4(dst_data, where, src_data_old, src_data_new);
 
    const hier::Index& old_ilo = old_dat->getGhostBox().lower();
@@ -146,9 +144,6 @@ FaceFloatLinearTimeInterpolateOp::timeInterpolate(
 
    const hier::Index& dst_ilo = dst_dat->getGhostBox().lower();
    const hier::Index& dst_ihi = dst_dat->getGhostBox().upper();
-
-   const hier::Index& ifirst = where.lower();
-   const hier::Index& ilast = where.upper();
 
    const double old_time = old_dat->getTime();
    const double new_time = new_dat->getTime();
@@ -167,76 +162,121 @@ FaceFloatLinearTimeInterpolateOp::timeInterpolate(
       tfrac = 0.0;
    }
 
+   std::vector<hier::Box> face_where(dim.getValue(), hier::Box(dim));
+   std::vector<hier::BoxContainer> ovlp_boxes(dim.getValue());
+
+   const FaceOverlap* face_ovlp = CPP_CAST<const FaceOverlap*>(&overlap);
+   for (int dir = 0; dir < dim.getValue(); ++dir) {
+      face_where[dir] = FaceGeometry::toFaceBox(where, dir);
+      face_ovlp->getSourceBoxContainer(ovlp_boxes[dir], dir);
+   }
+
    for (int d = 0; d < dst_dat->getDepth(); ++d) {
       if (dim == tbox::Dimension(1)) {
-         SAMRAI_F77_FUNC(lintimeintfacefloat1d, LINTIMEINTFACEFLOAT1D) (ifirst(0),
-            ilast(0),
-            old_ilo(0), old_ihi(0),
-            new_ilo(0), new_ihi(0),
-            dst_ilo(0), dst_ihi(0),
-            tfrac,
-            old_dat->getPointer(0, d),
-            new_dat->getPointer(0, d),
-            dst_dat->getPointer(0, d));
+         for (auto itr = ovlp_boxes[0].begin();
+              itr != ovlp_boxes[0].end(); ++itr) {
+            hier::Box dest_box((*itr) * face_where[0]); 
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintfacefloat1d, LINTIMEINTFACEFLOAT1D) (
+               ifirst(0), ilast(0),
+               old_ilo(0), old_ihi(0),
+               new_ilo(0), new_ihi(0),
+               dst_ilo(0), dst_ihi(0),
+               tfrac,
+               old_dat->getPointer(0, d),
+               new_dat->getPointer(0, d),
+               dst_dat->getPointer(0, d));
+         }
       } else if (dim == tbox::Dimension(2)) {
-         SAMRAI_F77_FUNC(lintimeintfacefloat2d0, LINTIMEINTFACEFLOAT2D0) (ifirst(0),
-            ifirst(1), ilast(0), ilast(1),
-            old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-            new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-            dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-            tfrac,
-            old_dat->getPointer(0, d),
-            new_dat->getPointer(0, d),
-            dst_dat->getPointer(0, d));
-         SAMRAI_F77_FUNC(lintimeintfacefloat2d1, LINTIMEINTFACEFLOAT2D1) (ifirst(0),
-            ifirst(1), ilast(0), ilast(1),
-            old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-            new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-            dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-            tfrac,
-            old_dat->getPointer(1, d),
-            new_dat->getPointer(1, d),
-            dst_dat->getPointer(1, d));
+         for (auto itr = ovlp_boxes[0].begin();
+              itr != ovlp_boxes[0].end(); ++itr) {
+            hier::Box dest_box((*itr) * face_where[0]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintfacefloat2d0, LINTIMEINTFACEFLOAT2D0) (
+               ifirst(0), ifirst(1), ilast(0), ilast(1),
+               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+               tfrac,
+               old_dat->getPointer(0, d),
+               new_dat->getPointer(0, d),
+               dst_dat->getPointer(0, d));
+         }
+         for (auto itr = ovlp_boxes[1].begin();
+              itr != ovlp_boxes[1].end(); ++itr) {
+            hier::Box dest_box((*itr) * face_where[1]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintfacefloat2d1, LINTIMEINTFACEFLOAT2D1) (
+               ifirst(0), ifirst(1), ilast(0), ilast(1),
+               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+               tfrac,
+               old_dat->getPointer(1, d),
+               new_dat->getPointer(1, d),
+               dst_dat->getPointer(1, d));
+         }
       } else if (dim == tbox::Dimension(3)) {
-         SAMRAI_F77_FUNC(lintimeintfacefloat3d0, LINTIMEINTFACEFLOAT3D0) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(0, d),
-            new_dat->getPointer(0, d),
-            dst_dat->getPointer(0, d));
-         SAMRAI_F77_FUNC(lintimeintfacefloat3d1, LINTIMEINTFACEFLOAT3D1) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(1, d),
-            new_dat->getPointer(1, d),
-            dst_dat->getPointer(1, d));
-         SAMRAI_F77_FUNC(lintimeintfacefloat3d2, LINTIMEINTFACEFLOAT3D2) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(2, d),
-            new_dat->getPointer(2, d),
-            dst_dat->getPointer(2, d));
+         for (auto itr = ovlp_boxes[0].begin();
+              itr != ovlp_boxes[0].end(); ++itr) {
+            hier::Box dest_box((*itr) * face_where[0]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintfacefloat3d0, LINTIMEINTFACEFLOAT3D0) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(0, d),
+               new_dat->getPointer(0, d),
+               dst_dat->getPointer(0, d));
+         }
+         for (auto itr = ovlp_boxes[1].begin();
+              itr != ovlp_boxes[1].end(); ++itr) {
+            hier::Box dest_box((*itr) * face_where[1]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintfacefloat3d1, LINTIMEINTFACEFLOAT3D1) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(1, d),
+               new_dat->getPointer(1, d),
+               dst_dat->getPointer(1, d));
+         }
+         for (auto itr = ovlp_boxes[2].begin();
+              itr != ovlp_boxes[2].end(); ++itr) {
+            hier::Box dest_box((*itr) * face_where[2]);
+            const hier::Index& ifirst = dest_box.lower();
+            const hier::Index& ilast = dest_box.upper();
+            SAMRAI_F77_FUNC(lintimeintfacefloat3d2, LINTIMEINTFACEFLOAT3D2) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(2, d),
+               new_dat->getPointer(2, d),
+               dst_dat->getPointer(2, d));
+         }
       } else {
          TBOX_ERROR(
             "FaceFloatLinearTimeInterpolateOp::TimeInterpolate dim > 3 not supported"

--- a/source/SAMRAI/pdat/FaceFloatLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/FaceFloatLinearTimeInterpolateOp.h
@@ -66,6 +66,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/NodeComplexLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/NodeComplexLinearTimeInterpolateOp.C
@@ -84,6 +84,7 @@ void
 NodeComplexLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
@@ -99,10 +100,9 @@ NodeComplexLinearTimeInterpolateOp::timeInterpolate(
    TBOX_ASSERT(old_dat != 0);
    TBOX_ASSERT(new_dat != 0);
    TBOX_ASSERT(dst_dat != 0);
-   TBOX_ASSERT((where * old_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * new_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * dst_dat->getGhostBox()).isSpatiallyEqual(where));
    TBOX_ASSERT_OBJDIM_EQUALITY4(dst_data, where, src_data_old, src_data_new);
+
+   hier::Box node_where = NodeGeometry::toNodeBox(where);
 
    const hier::Index& old_ilo = old_dat->getGhostBox().lower();
    const hier::Index& old_ihi = old_dat->getGhostBox().upper();
@@ -111,9 +111,6 @@ NodeComplexLinearTimeInterpolateOp::timeInterpolate(
 
    const hier::Index& dst_ilo = dst_dat->getGhostBox().lower();
    const hier::Index& dst_ihi = dst_dat->getGhostBox().upper();
-
-   const hier::Index& ifirst = where.lower();
-   const hier::Index& ilast = where.upper();
 
    const double old_time = old_dat->getTime();
    const double new_time = new_dat->getTime();
@@ -132,45 +129,59 @@ NodeComplexLinearTimeInterpolateOp::timeInterpolate(
       tfrac = 0.0;
    }
 
-   for (int d = 0; d < dst_dat->getDepth(); ++d) {
-      if (dim == tbox::Dimension(1)) {
-         SAMRAI_F77_FUNC(lintimeintnodecmplx1d, LINTIMEINTNODECMPLX1D) (ifirst(0),
-            ilast(0),
-            old_ilo(0), old_ihi(0),
-            new_ilo(0), new_ihi(0),
-            dst_ilo(0), dst_ihi(0),
-            tfrac,
-            old_dat->getPointer(d),
-            new_dat->getPointer(d),
-            dst_dat->getPointer(d));
-      } else if (dim == tbox::Dimension(2)) {
-         SAMRAI_F77_FUNC(lintimeintnodecmplx2d, LINTIMEINTNODECMPLX2D) (ifirst(0),
-            ifirst(1), ilast(0), ilast(1),
-            old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-            new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-            dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-            tfrac,
-            old_dat->getPointer(d),
-            new_dat->getPointer(d),
-            dst_dat->getPointer(d));
-      } else if (dim == tbox::Dimension(3)) {
-         SAMRAI_F77_FUNC(lintimeintnodecmplx3d, LINTIMEINTNODECMPLX3D) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(d),
-            new_dat->getPointer(d),
-            dst_dat->getPointer(d));
-      } else {
-         TBOX_ERROR(
-            "NodeComplexLinearTimeInterpolateOp::TimeInterpolate dim > 3 not supported"
-            << std::endl);
+   const NodeOverlap* node_overlap = CPP_CAST<const NodeOverlap*>(&overlap);
+   hier::BoxContainer ovlp_boxes;
+   node_overlap->getSourceBoxContainer(ovlp_boxes);
+
+   for (auto itr = ovlp_boxes.begin(); itr != ovlp_boxes.end(); ++itr) {
+      hier::Box dest_box((*itr) * node_where);
+      TBOX_ASSERT((dest_box * old_dat->getArrayData().getBox()).isSpatiallyEqual(dest_box));
+      TBOX_ASSERT((dest_box * new_dat->getArrayData().getBox()).isSpatiallyEqual(dest_box));
+      TBOX_ASSERT((dest_box * dst_dat->getArrayData().getBox()).isSpatiallyEqual(dest_box));
+
+      const hier::Index& ifirst = dest_box.lower();
+      const hier::Index& ilast = dest_box.upper();
+
+      for (int d = 0; d < dst_dat->getDepth(); ++d) {
+         if (dim == tbox::Dimension(1)) {
+            SAMRAI_F77_FUNC(lintimeintnodecmplx1d, LINTIMEINTNODECMPLX1D) (
+               ifirst(0), ilast(0),
+               old_ilo(0), old_ihi(0),
+               new_ilo(0), new_ihi(0),
+               dst_ilo(0), dst_ihi(0),
+               tfrac,
+               old_dat->getPointer(d),
+               new_dat->getPointer(d),
+               dst_dat->getPointer(d));
+         } else if (dim == tbox::Dimension(2)) {
+            SAMRAI_F77_FUNC(lintimeintnodecmplx2d, LINTIMEINTNODECMPLX2D) (
+               ifirst(0), ifirst(1), ilast(0), ilast(1),
+               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+               tfrac,
+               old_dat->getPointer(d),
+               new_dat->getPointer(d),
+               dst_dat->getPointer(d));
+         } else if (dim == tbox::Dimension(3)) {
+            SAMRAI_F77_FUNC(lintimeintnodecmplx3d, LINTIMEINTNODECMPLX3D) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(d),
+               new_dat->getPointer(d),
+               dst_dat->getPointer(d));
+         } else {
+            TBOX_ERROR(
+               "NodeComplexLinearTimeInterpolateOp::TimeInterpolate dim > 3 not supported"
+               << std::endl);
+         }
       }
    }
 }

--- a/source/SAMRAI/pdat/NodeComplexLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/NodeComplexLinearTimeInterpolateOp.h
@@ -66,6 +66,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/NodeDoubleLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/NodeDoubleLinearTimeInterpolateOp.C
@@ -83,6 +83,7 @@ void
 NodeDoubleLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
@@ -98,10 +99,9 @@ NodeDoubleLinearTimeInterpolateOp::timeInterpolate(
    TBOX_ASSERT(old_dat != 0);
    TBOX_ASSERT(new_dat != 0);
    TBOX_ASSERT(dst_dat != 0);
-   TBOX_ASSERT((where * old_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * new_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * dst_dat->getGhostBox()).isSpatiallyEqual(where));
    TBOX_ASSERT_OBJDIM_EQUALITY4(dst_data, where, src_data_old, src_data_new);
+
+   hier::Box node_where = NodeGeometry::toNodeBox(where);
 
    const hier::Index& old_ilo = old_dat->getGhostBox().lower();
    const hier::Index& old_ihi = old_dat->getGhostBox().upper();
@@ -110,9 +110,6 @@ NodeDoubleLinearTimeInterpolateOp::timeInterpolate(
 
    const hier::Index& dst_ilo = dst_dat->getGhostBox().lower();
    const hier::Index& dst_ihi = dst_dat->getGhostBox().upper();
-
-   const hier::Index& ifirst = where.lower();
-   const hier::Index& ilast = where.upper();
 
    const double old_time = old_dat->getTime();
    const double new_time = new_dat->getTime();
@@ -131,45 +128,59 @@ NodeDoubleLinearTimeInterpolateOp::timeInterpolate(
       tfrac = 0.0;
    }
 
-   for (int d = 0; d < dst_dat->getDepth(); ++d) {
-      if (dim == tbox::Dimension(1)) {
-         SAMRAI_F77_FUNC(lintimeintnodedoub1d, LINTIMEINTNODEDOUB1D) (ifirst(0),
-            ilast(0),
-            old_ilo(0), old_ihi(0),
-            new_ilo(0), new_ihi(0),
-            dst_ilo(0), dst_ihi(0),
-            tfrac,
-            old_dat->getPointer(d),
-            new_dat->getPointer(d),
-            dst_dat->getPointer(d));
-      } else if (dim == tbox::Dimension(2)) {
-         SAMRAI_F77_FUNC(lintimeintnodedoub2d, LINTIMEINTNODEDOUB2D) (ifirst(0),
-            ifirst(1), ilast(0), ilast(1),
-            old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-            new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-            dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-            tfrac,
-            old_dat->getPointer(d),
-            new_dat->getPointer(d),
-            dst_dat->getPointer(d));
-      } else if (dim == tbox::Dimension(3)) {
-         SAMRAI_F77_FUNC(lintimeintnodedoub3d, LINTIMEINTNODEDOUB3D) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(d),
-            new_dat->getPointer(d),
-            dst_dat->getPointer(d));
-      } else {
-         TBOX_ERROR(
-            "NodeDoubleLinearTimeInterpolateOp::TimeInterpolate dim > 3 not supported"
-            << std::endl);
+   const NodeOverlap* node_overlap = CPP_CAST<const NodeOverlap*>(&overlap);
+   hier::BoxContainer ovlp_boxes;
+   node_overlap->getSourceBoxContainer(ovlp_boxes);
+
+   for (auto itr = ovlp_boxes.begin(); itr != ovlp_boxes.end(); ++itr) {
+      hier::Box dest_box((*itr) * node_where);
+      TBOX_ASSERT((dest_box * old_dat->getArrayData().getBox()).isSpatiallyEqual(dest_box));
+      TBOX_ASSERT((dest_box * new_dat->getArrayData().getBox()).isSpatiallyEqual(dest_box));
+      TBOX_ASSERT((dest_box * dst_dat->getArrayData().getBox()).isSpatiallyEqual(dest_box));
+
+      const hier::Index& ifirst = dest_box.lower();
+      const hier::Index& ilast = dest_box.upper();
+
+      for (int d = 0; d < dst_dat->getDepth(); ++d) {
+         if (dim == tbox::Dimension(1)) {
+            SAMRAI_F77_FUNC(lintimeintnodedoub1d, LINTIMEINTNODEDOUB1D) (
+               ifirst(0), ilast(0),
+               old_ilo(0), old_ihi(0),
+               new_ilo(0), new_ihi(0),
+               dst_ilo(0), dst_ihi(0),
+               tfrac,
+               old_dat->getPointer(d),
+               new_dat->getPointer(d),
+               dst_dat->getPointer(d));
+         } else if (dim == tbox::Dimension(2)) {
+            SAMRAI_F77_FUNC(lintimeintnodedoub2d, LINTIMEINTNODEDOUB2D) (
+               ifirst(0), ifirst(1), ilast(0), ilast(1),
+               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+               tfrac,
+               old_dat->getPointer(d),
+               new_dat->getPointer(d),
+               dst_dat->getPointer(d));
+         } else if (dim == tbox::Dimension(3)) {
+            SAMRAI_F77_FUNC(lintimeintnodedoub3d, LINTIMEINTNODEDOUB3D) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(d),
+               new_dat->getPointer(d),
+               dst_dat->getPointer(d));
+         } else {
+            TBOX_ERROR(
+               "NodeDoubleLinearTimeInterpolateOp::TimeInterpolate dim > 3 not supported"
+               << std::endl);
+         }
       }
    }
 }

--- a/source/SAMRAI/pdat/NodeDoubleLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/NodeDoubleLinearTimeInterpolateOp.h
@@ -66,6 +66,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/NodeFloatLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/NodeFloatLinearTimeInterpolateOp.C
@@ -83,6 +83,7 @@ void
 NodeFloatLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
@@ -98,10 +99,9 @@ NodeFloatLinearTimeInterpolateOp::timeInterpolate(
    TBOX_ASSERT(old_dat != 0);
    TBOX_ASSERT(new_dat != 0);
    TBOX_ASSERT(dst_dat != 0);
-   TBOX_ASSERT((where * old_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * new_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * dst_dat->getGhostBox()).isSpatiallyEqual(where));
    TBOX_ASSERT_OBJDIM_EQUALITY4(dst_data, where, src_data_old, src_data_new);
+
+   hier::Box node_where = NodeGeometry::toNodeBox(where);
 
    const hier::Index& old_ilo = old_dat->getGhostBox().lower();
    const hier::Index& old_ihi = old_dat->getGhostBox().upper();
@@ -110,9 +110,6 @@ NodeFloatLinearTimeInterpolateOp::timeInterpolate(
 
    const hier::Index& dst_ilo = dst_dat->getGhostBox().lower();
    const hier::Index& dst_ihi = dst_dat->getGhostBox().upper();
-
-   const hier::Index& ifirst = where.lower();
-   const hier::Index& ilast = where.upper();
 
    const double old_time = old_dat->getTime();
    const double new_time = new_dat->getTime();
@@ -131,45 +128,59 @@ NodeFloatLinearTimeInterpolateOp::timeInterpolate(
       tfrac = 0.0;
    }
 
-   for (int d = 0; d < dst_dat->getDepth(); ++d) {
-      if (dim == tbox::Dimension(1)) {
-         SAMRAI_F77_FUNC(lintimeintnodefloat1d, LINTIMEINTNODEFLOAT1D) (ifirst(0),
-            ilast(0),
-            old_ilo(0), old_ihi(0),
-            new_ilo(0), new_ihi(0),
-            dst_ilo(0), dst_ihi(0),
-            tfrac,
-            old_dat->getPointer(d),
-            new_dat->getPointer(d),
-            dst_dat->getPointer(d));
-      } else if (dim == tbox::Dimension(2)) {
-         SAMRAI_F77_FUNC(lintimeintnodefloat2d, LINTIMEINTNODEFLOAT2D) (ifirst(0),
-            ifirst(1), ilast(0), ilast(1),
-            old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-            new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-            dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-            tfrac,
-            old_dat->getPointer(d),
-            new_dat->getPointer(d),
-            dst_dat->getPointer(d));
-      } else if (dim == tbox::Dimension(3)) {
-         SAMRAI_F77_FUNC(lintimeintnodefloat3d, LINTIMEINTNODEFLOAT3D) (ifirst(0),
-            ifirst(1), ifirst(2),
-            ilast(0), ilast(1), ilast(2),
-            old_ilo(0), old_ilo(1), old_ilo(2),
-            old_ihi(0), old_ihi(1), old_ihi(2),
-            new_ilo(0), new_ilo(1), new_ilo(2),
-            new_ihi(0), new_ihi(1), new_ihi(2),
-            dst_ilo(0), dst_ilo(1), dst_ilo(2),
-            dst_ihi(0), dst_ihi(1), dst_ihi(2),
-            tfrac,
-            old_dat->getPointer(d),
-            new_dat->getPointer(d),
-            dst_dat->getPointer(d));
-      } else {
-         TBOX_ERROR(
-            "EdgeFloatLinearTimeInterpolateOp::TimeInterpolate dim > 3 not supported"
-            << std::endl);
+   const NodeOverlap* node_overlap = CPP_CAST<const NodeOverlap*>(&overlap);
+   hier::BoxContainer ovlp_boxes;
+   node_overlap->getSourceBoxContainer(ovlp_boxes);
+
+   for (auto itr = ovlp_boxes.begin(); itr != ovlp_boxes.end(); ++itr) {
+      hier::Box dest_box((*itr) * node_where);
+      TBOX_ASSERT((dest_box * old_dat->getArrayData().getBox()).isSpatiallyEqual(dest_box));
+      TBOX_ASSERT((dest_box * new_dat->getArrayData().getBox()).isSpatiallyEqual(dest_box));
+      TBOX_ASSERT((dest_box * dst_dat->getArrayData().getBox()).isSpatiallyEqual(dest_box));
+
+      const hier::Index& ifirst = dest_box.lower();
+      const hier::Index& ilast = dest_box.upper();
+
+      for (int d = 0; d < dst_dat->getDepth(); ++d) {
+         if (dim == tbox::Dimension(1)) {
+            SAMRAI_F77_FUNC(lintimeintnodefloat1d, LINTIMEINTNODEFLOAT1D) (
+               ifirst(0), ilast(0),
+               old_ilo(0), old_ihi(0),
+               new_ilo(0), new_ihi(0),
+               dst_ilo(0), dst_ihi(0),
+               tfrac,
+               old_dat->getPointer(d),
+               new_dat->getPointer(d),
+               dst_dat->getPointer(d));
+         } else if (dim == tbox::Dimension(2)) {
+            SAMRAI_F77_FUNC(lintimeintnodefloat2d, LINTIMEINTNODEFLOAT2D) (
+               ifirst(0), ifirst(1), ilast(0), ilast(1),
+               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+               tfrac,
+               old_dat->getPointer(d),
+               new_dat->getPointer(d),
+               dst_dat->getPointer(d));
+         } else if (dim == tbox::Dimension(3)) {
+            SAMRAI_F77_FUNC(lintimeintnodefloat3d, LINTIMEINTNODEFLOAT3D) (
+               ifirst(0), ifirst(1), ifirst(2),
+               ilast(0), ilast(1), ilast(2),
+               old_ilo(0), old_ilo(1), old_ilo(2),
+               old_ihi(0), old_ihi(1), old_ihi(2),
+               new_ilo(0), new_ilo(1), new_ilo(2),
+               new_ihi(0), new_ihi(1), new_ihi(2),
+               dst_ilo(0), dst_ilo(1), dst_ilo(2),
+               dst_ihi(0), dst_ihi(1), dst_ihi(2),
+               tfrac,
+               old_dat->getPointer(d),
+               new_dat->getPointer(d),
+               dst_dat->getPointer(d));
+         } else {
+            TBOX_ERROR(
+               "NodeFloatLinearTimeInterpolateOp::TimeInterpolate dim > 3 not supported"
+               << std::endl);
+         }
       }
    }
 }

--- a/source/SAMRAI/pdat/NodeFloatLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/NodeFloatLinearTimeInterpolateOp.h
@@ -65,6 +65,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/OuterfaceComplexLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/OuterfaceComplexLinearTimeInterpolateOp.C
@@ -122,9 +122,11 @@ void
 OuterfaceComplexLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
+   NULL_USE(overlap);
    const tbox::Dimension& dim(where.getDim());
 
    const OuterfaceData<dcomplex>* old_dat =

--- a/source/SAMRAI/pdat/OuterfaceComplexLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/OuterfaceComplexLinearTimeInterpolateOp.h
@@ -68,6 +68,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/OuterfaceDoubleLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/OuterfaceDoubleLinearTimeInterpolateOp.C
@@ -119,9 +119,11 @@ void
 OuterfaceDoubleLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
+   NULL_USE(overlap);
    const tbox::Dimension& dim(where.getDim());
 
    const OuterfaceData<double>* old_dat =

--- a/source/SAMRAI/pdat/OuterfaceDoubleLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/OuterfaceDoubleLinearTimeInterpolateOp.h
@@ -68,6 +68,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/OuterfaceFloatLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/OuterfaceFloatLinearTimeInterpolateOp.C
@@ -119,9 +119,11 @@ void
 OuterfaceFloatLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
+   NULL_USE(overlap);
    const tbox::Dimension& dim(where.getDim());
 
    const OuterfaceData<float>* old_dat =

--- a/source/SAMRAI/pdat/OuterfaceFloatLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/OuterfaceFloatLinearTimeInterpolateOp.h
@@ -68,6 +68,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/OutersideComplexLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/OutersideComplexLinearTimeInterpolateOp.C
@@ -122,9 +122,11 @@ void
 OutersideComplexLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
+   NULL_USE(overlap);
    const tbox::Dimension& dim(where.getDim());
 
    const OutersideData<dcomplex>* old_dat =

--- a/source/SAMRAI/pdat/OutersideComplexLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/OutersideComplexLinearTimeInterpolateOp.h
@@ -68,6 +68,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/OutersideDoubleLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/OutersideDoubleLinearTimeInterpolateOp.C
@@ -119,9 +119,11 @@ void
 OutersideDoubleLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
+   NULL_USE(overlap);
    const tbox::Dimension& dim(where.getDim());
 
    const OutersideData<double>* old_dat =

--- a/source/SAMRAI/pdat/OutersideDoubleLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/OutersideDoubleLinearTimeInterpolateOp.h
@@ -68,6 +68,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/OutersideFloatLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/OutersideFloatLinearTimeInterpolateOp.C
@@ -119,9 +119,11 @@ void
 OutersideFloatLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
+   NULL_USE(overlap);
    const tbox::Dimension& dim(where.getDim());
 
    const OutersideData<float>* old_dat =

--- a/source/SAMRAI/pdat/OutersideFloatLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/OutersideFloatLinearTimeInterpolateOp.h
@@ -68,6 +68,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/SideComplexLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/SideComplexLinearTimeInterpolateOp.C
@@ -8,9 +8,7 @@
  *
  ************************************************************************/
 #include "SAMRAI/pdat/SideComplexLinearTimeInterpolateOp.h"
-#include "SAMRAI/tbox/Complex.h"
 
-#include "SAMRAI/tbox/Utilities.h"
 #include "SAMRAI/hier/Box.h"
 #include "SAMRAI/hier/Index.h"
 #include "SAMRAI/pdat/SideData.h"
@@ -121,6 +119,7 @@ void
 SideComplexLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
@@ -136,9 +135,6 @@ SideComplexLinearTimeInterpolateOp::timeInterpolate(
    TBOX_ASSERT(old_dat != 0);
    TBOX_ASSERT(new_dat != 0);
    TBOX_ASSERT(dst_dat != 0);
-   TBOX_ASSERT((where * old_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * new_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * dst_dat->getGhostBox()).isSpatiallyEqual(where));
    TBOX_ASSERT_OBJDIM_EQUALITY4(dst_data, where, src_data_old, src_data_new);
 
    const hier::IntVector& directions = dst_dat->getDirectionVector();
@@ -155,9 +151,6 @@ SideComplexLinearTimeInterpolateOp::timeInterpolate(
 
    const hier::Index& dst_ilo = dst_dat->getGhostBox().lower();
    const hier::Index& dst_ihi = dst_dat->getGhostBox().upper();
-
-   const hier::Index& ifirst = where.lower();
-   const hier::Index& ilast = where.upper();
 
    const double old_time = old_dat->getTime();
    const double new_time = new_dat->getTime();
@@ -176,87 +169,134 @@ SideComplexLinearTimeInterpolateOp::timeInterpolate(
       tfrac = 0.0;
    }
 
+   std::vector<hier::Box> side_where(dim.getValue(), hier::Box(dim));
+   std::vector<hier::BoxContainer> ovlp_boxes(dim.getValue());
+
+   const SideOverlap* side_ovlp = CPP_CAST<const SideOverlap*>(&overlap);
+   for (int dir = 0; dir < dim.getValue(); ++dir) {
+      if (directions(dir)) {
+         side_where[dir] = SideGeometry::toSideBox(where, dir);
+         side_ovlp->getSourceBoxContainer(ovlp_boxes[dir], dir);
+      }
+   }
+
    for (int d = 0; d < dst_dat->getDepth(); ++d) {
       if (dim == tbox::Dimension(1)) {
          if (directions(0)) {
-            SAMRAI_F77_FUNC(lintimeintsidecmplx1d, LINTIMEINTSIDECMPLX1D) (ifirst(0),
-               ilast(0),
-               old_ilo(0), old_ihi(0),
-               new_ilo(0), new_ihi(0),
-               dst_ilo(0), dst_ihi(0),
-               tfrac,
-               old_dat->getPointer(0, d),
-               new_dat->getPointer(0, d),
-               dst_dat->getPointer(0, d));
+            for (auto itr = ovlp_boxes[0].begin();
+                 itr != ovlp_boxes[0].end(); ++itr) {
+               hier::Box dest_box((*itr) * side_where[0]); 
+               const hier::Index& ifirst = dest_box.lower();
+               const hier::Index& ilast = dest_box.upper();
+               SAMRAI_F77_FUNC(lintimeintsidecmplx1d, LINTIMEINTSIDECMPLX1D) (
+                  ifirst(0), ilast(0),
+                  old_ilo(0), old_ihi(0),
+                  new_ilo(0), new_ihi(0),
+                  dst_ilo(0), dst_ihi(0),
+                  tfrac,
+                  old_dat->getPointer(0, d),
+                  new_dat->getPointer(0, d),
+                  dst_dat->getPointer(0, d));
+            }
          }
       } else if (dim == tbox::Dimension(2)) {
          if (directions(0)) {
-            SAMRAI_F77_FUNC(lintimeintsidecmplx2d0, LINTIMEINTSIDECMPLX2D0) (ifirst(0),
-               ifirst(1), ilast(0), ilast(1),
-               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-               tfrac,
-               old_dat->getPointer(0, d),
-               new_dat->getPointer(0, d),
-               dst_dat->getPointer(0, d));
+            for (auto itr = ovlp_boxes[0].begin();
+                 itr != ovlp_boxes[0].end(); ++itr) {
+               hier::Box dest_box((*itr) * side_where[0]);
+               const hier::Index& ifirst = dest_box.lower();
+               const hier::Index& ilast = dest_box.upper();
+               SAMRAI_F77_FUNC(lintimeintsidecmplx2d0, LINTIMEINTSIDECMPLX2D0) (
+                  ifirst(0), ifirst(1), ilast(0), ilast(1),
+                  old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+                  new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+                  dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+                  tfrac,
+                  old_dat->getPointer(0, d),
+                  new_dat->getPointer(0, d),
+                  dst_dat->getPointer(0, d));
+            }
          }
          if (directions(1)) {
-            SAMRAI_F77_FUNC(lintimeintsidecmplx2d1, LINTIMEINTSIDECMPLX2D1) (ifirst(0),
-               ifirst(1), ilast(0), ilast(1),
-               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-               tfrac,
-               old_dat->getPointer(1, d),
-               new_dat->getPointer(1, d),
-               dst_dat->getPointer(1, d));
+            for (auto itr = ovlp_boxes[1].begin();
+                 itr != ovlp_boxes[1].end(); ++itr) {
+               hier::Box dest_box((*itr) * side_where[1]);
+               const hier::Index& ifirst = dest_box.lower();
+               const hier::Index& ilast = dest_box.upper();
+               SAMRAI_F77_FUNC(lintimeintsidecmplx2d1, LINTIMEINTSIDECMPLX2D1) (
+                  ifirst(0), ifirst(1), ilast(0), ilast(1),
+                  old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+                  new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+                  dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+                  tfrac,
+                  old_dat->getPointer(1, d),
+                  new_dat->getPointer(1, d),
+                  dst_dat->getPointer(1, d));
+            }
          }
       } else if (dim == tbox::Dimension(3)) {
          if (directions(0)) {
-            SAMRAI_F77_FUNC(lintimeintsidecmplx3d0, LINTIMEINTSIDECMPLX3D0) (ifirst(0),
-               ifirst(1), ifirst(2),
-               ilast(0), ilast(1), ilast(2),
-               old_ilo(0), old_ilo(1), old_ilo(2),
-               old_ihi(0), old_ihi(1), old_ihi(2),
-               new_ilo(0), new_ilo(1), new_ilo(2),
-               new_ihi(0), new_ihi(1), new_ihi(2),
-               dst_ilo(0), dst_ilo(1), dst_ilo(2),
-               dst_ihi(0), dst_ihi(1), dst_ihi(2),
-               tfrac,
-               old_dat->getPointer(0, d),
-               new_dat->getPointer(0, d),
-               dst_dat->getPointer(0, d));
+            for (auto itr = ovlp_boxes[0].begin();
+                 itr != ovlp_boxes[0].end(); ++itr) {
+               hier::Box dest_box((*itr) * side_where[0]);
+               const hier::Index& ifirst = dest_box.lower();
+               const hier::Index& ilast = dest_box.upper();
+               SAMRAI_F77_FUNC(lintimeintsidecmplx3d0, LINTIMEINTSIDECMPLX3D0) (
+                  ifirst(0), ifirst(1), ifirst(2),
+                  ilast(0), ilast(1), ilast(2),
+                  old_ilo(0), old_ilo(1), old_ilo(2),
+                  old_ihi(0), old_ihi(1), old_ihi(2),
+                  new_ilo(0), new_ilo(1), new_ilo(2),
+                  new_ihi(0), new_ihi(1), new_ihi(2),
+                  dst_ilo(0), dst_ilo(1), dst_ilo(2),
+                  dst_ihi(0), dst_ihi(1), dst_ihi(2),
+                  tfrac,
+                  old_dat->getPointer(0, d),
+                  new_dat->getPointer(0, d),
+                  dst_dat->getPointer(0, d));
+            }
          }
          if (directions(1)) {
-            SAMRAI_F77_FUNC(lintimeintsidecmplx3d1, LINTIMEINTSIDECMPLX3D1) (ifirst(0),
-               ifirst(1), ifirst(2),
-               ilast(0), ilast(1), ilast(2),
-               old_ilo(0), old_ilo(1), old_ilo(2),
-               old_ihi(0), old_ihi(1), old_ihi(2),
-               new_ilo(0), new_ilo(1), new_ilo(2),
-               new_ihi(0), new_ihi(1), new_ihi(2),
-               dst_ilo(0), dst_ilo(1), dst_ilo(2),
-               dst_ihi(0), dst_ihi(1), dst_ihi(2),
-               tfrac,
-               old_dat->getPointer(1, d),
-               new_dat->getPointer(1, d),
-               dst_dat->getPointer(1, d));
+            for (auto itr = ovlp_boxes[1].begin();
+                 itr != ovlp_boxes[1].end(); ++itr) {
+               hier::Box dest_box((*itr) * side_where[1]);
+               const hier::Index& ifirst = dest_box.lower();
+               const hier::Index& ilast = dest_box.upper();
+               SAMRAI_F77_FUNC(lintimeintsidecmplx3d1, LINTIMEINTSIDECMPLX3D1) (
+                  ifirst(0), ifirst(1), ifirst(2),
+                  ilast(0), ilast(1), ilast(2),
+                  old_ilo(0), old_ilo(1), old_ilo(2),
+                  old_ihi(0), old_ihi(1), old_ihi(2),
+                  new_ilo(0), new_ilo(1), new_ilo(2),
+                  new_ihi(0), new_ihi(1), new_ihi(2),
+                  dst_ilo(0), dst_ilo(1), dst_ilo(2),
+                  dst_ihi(0), dst_ihi(1), dst_ihi(2),
+                  tfrac,
+                  old_dat->getPointer(1, d),
+                  new_dat->getPointer(1, d),
+                  dst_dat->getPointer(1, d));
+            }
          }
          if (directions(2)) {
-            SAMRAI_F77_FUNC(lintimeintsidecmplx3d2, LINTIMEINTSIDECMPLX3D2) (ifirst(0),
-               ifirst(1), ifirst(2),
-               ilast(0), ilast(1), ilast(2),
-               old_ilo(0), old_ilo(1), old_ilo(2),
-               old_ihi(0), old_ihi(1), old_ihi(2),
-               new_ilo(0), new_ilo(1), new_ilo(2),
-               new_ihi(0), new_ihi(1), new_ihi(2),
-               dst_ilo(0), dst_ilo(1), dst_ilo(2),
-               dst_ihi(0), dst_ihi(1), dst_ihi(2),
-               tfrac,
-               old_dat->getPointer(2, d),
-               new_dat->getPointer(2, d),
-               dst_dat->getPointer(2, d));
+            for (auto itr = ovlp_boxes[2].begin();
+                 itr != ovlp_boxes[2].end(); ++itr) {
+               hier::Box dest_box((*itr) * side_where[2]);
+               const hier::Index& ifirst = dest_box.lower();
+               const hier::Index& ilast = dest_box.upper();
+               SAMRAI_F77_FUNC(lintimeintsidecmplx3d2, LINTIMEINTSIDECMPLX3D2) (
+                  ifirst(0), ifirst(1), ifirst(2),
+                  ilast(0), ilast(1), ilast(2),
+                  old_ilo(0), old_ilo(1), old_ilo(2),
+                  old_ihi(0), old_ihi(1), old_ihi(2),
+                  new_ilo(0), new_ilo(1), new_ilo(2),
+                  new_ihi(0), new_ihi(1), new_ihi(2),
+                  dst_ilo(0), dst_ilo(1), dst_ilo(2),
+                  dst_ihi(0), dst_ihi(1), dst_ihi(2),
+                  tfrac,
+                  old_dat->getPointer(2, d),
+                  new_dat->getPointer(2, d),
+                  dst_dat->getPointer(2, d));
+            }
          }
       } else {
          TBOX_ERROR(

--- a/source/SAMRAI/pdat/SideComplexLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/SideComplexLinearTimeInterpolateOp.h
@@ -66,6 +66,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/SideDoubleLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/SideDoubleLinearTimeInterpolateOp.C
@@ -119,6 +119,7 @@ void
 SideDoubleLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
@@ -134,9 +135,6 @@ SideDoubleLinearTimeInterpolateOp::timeInterpolate(
    TBOX_ASSERT(old_dat != 0);
    TBOX_ASSERT(new_dat != 0);
    TBOX_ASSERT(dst_dat != 0);
-   TBOX_ASSERT((where * old_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * new_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * dst_dat->getGhostBox()).isSpatiallyEqual(where));
    TBOX_ASSERT_OBJDIM_EQUALITY4(dst_data, where, src_data_old, src_data_new);
 
    const hier::IntVector& directions = dst_dat->getDirectionVector();
@@ -153,9 +151,6 @@ SideDoubleLinearTimeInterpolateOp::timeInterpolate(
 
    const hier::Index& dst_ilo = dst_dat->getGhostBox().lower();
    const hier::Index& dst_ihi = dst_dat->getGhostBox().upper();
-
-   const hier::Index& ifirst = where.lower();
-   const hier::Index& ilast = where.upper();
 
    const double old_time = old_dat->getTime();
    const double new_time = new_dat->getTime();
@@ -174,87 +169,134 @@ SideDoubleLinearTimeInterpolateOp::timeInterpolate(
       tfrac = 0.0;
    }
 
+   std::vector<hier::Box> side_where(dim.getValue(), hier::Box(dim));
+   std::vector<hier::BoxContainer> ovlp_boxes(dim.getValue());
+
+   const SideOverlap* side_ovlp = CPP_CAST<const SideOverlap*>(&overlap);
+   for (int dir = 0; dir < dim.getValue(); ++dir) {
+      if (directions(dir)) {
+         side_where[dir] = SideGeometry::toSideBox(where, dir);
+         side_ovlp->getSourceBoxContainer(ovlp_boxes[dir], dir);
+      }
+   }
+
    for (int d = 0; d < dst_dat->getDepth(); ++d) {
       if (dim == tbox::Dimension(1)) {
          if (directions(0)) {
-            SAMRAI_F77_FUNC(lintimeintsidedoub1d, LINTIMEINTSIDEDOUB1D) (ifirst(0),
-               ilast(0),
-               old_ilo(0), old_ihi(0),
-               new_ilo(0), new_ihi(0),
-               dst_ilo(0), dst_ihi(0),
-               tfrac,
-               old_dat->getPointer(0, d),
-               new_dat->getPointer(0, d),
-               dst_dat->getPointer(0, d));
+            for (auto itr = ovlp_boxes[0].begin();
+                 itr != ovlp_boxes[0].end(); ++itr) {
+               hier::Box dest_box((*itr) * side_where[0]); 
+               const hier::Index& ifirst = dest_box.lower();
+               const hier::Index& ilast = dest_box.upper();
+               SAMRAI_F77_FUNC(lintimeintsidedoub1d, LINTIMEINTSIDEDOUB1D) (
+                  ifirst(0), ilast(0),
+                  old_ilo(0), old_ihi(0),
+                  new_ilo(0), new_ihi(0),
+                  dst_ilo(0), dst_ihi(0),
+                  tfrac,
+                  old_dat->getPointer(0, d),
+                  new_dat->getPointer(0, d),
+                  dst_dat->getPointer(0, d));
+            }
          }
       } else if (dim == tbox::Dimension(2)) {
          if (directions(0)) {
-            SAMRAI_F77_FUNC(lintimeintsidedoub2d0, LINTIMEINTSIDEDOUB2D0) (ifirst(0),
-               ifirst(1), ilast(0), ilast(1),
-               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-               tfrac,
-               old_dat->getPointer(0, d),
-               new_dat->getPointer(0, d),
-               dst_dat->getPointer(0, d));
+            for (auto itr = ovlp_boxes[0].begin();
+                 itr != ovlp_boxes[0].end(); ++itr) {
+               hier::Box dest_box((*itr) * side_where[0]);
+               const hier::Index& ifirst = dest_box.lower();
+               const hier::Index& ilast = dest_box.upper();
+               SAMRAI_F77_FUNC(lintimeintsidedoub2d0, LINTIMEINTSIDEDOUB2D0) (
+                  ifirst(0), ifirst(1), ilast(0), ilast(1),
+                  old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+                  new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+                  dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+                  tfrac,
+                  old_dat->getPointer(0, d),
+                  new_dat->getPointer(0, d),
+                  dst_dat->getPointer(0, d));
+            }
          }
          if (directions(1)) {
-            SAMRAI_F77_FUNC(lintimeintsidedoub2d1, LINTIMEINTSIDEDOUB2D1) (ifirst(0),
-               ifirst(1), ilast(0), ilast(1),
-               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-               tfrac,
-               old_dat->getPointer(1, d),
-               new_dat->getPointer(1, d),
-               dst_dat->getPointer(1, d));
+            for (auto itr = ovlp_boxes[1].begin();
+                 itr != ovlp_boxes[1].end(); ++itr) {
+               hier::Box dest_box((*itr) * side_where[1]);
+               const hier::Index& ifirst = dest_box.lower();
+               const hier::Index& ilast = dest_box.upper();
+               SAMRAI_F77_FUNC(lintimeintsidedoub2d1, LINTIMEINTSIDEDOUB2D1) (
+                  ifirst(0), ifirst(1), ilast(0), ilast(1),
+                  old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+                  new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+                  dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+                  tfrac,
+                  old_dat->getPointer(1, d),
+                  new_dat->getPointer(1, d),
+                  dst_dat->getPointer(1, d));
+            }
          }
       } else if (dim == tbox::Dimension(3)) {
          if (directions(0)) {
-            SAMRAI_F77_FUNC(lintimeintsidedoub3d0, LINTIMEINTSIDEDOUB3D0) (ifirst(0),
-               ifirst(1), ifirst(2),
-               ilast(0), ilast(1), ilast(2),
-               old_ilo(0), old_ilo(1), old_ilo(2),
-               old_ihi(0), old_ihi(1), old_ihi(2),
-               new_ilo(0), new_ilo(1), new_ilo(2),
-               new_ihi(0), new_ihi(1), new_ihi(2),
-               dst_ilo(0), dst_ilo(1), dst_ilo(2),
-               dst_ihi(0), dst_ihi(1), dst_ihi(2),
-               tfrac,
-               old_dat->getPointer(0, d),
-               new_dat->getPointer(0, d),
-               dst_dat->getPointer(0, d));
+            for (auto itr = ovlp_boxes[0].begin();
+                 itr != ovlp_boxes[0].end(); ++itr) {
+               hier::Box dest_box((*itr) * side_where[0]);
+               const hier::Index& ifirst = dest_box.lower();
+               const hier::Index& ilast = dest_box.upper();
+               SAMRAI_F77_FUNC(lintimeintsidedoub3d0, LINTIMEINTSIDEDOUB3D0) (
+                  ifirst(0), ifirst(1), ifirst(2),
+                  ilast(0), ilast(1), ilast(2),
+                  old_ilo(0), old_ilo(1), old_ilo(2),
+                  old_ihi(0), old_ihi(1), old_ihi(2),
+                  new_ilo(0), new_ilo(1), new_ilo(2),
+                  new_ihi(0), new_ihi(1), new_ihi(2),
+                  dst_ilo(0), dst_ilo(1), dst_ilo(2),
+                  dst_ihi(0), dst_ihi(1), dst_ihi(2),
+                  tfrac,
+                  old_dat->getPointer(0, d),
+                  new_dat->getPointer(0, d),
+                  dst_dat->getPointer(0, d));
+            }
          }
          if (directions(1)) {
-            SAMRAI_F77_FUNC(lintimeintsidedoub3d1, LINTIMEINTSIDEDOUB3D1) (ifirst(0),
-               ifirst(1), ifirst(2),
-               ilast(0), ilast(1), ilast(2),
-               old_ilo(0), old_ilo(1), old_ilo(2),
-               old_ihi(0), old_ihi(1), old_ihi(2),
-               new_ilo(0), new_ilo(1), new_ilo(2),
-               new_ihi(0), new_ihi(1), new_ihi(2),
-               dst_ilo(0), dst_ilo(1), dst_ilo(2),
-               dst_ihi(0), dst_ihi(1), dst_ihi(2),
-               tfrac,
-               old_dat->getPointer(1, d),
-               new_dat->getPointer(1, d),
-               dst_dat->getPointer(1, d));
+            for (auto itr = ovlp_boxes[1].begin();
+                 itr != ovlp_boxes[1].end(); ++itr) {
+               hier::Box dest_box((*itr) * side_where[1]);
+               const hier::Index& ifirst = dest_box.lower();
+               const hier::Index& ilast = dest_box.upper();
+               SAMRAI_F77_FUNC(lintimeintsidedoub3d1, LINTIMEINTSIDEDOUB3D1) (
+                  ifirst(0), ifirst(1), ifirst(2),
+                  ilast(0), ilast(1), ilast(2),
+                  old_ilo(0), old_ilo(1), old_ilo(2),
+                  old_ihi(0), old_ihi(1), old_ihi(2),
+                  new_ilo(0), new_ilo(1), new_ilo(2),
+                  new_ihi(0), new_ihi(1), new_ihi(2),
+                  dst_ilo(0), dst_ilo(1), dst_ilo(2),
+                  dst_ihi(0), dst_ihi(1), dst_ihi(2),
+                  tfrac,
+                  old_dat->getPointer(1, d),
+                  new_dat->getPointer(1, d),
+                  dst_dat->getPointer(1, d));
+            }
          }
          if (directions(2)) {
-            SAMRAI_F77_FUNC(lintimeintsidedoub3d2, LINTIMEINTSIDEDOUB3D2) (ifirst(0),
-               ifirst(1), ifirst(2),
-               ilast(0), ilast(1), ilast(2),
-               old_ilo(0), old_ilo(1), old_ilo(2),
-               old_ihi(0), old_ihi(1), old_ihi(2),
-               new_ilo(0), new_ilo(1), new_ilo(2),
-               new_ihi(0), new_ihi(1), new_ihi(2),
-               dst_ilo(0), dst_ilo(1), dst_ilo(2),
-               dst_ihi(0), dst_ihi(1), dst_ihi(2),
-               tfrac,
-               old_dat->getPointer(2, d),
-               new_dat->getPointer(2, d),
-               dst_dat->getPointer(2, d));
+            for (auto itr = ovlp_boxes[2].begin();
+                 itr != ovlp_boxes[2].end(); ++itr) {
+               hier::Box dest_box((*itr) * side_where[2]);
+               const hier::Index& ifirst = dest_box.lower();
+               const hier::Index& ilast = dest_box.upper();
+               SAMRAI_F77_FUNC(lintimeintsidedoub3d2, LINTIMEINTSIDEDOUB3D2) (
+                  ifirst(0), ifirst(1), ifirst(2),
+                  ilast(0), ilast(1), ilast(2),
+                  old_ilo(0), old_ilo(1), old_ilo(2),
+                  old_ihi(0), old_ihi(1), old_ihi(2),
+                  new_ilo(0), new_ilo(1), new_ilo(2),
+                  new_ihi(0), new_ihi(1), new_ihi(2),
+                  dst_ilo(0), dst_ilo(1), dst_ilo(2),
+                  dst_ihi(0), dst_ihi(1), dst_ihi(2),
+                  tfrac,
+                  old_dat->getPointer(2, d),
+                  new_dat->getPointer(2, d),
+                  dst_dat->getPointer(2, d));
+            }
          }
       } else {
          TBOX_ERROR(

--- a/source/SAMRAI/pdat/SideDoubleLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/SideDoubleLinearTimeInterpolateOp.h
@@ -66,6 +66,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/SideFloatLinearTimeInterpolateOp.C
+++ b/source/SAMRAI/pdat/SideFloatLinearTimeInterpolateOp.C
@@ -119,6 +119,7 @@ void
 SideFloatLinearTimeInterpolateOp::timeInterpolate(
    hier::PatchData& dst_data,
    const hier::Box& where,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& src_data_old,
    const hier::PatchData& src_data_new) const
 {
@@ -134,9 +135,6 @@ SideFloatLinearTimeInterpolateOp::timeInterpolate(
    TBOX_ASSERT(old_dat != 0);
    TBOX_ASSERT(new_dat != 0);
    TBOX_ASSERT(dst_dat != 0);
-   TBOX_ASSERT((where * old_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * new_dat->getGhostBox()).isSpatiallyEqual(where));
-   TBOX_ASSERT((where * dst_dat->getGhostBox()).isSpatiallyEqual(where));
    TBOX_ASSERT_OBJDIM_EQUALITY4(dst_data, where, src_data_old, src_data_new);
 
    const hier::IntVector& directions = dst_dat->getDirectionVector();
@@ -153,9 +151,6 @@ SideFloatLinearTimeInterpolateOp::timeInterpolate(
 
    const hier::Index& dst_ilo = dst_dat->getGhostBox().lower();
    const hier::Index& dst_ihi = dst_dat->getGhostBox().upper();
-
-   const hier::Index& ifirst = where.lower();
-   const hier::Index& ilast = where.upper();
 
    const double old_time = old_dat->getTime();
    const double new_time = new_dat->getTime();
@@ -174,87 +169,134 @@ SideFloatLinearTimeInterpolateOp::timeInterpolate(
       tfrac = 0.0;
    }
 
+   std::vector<hier::Box> side_where(dim.getValue(), hier::Box(dim));
+   std::vector<hier::BoxContainer> ovlp_boxes(dim.getValue());
+
+   const SideOverlap* side_ovlp = CPP_CAST<const SideOverlap*>(&overlap);
+   for (int dir = 0; dir < dim.getValue(); ++dir) {
+      if (directions(dir)) {
+         side_where[dir] = SideGeometry::toSideBox(where, dir);
+         side_ovlp->getSourceBoxContainer(ovlp_boxes[dir], dir);
+      }
+   }
+
    for (int d = 0; d < dst_dat->getDepth(); ++d) {
       if (dim == tbox::Dimension(1)) {
          if (directions(0)) {
-            SAMRAI_F77_FUNC(lintimeintsidefloat1d, LINTIMEINTSIDEFLOAT1D) (ifirst(0),
-               ilast(0),
-               old_ilo(0), old_ihi(0),
-               new_ilo(0), new_ihi(0),
-               dst_ilo(0), dst_ihi(0),
-               tfrac,
-               old_dat->getPointer(0, d),
-               new_dat->getPointer(0, d),
-               dst_dat->getPointer(0, d));
+            for (auto itr = ovlp_boxes[0].begin();
+                 itr != ovlp_boxes[0].end(); ++itr) {
+               hier::Box dest_box((*itr) * side_where[0]); 
+               const hier::Index& ifirst = dest_box.lower();
+               const hier::Index& ilast = dest_box.upper();
+               SAMRAI_F77_FUNC(lintimeintsidefloat1d, LINTIMEINTSIDEFLOAT1D) (
+                  ifirst(0), ilast(0),
+                  old_ilo(0), old_ihi(0),
+                  new_ilo(0), new_ihi(0),
+                  dst_ilo(0), dst_ihi(0),
+                  tfrac,
+                  old_dat->getPointer(0, d),
+                  new_dat->getPointer(0, d),
+                  dst_dat->getPointer(0, d));
+            }
          }
       } else if (dim == tbox::Dimension(2)) {
          if (directions(0)) {
-            SAMRAI_F77_FUNC(lintimeintsidefloat2d0, LINTIMEINTSIDEFLOAT2D0) (ifirst(0),
-               ifirst(1), ilast(0), ilast(1),
-               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-               tfrac,
-               old_dat->getPointer(0, d),
-               new_dat->getPointer(0, d),
-               dst_dat->getPointer(0, d));
+            for (auto itr = ovlp_boxes[0].begin();
+                 itr != ovlp_boxes[0].end(); ++itr) {
+               hier::Box dest_box((*itr) * side_where[0]);
+               const hier::Index& ifirst = dest_box.lower();
+               const hier::Index& ilast = dest_box.upper();
+               SAMRAI_F77_FUNC(lintimeintsidefloat2d0, LINTIMEINTSIDEFLOAT2D0) (
+                  ifirst(0), ifirst(1), ilast(0), ilast(1),
+                  old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+                  new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+                  dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+                  tfrac,
+                  old_dat->getPointer(0, d),
+                  new_dat->getPointer(0, d),
+                  dst_dat->getPointer(0, d));
+            }
          }
          if (directions(1)) {
-            SAMRAI_F77_FUNC(lintimeintsidefloat2d1, LINTIMEINTSIDEFLOAT2D1) (ifirst(0),
-               ifirst(1), ilast(0), ilast(1),
-               old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
-               new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
-               dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
-               tfrac,
-               old_dat->getPointer(1, d),
-               new_dat->getPointer(1, d),
-               dst_dat->getPointer(1, d));
+            for (auto itr = ovlp_boxes[1].begin();
+                 itr != ovlp_boxes[1].end(); ++itr) {
+               hier::Box dest_box((*itr) * side_where[1]);
+               const hier::Index& ifirst = dest_box.lower();
+               const hier::Index& ilast = dest_box.upper();
+               SAMRAI_F77_FUNC(lintimeintsidefloat2d1, LINTIMEINTSIDEFLOAT2D1) (
+                  ifirst(0), ifirst(1), ilast(0), ilast(1),
+                  old_ilo(0), old_ilo(1), old_ihi(0), old_ihi(1),
+                  new_ilo(0), new_ilo(1), new_ihi(0), new_ihi(1),
+                  dst_ilo(0), dst_ilo(1), dst_ihi(0), dst_ihi(1),
+                  tfrac,
+                  old_dat->getPointer(1, d),
+                  new_dat->getPointer(1, d),
+                  dst_dat->getPointer(1, d));
+            }
          }
       } else if (dim == tbox::Dimension(3)) {
          if (directions(0)) {
-            SAMRAI_F77_FUNC(lintimeintsidefloat3d0, LINTIMEINTSIDEFLOAT3D0) (ifirst(0),
-               ifirst(1), ifirst(2),
-               ilast(0), ilast(1), ilast(2),
-               old_ilo(0), old_ilo(1), old_ilo(2),
-               old_ihi(0), old_ihi(1), old_ihi(2),
-               new_ilo(0), new_ilo(1), new_ilo(2),
-               new_ihi(0), new_ihi(1), new_ihi(2),
-               dst_ilo(0), dst_ilo(1), dst_ilo(2),
-               dst_ihi(0), dst_ihi(1), dst_ihi(2),
-               tfrac,
-               old_dat->getPointer(0, d),
-               new_dat->getPointer(0, d),
-               dst_dat->getPointer(0, d));
+            for (auto itr = ovlp_boxes[0].begin();
+                 itr != ovlp_boxes[0].end(); ++itr) {
+               hier::Box dest_box((*itr) * side_where[0]);
+               const hier::Index& ifirst = dest_box.lower();
+               const hier::Index& ilast = dest_box.upper();
+               SAMRAI_F77_FUNC(lintimeintsidefloat3d0, LINTIMEINTSIDEFLOAT3D0) (
+                  ifirst(0), ifirst(1), ifirst(2),
+                  ilast(0), ilast(1), ilast(2),
+                  old_ilo(0), old_ilo(1), old_ilo(2),
+                  old_ihi(0), old_ihi(1), old_ihi(2),
+                  new_ilo(0), new_ilo(1), new_ilo(2),
+                  new_ihi(0), new_ihi(1), new_ihi(2),
+                  dst_ilo(0), dst_ilo(1), dst_ilo(2),
+                  dst_ihi(0), dst_ihi(1), dst_ihi(2),
+                  tfrac,
+                  old_dat->getPointer(0, d),
+                  new_dat->getPointer(0, d),
+                  dst_dat->getPointer(0, d));
+            }
          }
          if (directions(1)) {
-            SAMRAI_F77_FUNC(lintimeintsidefloat3d1, LINTIMEINTSIDEFLOAT3D1) (ifirst(0),
-               ifirst(1), ifirst(2),
-               ilast(0), ilast(1), ilast(2),
-               old_ilo(0), old_ilo(1), old_ilo(2),
-               old_ihi(0), old_ihi(1), old_ihi(2),
-               new_ilo(0), new_ilo(1), new_ilo(2),
-               new_ihi(0), new_ihi(1), new_ihi(2),
-               dst_ilo(0), dst_ilo(1), dst_ilo(2),
-               dst_ihi(0), dst_ihi(1), dst_ihi(2),
-               tfrac,
-               old_dat->getPointer(1, d),
-               new_dat->getPointer(1, d),
-               dst_dat->getPointer(1, d));
+            for (auto itr = ovlp_boxes[1].begin();
+                 itr != ovlp_boxes[1].end(); ++itr) {
+               hier::Box dest_box((*itr) * side_where[1]);
+               const hier::Index& ifirst = dest_box.lower();
+               const hier::Index& ilast = dest_box.upper();
+               SAMRAI_F77_FUNC(lintimeintsidefloat3d1, LINTIMEINTSIDEFLOAT3D1) (
+                  ifirst(0), ifirst(1), ifirst(2),
+                  ilast(0), ilast(1), ilast(2),
+                  old_ilo(0), old_ilo(1), old_ilo(2),
+                  old_ihi(0), old_ihi(1), old_ihi(2),
+                  new_ilo(0), new_ilo(1), new_ilo(2),
+                  new_ihi(0), new_ihi(1), new_ihi(2),
+                  dst_ilo(0), dst_ilo(1), dst_ilo(2),
+                  dst_ihi(0), dst_ihi(1), dst_ihi(2),
+                  tfrac,
+                  old_dat->getPointer(1, d),
+                  new_dat->getPointer(1, d),
+                  dst_dat->getPointer(1, d));
+            }
          }
          if (directions(2)) {
-            SAMRAI_F77_FUNC(lintimeintsidefloat3d2, LINTIMEINTSIDEFLOAT3D2) (ifirst(0),
-               ifirst(1), ifirst(2),
-               ilast(0), ilast(1), ilast(2),
-               old_ilo(0), old_ilo(1), old_ilo(2),
-               old_ihi(0), old_ihi(1), old_ihi(2),
-               new_ilo(0), new_ilo(1), new_ilo(2),
-               new_ihi(0), new_ihi(1), new_ihi(2),
-               dst_ilo(0), dst_ilo(1), dst_ilo(2),
-               dst_ihi(0), dst_ihi(1), dst_ihi(2),
-               tfrac,
-               old_dat->getPointer(2, d),
-               new_dat->getPointer(2, d),
-               dst_dat->getPointer(2, d));
+            for (auto itr = ovlp_boxes[2].begin();
+                 itr != ovlp_boxes[2].end(); ++itr) {
+               hier::Box dest_box((*itr) * side_where[2]);
+               const hier::Index& ifirst = dest_box.lower();
+               const hier::Index& ilast = dest_box.upper();
+               SAMRAI_F77_FUNC(lintimeintsidefloat3d2, LINTIMEINTSIDEFLOAT3D2) (
+                  ifirst(0), ifirst(1), ifirst(2),
+                  ilast(0), ilast(1), ilast(2),
+                  old_ilo(0), old_ilo(1), old_ilo(2),
+                  old_ihi(0), old_ihi(1), old_ihi(2),
+                  new_ilo(0), new_ilo(1), new_ilo(2),
+                  new_ihi(0), new_ihi(1), new_ihi(2),
+                  dst_ilo(0), dst_ilo(1), dst_ilo(2),
+                  dst_ihi(0), dst_ihi(1), dst_ihi(2),
+                  tfrac,
+                  old_dat->getPointer(2, d),
+                  new_dat->getPointer(2, d),
+                  dst_dat->getPointer(2, d));
+            }
          }
       } else {
          TBOX_ERROR(

--- a/source/SAMRAI/pdat/SideFloatLinearTimeInterpolateOp.h
+++ b/source/SAMRAI/pdat/SideFloatLinearTimeInterpolateOp.h
@@ -66,6 +66,7 @@ public:
    timeInterpolate(
       hier::PatchData& dst_data,
       const hier::Box& where,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& src_data_old,
       const hier::PatchData& src_data_new) const;
 

--- a/source/SAMRAI/pdat/fortran/pdat_m4lintimeintops1d.i
+++ b/source/SAMRAI/pdat/fortran/pdat_m4lintimeintops1d.i
@@ -71,7 +71,7 @@ lin_time_int_subroutine_head_1d()dnl
      &  arraynew(FACE1d(nilo,nihi,0)),
      &  arraydst(FACE1d(dilo,dihi,0))
       integer ie0
-lin_time_int_body_1d(`ie0',`ifirst0,ilast0+1')dnl
+lin_time_int_body_1d(`ie0',`ifirst0,ilast0')dnl
 ')dnl
 c
 define(lin_time_int_op_node_1d,`dnl
@@ -81,7 +81,7 @@ lin_time_int_subroutine_head_1d()dnl
      &  arraynew(NODE1d(nilo,nihi,0)),
      &  arraydst(NODE1d(dilo,dihi,0))
       integer ie0
-lin_time_int_body_1d(`ie0',`ifirst0,ilast0+1')dnl
+lin_time_int_body_1d(`ie0',`ifirst0,ilast0')dnl
 ')dnl
 c
 define(lin_time_int_op_outerface_1d,`dnl
@@ -127,5 +127,5 @@ lin_time_int_subroutine_head_1d()dnl
      &  arraynew(SIDE1d(nilo,nihi,0)),
      &  arraydst(SIDE1d(dilo,dihi,0))
       integer ie0
-lin_time_int_body_1d(`ie0',`ifirst0,ilast0+1')dnl
+lin_time_int_body_1d(`ie0',`ifirst0,ilast0')dnl
 ')dnl

--- a/source/SAMRAI/pdat/fortran/pdat_m4lintimeintops2d.i
+++ b/source/SAMRAI/pdat/fortran/pdat_m4lintimeintops2d.i
@@ -63,7 +63,7 @@ lin_time_int_subroutine_head_2d()dnl
      &  arraynew(EDGE2d$2(nilo,nihi,0)),
      &  arraydst(EDGE2d$2(dilo,dihi,0))
       integer ie0,ie1
-lin_time_int_body_2d(`ie0',`ie1',`ifirst0,ilast0+$2',`ifirst1,ilast1+$3')dnl
+lin_time_int_body_2d(`ie0',`ie1',`ifirst0,ilast0',`ifirst1,ilast1')dnl
 ')dnl
 c
 define(lin_time_int_op_face_2d,`dnl
@@ -72,8 +72,8 @@ lin_time_int_subroutine_head_2d()dnl
      &  arrayold(FACE2d$2(oilo,oihi,0)),
      &  arraynew(FACE2d$2(nilo,nihi,0)),
      &  arraydst(FACE2d$2(dilo,dihi,0))
-      integer ie$2,ic$3
-lin_time_int_body_2d(`ie$2',`ic$3',`ifirst$2,ilast$2+1',`ifirst$3,ilast$3')dnl
+      integer ie0,ic1
+lin_time_int_body_2d(`ie0',`ic1',`ifirst0,ilast0',`ifirst1,ilast1')dnl
 ')dnl
 c
 define(lin_time_int_op_node_2d,`dnl
@@ -83,7 +83,7 @@ lin_time_int_subroutine_head_2d()dnl
      &  arraynew(NODE2d(nilo,nihi,0)),
      &  arraydst(NODE2d(dilo,dihi,0))
       integer ie0,ie1
-lin_time_int_body_2d(`ie0',`ie1',`ifirst0,ilast0+1',`ifirst1,ilast1+1')dnl
+lin_time_int_body_2d(`ie0',`ie1',`ifirst0,ilast0',`ifirst1,ilast1')dnl
 ')dnl
 c
 define(lin_time_int_op_outerface_2d,`dnl
@@ -135,5 +135,5 @@ lin_time_int_subroutine_head_2d()dnl
      &  arraynew(SIDE2d$2(nilo,nihi,0)),
      &  arraydst(SIDE2d$2(dilo,dihi,0))
       integer ie0,ie1
-lin_time_int_body_2d(`ie0',`ie1',`ifirst0,ilast0+$3',`ifirst1,ilast1+$2')dnl
+lin_time_int_body_2d(`ie0',`ie1',`ifirst0,ilast0',`ifirst1,ilast1')dnl
 ')dnl

--- a/source/SAMRAI/pdat/fortran/pdat_m4lintimeintops3d.i
+++ b/source/SAMRAI/pdat/fortran/pdat_m4lintimeintops3d.i
@@ -66,11 +66,11 @@ lin_time_int_subroutine_head_3d()dnl
      &  arraynew(EDGE3d$2(nilo,nihi,0)),
      &  arraydst(EDGE3d$2(dilo,dihi,0))
       integer ie0,ie1,ie2
-ifelse($2,`0',`lin_time_int_body_3d(`ie0',`ie1',`ie2',`ifirst0,ilast0',`ifirst1,ilast1+1',`ifirst2,ilast2+1')dnl
+ifelse($2,`0',`lin_time_int_body_3d(`ie0',`ie1',`ie2',`ifirst0,ilast0',`ifirst1,ilast1',`ifirst2,ilast2')dnl
 ',`')dnl
-ifelse($2,`1',`lin_time_int_body_3d(`ie0',`ie1',`ie2',`ifirst0,ilast0+1',`ifirst1,ilast1',`ifirst2,ilast2+1')dnl
+ifelse($2,`1',`lin_time_int_body_3d(`ie0',`ie1',`ie2',`ifirst0,ilast0',`ifirst1,ilast1',`ifirst2,ilast2')dnl
 ',`')dnl
-ifelse($2,`2',`lin_time_int_body_3d(`ie0',`ie1',`ie2',`ifirst0,ilast0+1',`ifirst1,ilast1+1',`ifirst2,ilast2')dnl
+ifelse($2,`2',`lin_time_int_body_3d(`ie0',`ie1',`ie2',`ifirst0,ilast0',`ifirst1,ilast1',`ifirst2,ilast2')dnl
 ',`')dnl
 ')dnl
 c
@@ -80,8 +80,8 @@ lin_time_int_subroutine_head_3d()dnl
      &  arrayold(FACE3d$2(oilo,oihi,0)),
      &  arraynew(FACE3d$2(nilo,nihi,0)),
      &  arraydst(FACE3d$2(dilo,dihi,0))
-      integer ie$2,ic$3,ic$4
-lin_time_int_body_3d(`ie$2',`ic$3',`ic$4',`ifirst$2,ilast$2+1',`ifirst$3,ilast$3',`ifirst$4,ilast$4')dnl
+      integer ie0,ic1,ic2
+lin_time_int_body_3d(`ie0',`ic1',`ic2',`ifirst0,ilast0',`ifirst1,ilast1',`ifirst2,ilast2')dnl
 ')dnl
 c
 define(lin_time_int_op_node_3d,`dnl
@@ -91,7 +91,7 @@ lin_time_int_subroutine_head_3d()dnl
      &  arraynew(NODE3d(nilo,nihi,0)),
      &  arraydst(NODE3d(dilo,dihi,0))
       integer ie0,ie1,ie2
-lin_time_int_body_3d(`ie0',`ie1',`ie2',`ifirst0,ilast0+1',`ifirst1,ilast1+1',`ifirst2,ilast2+1')dnl
+lin_time_int_body_3d(`ie0',`ie1',`ie2',`ifirst0,ilast0',`ifirst1,ilast1',`ifirst2,ilast2')dnl
 ')dnl
 c
 define(lin_time_int_op_outerface_3d,`dnl
@@ -147,11 +147,11 @@ lin_time_int_subroutine_head_3d()dnl
      &  arraynew(SIDE3d$2(nilo,nihi,0)),
      &  arraydst(SIDE3d$2(dilo,dihi,0))
       integer ie0,ie1,ie2
-ifelse($2,`0',`lin_time_int_body_3d(`ie0',`ie1',`ie2',`ifirst0,ilast0+1',`ifirst1,ilast1',`ifirst2,ilast2')dnl
+ifelse($2,`0',`lin_time_int_body_3d(`ie0',`ie1',`ie2',`ifirst0,ilast0',`ifirst1,ilast1',`ifirst2,ilast2')dnl
 ',`')dnl
-ifelse($2,`1',`lin_time_int_body_3d(`ie0',`ie1',`ie2',`ifirst0,ilast0',`ifirst1,ilast1+1',`ifirst2,ilast2')dnl
+ifelse($2,`1',`lin_time_int_body_3d(`ie0',`ie1',`ie2',`ifirst0,ilast0',`ifirst1,ilast1',`ifirst2,ilast2')dnl
 ',`')dnl
-ifelse($2,`2',`lin_time_int_body_3d(`ie0',`ie1',`ie2',`ifirst0,ilast0',`ifirst1,ilast1',`ifirst2,ilast2+1')dnl
+ifelse($2,`2',`lin_time_int_body_3d(`ie0',`ie1',`ie2',`ifirst0,ilast0',`ifirst1,ilast1',`ifirst2,ilast2')dnl
 ',`')dnl
 ')dnl
 c

--- a/source/SAMRAI/xfer/RefineTimeTransaction.C
+++ b/source/SAMRAI/xfer/RefineTimeTransaction.C
@@ -170,6 +170,7 @@ RefineTimeTransaction::packStream(
 
       timeInterpolate(
          *temporary_patch_data,
+         *d_overlap,
          src_told_data,
          d_src_patch->getPatchData(d_refine_data[d_item_id]->d_src_tnew));
 
@@ -204,9 +205,8 @@ RefineTimeTransaction::copyLocalData()
        */
 
       scratch_data.copy(src_told_data, *d_overlap);
-   }
 
-   else if (d_overlap->getSourceOffset() ==
+   } else if (d_overlap->getSourceOffset() ==
        hier::IntVector::getZero(d_box.getDim()) &&
        d_overlap->getTransformation().getRotation() ==
        hier::Transformation::NO_ROTATE) {
@@ -219,7 +219,7 @@ RefineTimeTransaction::copyLocalData()
        * to the destination patchdata.
        */
 
-      timeInterpolate(scratch_data, src_told_data, src_tnew_data);
+      timeInterpolate(scratch_data, *d_overlap, src_told_data, src_tnew_data);
 
    } else {
 
@@ -239,7 +239,7 @@ RefineTimeTransaction::copyLocalData()
 
       temp->setTime(s_time);
 
-      timeInterpolate(*temp, src_told_data, src_tnew_data);
+      timeInterpolate(*temp, *d_overlap, src_told_data, src_tnew_data);
 
       scratch_data.copy(*temp, *d_overlap);
 
@@ -250,6 +250,7 @@ RefineTimeTransaction::copyLocalData()
 void
 RefineTimeTransaction::timeInterpolate(
    hier::PatchData& pd_dst,
+   const hier::BoxOverlap& overlap,
    const hier::PatchData& pd_old,
    const std::shared_ptr<hier::PatchData>& pd_new)
 {
@@ -258,7 +259,7 @@ RefineTimeTransaction::timeInterpolate(
 
    if (tbox::MathUtilities<double>::equalEps(pd_old.getTime(), s_time)) {
       d_refine_data[d_item_id]->
-      d_optime->timeInterpolate(pd_dst, d_box, pd_old, pd_old);
+      d_optime->timeInterpolate(pd_dst, d_box, overlap, pd_old, pd_old);
    } else {
 
       TBOX_ASSERT(pd_new);
@@ -267,7 +268,7 @@ RefineTimeTransaction::timeInterpolate(
       TBOX_ASSERT(pd_new->getTime() >= s_time);
 
       d_refine_data[d_item_id]->
-      d_optime->timeInterpolate(pd_dst, d_box, pd_old, *pd_new);
+      d_optime->timeInterpolate(pd_dst, d_box, overlap, pd_old, *pd_new);
    }
 }
 

--- a/source/SAMRAI/xfer/RefineTimeTransaction.h
+++ b/source/SAMRAI/xfer/RefineTimeTransaction.h
@@ -184,6 +184,7 @@ private:
    void
    timeInterpolate(
       hier::PatchData& pd_dst,
+      const hier::BoxOverlap& overlap,
       const hier::PatchData& pd_old,
       const std::shared_ptr<hier::PatchData>& pd_new);
 


### PR DESCRIPTION
This is necessary because for data that is located on cell boundaries (Node, Face, Side, Edge centerings), the RefineSchedule can create transactions between patches that overlap only on the patch boundaries.  For copy transactions, the information about these overlaps is stored in BoxOverlap objects that precisely define in a centering-specific manner the mesh region that the transaction must compute over.

However for time interpolation transactions the code flows through implementations of the pure virtural TimeInterpolateOperator::timeInterpolate() which receives only a cell-centered Box and requires the implementation to figure out how to translate that Box into the centering of the data being used.  If the true overlap between source and destination patches is only at the patch boundary, then a cell-centered Box, which always has a thickness of at least one cell width in every dimensional direction, is too big, but the timeInterpolate() interface gives no information about what the true overlap is.  This creates a genuine risk that timeInterpolate() implementations will operate on too large of a region of the mesh and possibly overrun array bounds.

This change adds a BoxOverlap argument to timeInterpolate() so that the exact, centering-specific, region of the mesh that the method should compute over is available.  This BoxOverlap has always been computed, but was not passed down into this method.  All child class implementations in the SAMRAI library have been modified to use this change.

This is an API change to a pure virtual method, so any user codes that have their own child class implementations of TimeInterpolateOperator will need to add the BoxOverlap argument.  They can choose whether or not they need to make use of the new argument, depending on the specifics of their implementation.