### PR TITLE
Initialize uninitialzed flags

### DIFF
--- a/source/SAMRAI/solv/CVODESolver.C
+++ b/source/SAMRAI/solv/CVODESolver.C
@@ -89,6 +89,8 @@ CVODESolver::CVODESolver(
    setCVSpgmrToleranceScaleFactor(0);
 
    d_CVODE_needs_initialization = true;
+   d_uses_projectionfn = false;
+   d_uses_jtimesrhsfn = false;
 }
 
 CVODESolver::~CVODESolver()


### PR DESCRIPTION
If left uninitialized in constructor, these flags may be used uninitialized and lead to undefined behavior