### PR TITLE
Make all variables in code using HYPRE and Sundials solvers to use Umpire allocators when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ option(ENABLE_SUNDIALS "Enable SUNDIALS" Off)
 
 # SAMRAI options
 option(ENABLE_SAMRAI_TESTS "Enable SAMRAI Test Programs" On)
-option(ENABLE_PERF_TESTS "Enable Performance Tests." On)
+option(ENABLE_PERF_TESTS "Enable Performance Tests." Off)
 set(NUM_PERF_PROCS 8 CACHE INT "Number of processors for performance tests.")
 option(ENABLE_CHECK_ASSERTIONS "Enable assertion checking." On)
 option(ENABLE_CHECK_DEV_ASSERTIONS "Enable SAMRAI developer assertion checking." Off)

--- a/source/SAMRAI/pdat/FaceVariable.C
+++ b/source/SAMRAI/pdat/FaceVariable.C
@@ -43,6 +43,26 @@ FaceVariable<TYPE>::FaceVariable(
 {
 }
 
+#ifdef HAVE_UMPIRE
+template<class TYPE>
+FaceVariable<TYPE>::FaceVariable(
+   const tbox::Dimension& dim,
+   const std::string& name,
+   umpire::Allocator allocator,
+   int depth,
+   const bool fine_boundary_represents_var):
+   hier::Variable(name,
+                  std::make_shared<FaceDataFactory<TYPE> >(
+                     depth,
+                     // default zero ghost cells
+                     hier::IntVector::getZero(dim),
+                     fine_boundary_represents_var,
+                     allocator)),
+   d_fine_boundary_represents_var(fine_boundary_represents_var)
+{
+}
+#endif
+
 template<class TYPE>
 FaceVariable<TYPE>::~FaceVariable()
 {

--- a/source/SAMRAI/pdat/FaceVariable.h
+++ b/source/SAMRAI/pdat/FaceVariable.h
@@ -60,6 +60,19 @@ public:
       int depth = 1,
       bool fine_boundary_represents_var = true);
 
+#ifdef HAVE_UMPIRE
+   /*!
+    * @brief Constructor that also includes an Umpire allocator for
+    * allocations of the underlying data.
+    */
+   FaceVariable(
+      const tbox::Dimension& dim,
+      const std::string& name,
+      umpire::Allocator allocator,
+      int depth = 1,
+      bool fine_boundary_represents_var = true);
+#endif
+
    /*!
     * @brief Virtual destructor for face variable objects.
     */

--- a/source/SAMRAI/pdat/NodeVariable.C
+++ b/source/SAMRAI/pdat/NodeVariable.C
@@ -44,6 +44,27 @@ NodeVariable<TYPE>::NodeVariable(
 {
 }
 
+#ifdef HAVE_UMPIRE
+template<class TYPE>
+NodeVariable<TYPE>::NodeVariable(
+   const tbox::Dimension& dim,
+   const std::string& name,
+   umpire::Allocator allocator,
+   int depth,
+   bool fine_boundary_represents_var):
+   hier::Variable(name,
+                  std::make_shared<NodeDataFactory<TYPE> >(
+                     depth,
+                     // default zero ghost cells
+                     hier::IntVector::getZero(dim),
+                     fine_boundary_represents_var,
+                     allocator)),
+
+   d_fine_boundary_represents_var(fine_boundary_represents_var)
+{
+}
+#endif
+
 template<class TYPE>
 NodeVariable<TYPE>::~NodeVariable()
 {

--- a/source/SAMRAI/pdat/NodeVariable.h
+++ b/source/SAMRAI/pdat/NodeVariable.h
@@ -40,8 +40,8 @@ class NodeVariable:public hier::Variable
 {
 public:
    /*!
-    * @brief Create a cell-centered variable object with the given name and
-    * depth (i.e., number of data values at each cell index location).
+    * @brief Create a node-centered variable object with the given name and
+    * depth (i.e., number of data values at each node index location).
     * A default depth of one is provided.  The fine boundary representation
     * boolean argument indicates which values (either coarse or fine) take
     * precedence at coarse-fine mesh boundaries during coarsen and refine
@@ -53,6 +53,19 @@ public:
       const std::string& name,
       int depth = 1,
       bool fine_boundary_represents_var = true);
+
+#ifdef HAVE_UMPIRE
+   /*!
+    * @brief Constructor that also includes an Umpire allocator for
+    * allocations of the underlying data.
+    */
+   NodeVariable(
+      const tbox::Dimension& dim,
+      const std::string& name,
+      umpire::Allocator allocator,
+      int depth = 1,
+      bool fine_boundary_represents_var = true);
+#endif
 
    /*!
     * @brief Virtual destructor for node variable objects.

--- a/source/SAMRAI/pdat/OuterfaceVariable.C
+++ b/source/SAMRAI/pdat/OuterfaceVariable.C
@@ -37,6 +37,20 @@ OuterfaceVariable<TYPE>::OuterfaceVariable(
 {
 }
 
+#ifdef HAVE_UMPIRE
+template<class TYPE>
+OuterfaceVariable<TYPE>::OuterfaceVariable(
+   const tbox::Dimension& dim,
+   const std::string& name,
+   umpire::Allocator allocator,
+   int depth):
+   hier::Variable(name,
+                  std::make_shared<OuterfaceDataFactory<TYPE> >(
+                     dim, depth, allocator))
+{
+}
+#endif
+
 template<class TYPE>
 OuterfaceVariable<TYPE>::~OuterfaceVariable()
 {

--- a/source/SAMRAI/pdat/OuterfaceVariable.h
+++ b/source/SAMRAI/pdat/OuterfaceVariable.h
@@ -59,6 +59,18 @@ public:
       const std::string& name,
       int depth = 1);
 
+#ifdef HAVE_UMPIRE
+   /*!
+    * @brief Constructor that also includes an Umpire allocator for
+    * allocations of the underlying data.
+    */
+   OuterfaceVariable(
+      const tbox::Dimension& dim,
+      const std::string& name,
+      umpire::Allocator allocator,
+      int depth = 1);
+#endif
+
    /*!
     * @brief Virtual destructor for outerface variable objects.
     */

--- a/source/SAMRAI/pdat/OutersideData.C
+++ b/source/SAMRAI/pdat/OutersideData.C
@@ -74,10 +74,10 @@ OutersideData<TYPE>::OutersideData(
       const hier::Box& ghosts = getGhostBox();
       const hier::Box sidebox = SideGeometry::toSideBox(ghosts, d);
       hier::Box outersidebox = sidebox;
-      outersidebox.setUpper(0, sidebox.lower(0));
+      outersidebox.setUpper(d, sidebox.lower(d));
       d_data[d][0].reset(new ArrayData<TYPE>(outersidebox, depth,allocator));
-      outersidebox.setLower(0, sidebox.upper(0));
-      outersidebox.setUpper(0, sidebox.upper(0));
+      outersidebox.setLower(d, sidebox.upper(d));
+      outersidebox.setUpper(d, sidebox.upper(d));
       d_data[d][1].reset(new ArrayData<TYPE>(outersidebox, depth,allocator));
    }
 }

--- a/source/SAMRAI/pdat/OutersideVariable.C
+++ b/source/SAMRAI/pdat/OutersideVariable.C
@@ -37,6 +37,21 @@ OutersideVariable<TYPE>::OutersideVariable(
 {
 }
 
+#ifdef HAVE_UMPIRE
+template<class TYPE>
+OutersideVariable<TYPE>::OutersideVariable(
+   const tbox::Dimension& dim,
+   const std::string& name,
+   umpire::Allocator allocator,
+   int depth):
+   hier::Variable(name,
+                  std::make_shared<OutersideDataFactory<TYPE> >(dim,
+                                                                depth,
+                                                                allocator))
+{
+}
+#endif
+
 template<class TYPE>
 OutersideVariable<TYPE>::~OutersideVariable()
 {

--- a/source/SAMRAI/pdat/OutersideVariable.h
+++ b/source/SAMRAI/pdat/OutersideVariable.h
@@ -59,6 +59,18 @@ public:
       const std::string& name,
       int depth = 1);
 
+#ifdef HAVE_UMPIRE
+   /*!
+    * @brief Constructor that also includes an Umpire allocator for
+    * allocations of the underlying data.
+    */
+   OutersideVariable(
+      const tbox::Dimension& dim,
+      const std::string& name,
+      umpire::Allocator allocator,
+      int depth = 1);
+#endif
+
    /*!
     * @brief Virtual destructor for outerside variable objects.
     */

--- a/source/SAMRAI/pdat/SideVariable.C
+++ b/source/SAMRAI/pdat/SideVariable.C
@@ -65,6 +65,51 @@ SideVariable<TYPE>::SideVariable(
 {
 }
 
+#ifdef HAVE_UMPIRE
+template<class TYPE>
+SideVariable<TYPE>::SideVariable(
+   const tbox::Dimension& dim,
+   const std::string& name,
+   const hier::IntVector& directions,
+   umpire::Allocator allocator,
+   int depth,
+   bool fine_boundary_represents_var):
+   hier::Variable(name,
+                  std::make_shared<SideDataFactory<TYPE> >(
+                     depth,
+                     // default zero ghost cells
+                     hier::IntVector::getZero(dim),
+                     fine_boundary_represents_var,
+                     directions,
+                     allocator)),
+   d_fine_boundary_represents_var(fine_boundary_represents_var),
+   d_directions(directions)
+{
+   TBOX_ASSERT(directions.getDim() == getDim());
+}
+
+template<class TYPE>
+SideVariable<TYPE>::SideVariable(
+   const tbox::Dimension& dim,
+   const std::string& name,
+   umpire::Allocator allocator,
+   int depth,
+   bool fine_boundary_represents_var):
+   hier::Variable(name,
+                  std::make_shared<SideDataFactory<TYPE> >(
+                     depth,
+                     // default zero ghost cells
+                     hier::IntVector::getZero(dim),
+                     fine_boundary_represents_var,
+                     hier::IntVector::getOne(dim),
+                     allocator)),
+   d_fine_boundary_represents_var(fine_boundary_represents_var),
+   d_directions(hier::IntVector::getOne(dim))
+{
+}
+#endif
+
+
 template<class TYPE>
 SideVariable<TYPE>::~SideVariable()
 {

--- a/source/SAMRAI/pdat/SideVariable.h
+++ b/source/SAMRAI/pdat/SideVariable.h
@@ -78,6 +78,32 @@ public:
       int depth = 1,
       bool fine_boundary_represents_var = true);
 
+#ifdef HAVE_UMPIRE
+   /*!
+    * @brief Constructor with directions vector and  an Umpire allocator for
+    * allocations of the underlying data.
+    */
+   SideVariable(
+      const tbox::Dimension& dim,
+      const std::string& name,
+      const hier::IntVector& directions,
+      umpire::Allocator allocator,
+      int depth = 1,
+      bool fine_boundary_represents_var = true);
+
+   /*!
+    * @brief Constructor that asumes all coordinate directions are used and
+    * also includes an Umpire allocator for allocations of the underlying
+    * data.
+    */
+   SideVariable(
+      const tbox::Dimension& dim,
+      const std::string& name,
+      umpire::Allocator allocator,
+      int depth = 1,
+      bool fine_boundary_represents_var = true);
+#endif
+
    /*!
     * @brief Virtual destructor for side variable objects.
     */

--- a/source/SAMRAI/solv/CartesianRobinBcHelper.C
+++ b/source/SAMRAI/solv/CartesianRobinBcHelper.C
@@ -96,6 +96,10 @@ CartesianRobinBcHelper::CartesianRobinBcHelper(
 
    NULL_USE(coef_strategy);
 
+#ifdef HAVE_UMPIRE
+   d_allocator = umpire::ResourceManager::getInstance().getAllocator("samrai::data_allocator");
+#endif
+
    t_set_boundary_values_in_cells = tbox::TimerManager::getManager()->
       getTimer("solv::CartesianRobinBcHelper::setBoundaryValuesInCells()");
    t_use_set_bc_coefs = tbox::TimerManager::getManager()->
@@ -229,12 +233,24 @@ CartesianRobinBcHelper::setBoundaryValuesInCells(
          const hier::Index& upper = boundary_box.getBox().upper();
          const hier::Box coefbox = makeFaceBoundaryBox(boundary_box);
          std::shared_ptr<pdat::ArrayData<double> > acoef_data(
-            std::make_shared<pdat::ArrayData<double> >(coefbox, 1));
+            std::make_shared<pdat::ArrayData<double> >(coefbox, 1
+#ifdef HAVE_UMPIRE
+                                                       , d_allocator
+#endif
+                                                       ));
          std::shared_ptr<pdat::ArrayData<double> > bcoef_data(
-            std::make_shared<pdat::ArrayData<double> >(coefbox, 1));
+            std::make_shared<pdat::ArrayData<double> >(coefbox, 1
+#ifdef HAVE_UMPIRE
+                                                       , d_allocator
+#endif
+                                                       ));
          std::shared_ptr<pdat::ArrayData<double> > gcoef_data(
             homogeneous_bc ? 0 :
-            new pdat::ArrayData<double>(coefbox, 1));
+            new pdat::ArrayData<double>(coefbox, 1
+#ifdef HAVE_UMPIRE
+                                        , d_allocator
+#endif
+                                        ));
          t_use_set_bc_coefs->start();
          d_coef_strategy->setBcCoefs(acoef_data,
             bcoef_data,

--- a/source/SAMRAI/solv/CartesianRobinBcHelper.h
+++ b/source/SAMRAI/solv/CartesianRobinBcHelper.h
@@ -460,6 +460,13 @@ private:
     */
    bool d_homogeneous_bc;
 
+#ifdef HAVE_UMPIRE
+   /*!
+    * Umpire allocator for internal temporary data.
+    */
+   umpire::Allocator d_allocator;
+#endif
+
    /*!
     * @brief Timers for performance measurement.
     */

--- a/source/SAMRAI/solv/CellPoissonFACOps.C
+++ b/source/SAMRAI/solv/CellPoissonFACOps.C
@@ -565,6 +565,9 @@ CellPoissonFACOps::CellPoissonFACOps(
    d_coarse_solver_max_iterations(20),
    d_residual_tolerance_during_smoothing(-1.0),
    d_flux_id(-1),
+#ifdef HAVE_UMPIRE
+   d_allocator(umpire::ResourceManager::getInstance().getAllocator("samrai::data_allocator")),
+#endif
    d_hypre_solver(hypre_solver),
    d_physical_bc_coef(0),
    d_context(hier::VariableDatabase::getDatabase()->getContext(
@@ -595,6 +598,9 @@ CellPoissonFACOps::CellPoissonFACOps(
    d_coarse_solver_max_iterations(500),
    d_residual_tolerance_during_smoothing(-1.0),
    d_flux_id(-1),
+#ifdef HAVE_UMPIRE
+   d_allocator(umpire::ResourceManager::getInstance().getAllocator("samrai::data_allocator")),
+#endif
    d_physical_bc_coef(0),
    d_context(hier::VariableDatabase::getDatabase()->getContext(
                 object_name + "::PRIVATE_CONTEXT")),
@@ -642,16 +648,28 @@ CellPoissonFACOps::buildObject(
       std::ostringstream ss;
       ss << "CellPoissonFACOps::private_cell_scratch" << d_dim.getValue();
       s_cell_scratch_var[d_dim.getValue() - 1].reset(
-         new pdat::CellVariable<double>(d_dim, ss.str()));
+         new pdat::CellVariable<double>(d_dim, ss.str()
+#ifdef HAVE_UMPIRE
+                                        , d_allocator
+#endif
+                                        ));
       ss.str("");
       ss << "CellPoissonFACOps::private_flux_scratch" << d_dim.getValue();
       s_flux_scratch_var[d_dim.getValue() - 1].reset(
          new pdat::SideVariable<double>(d_dim, ss.str(),
-            hier::IntVector::getOne(d_dim)));
+                                        hier::IntVector::getOne(d_dim)
+#ifdef HAVE_UMPIRE
+                                        , d_allocator
+#endif
+                                        ));
       ss.str("");
       ss << "CellPoissonFACOps::private_oflux_scratch" << d_dim.getValue();
       s_oflux_scratch_var[d_dim.getValue() - 1].reset(
-         new pdat::OutersideVariable<double>(d_dim, ss.str()));
+         new pdat::OutersideVariable<double>(d_dim, ss.str()
+#ifdef HAVE_UMPIRE
+                                             , d_allocator
+#endif
+                                             ));
    }
 
    /*

--- a/source/SAMRAI/solv/CellPoissonFACOps.h
+++ b/source/SAMRAI/solv/CellPoissonFACOps.h
@@ -887,6 +887,13 @@ private:
     */
    int d_flux_id;
 
+#ifdef HAVE_UMPIRE
+   /*!
+    * Umpire Allocator for internal data allocations
+    */
+   umpire::Allocator d_allocator;
+#endif
+
 #ifdef HAVE_HYPRE
    /*!
     * @brief HYPRE coarse-level solver object.

--- a/source/SAMRAI/solv/CellPoissonFACSolver.C
+++ b/source/SAMRAI/solv/CellPoissonFACSolver.C
@@ -78,6 +78,12 @@ CellPoissonFACSolver::CellPoissonFACSolver(
    // Read user input.
    getFromInput(input_db);
 
+#ifdef HAVE_UMPIRE
+   umpire::Allocator allocator =
+      umpire::ResourceManager::getInstance().getAllocator(
+         "samrai::data_allocator");
+#endif
+
    /*
     * Construct integer tag variables and add to variable database.  Note that
     * variables and patch data indices are shared among all instances.
@@ -95,7 +101,11 @@ CellPoissonFACSolver::CellPoissonFACSolver(
          var_db->getVariable(weight_variable_name)));
    if (!weight) {
       weight.reset(
-         new pdat::CellVariable<double>(d_dim, weight_variable_name, 1));
+         new pdat::CellVariable<double>(d_dim, weight_variable_name
+#ifdef HAVE_UMPIRE
+                                        , allocator
+#endif
+                                        ));
    }
 
    if (s_weight_id[d_dim.getValue() - 1] < 0) {

--- a/source/SAMRAI/solv/CellPoissonHypreSolver.h
+++ b/source/SAMRAI/solv/CellPoissonHypreSolver.h
@@ -691,6 +691,10 @@ private:
     */
    bool d_use_smg;
 
+#ifdef HAVE_UMPIRE
+   umpire::Allocator d_allocator;
+#endif
+
    //@{
    //! @name Hypre object
    //! @brief HYPRE grid

--- a/source/SAMRAI/solv/SimpleCellRobinBcCoefs.C
+++ b/source/SAMRAI/solv/SimpleCellRobinBcCoefs.C
@@ -519,6 +519,13 @@ SimpleCellRobinBcCoefs::cacheDirichletData(
                        << "caching boundary ghost cell data.\n");
    }
 #endif
+
+#ifdef HAVE_UMPIRE
+   umpire::Allocator allocator =
+      umpire::ResourceManager::getInstance().getAllocator(
+         "samrai::data_allocator");
+#endif
+
    d_dirichlet_data.clear();
    d_dirichlet_data_pos.clear();
    int ln, bn, position, n_reqd_boxes = 0;
@@ -569,7 +576,11 @@ SimpleCellRobinBcCoefs::cacheDirichletData(
             position = d_dirichlet_data_pos[ln][box_id] + bn;
             hier::Box databox = makeSideBoundaryBox(bdry_box);
             d_dirichlet_data[position].reset(
-               new pdat::ArrayData<double>(databox, 1));
+               new pdat::ArrayData<double>(databox, 1
+#ifdef HAVE_UMPIRE
+                                           , allocator
+#endif
+                                           ));
             pdat::ArrayData<double>& array_data = *d_dirichlet_data[position];
             hier::IntVector shift_amount(d_dim, 0);
             const int location_index = bdry_box.getLocationIndex();

--- a/source/test/FAC_adaptive/AdaptivePoisson.C
+++ b/source/test/FAC_adaptive/AdaptivePoisson.C
@@ -68,21 +68,58 @@ AdaptivePoisson::AdaptivePoisson(
    d_dim(dim),
    d_fac_ops(fac_ops),
    d_fac_preconditioner(fac_precond),
+#ifdef HAVE_UMPIRE
+   d_allocator(umpire::ResourceManager::getInstance().getAllocator("samrai::data_allocator")),
+#endif
    d_context_persistent(new hier::VariableContext("PERSISTENT")),
    d_context_scratch(new hier::VariableContext("SCRATCH")),
    d_diffcoef(new pdat::SideVariable<double>(d_dim, "solution:diffcoef",
-                                             hier::IntVector::getOne(d_dim), 1)),
+                                             hier::IntVector::getOne(d_dim)
+#ifdef HAVE_UMPIRE
+                                             , d_allocator
+#endif
+                                             )),
    d_flux(new pdat::SideVariable<double>(d_dim, "flux",
-                                         hier::IntVector::getOne(d_dim), 1)),
-   d_scalar(new pdat::CellVariable<double>(d_dim, "solution:scalar", 1)),
-   d_constant_source(new pdat::CellVariable<double>(
-                        d_dim, "poisson source", 1)),
-   d_ccoef(new pdat::CellVariable<double>(
-              d_dim, "linear source coefficient", 1)),
-   d_rhs(new pdat::CellVariable<double>(d_dim, "linear system rhs", 1)),
-   d_exact(new pdat::CellVariable<double>(d_dim, "solution:exact", 1)),
-   d_resid(new pdat::CellVariable<double>(d_dim, object_name + "residual")),
-   d_weight(new pdat::CellVariable<double>(d_dim, "vector weight", 1)),
+                                         hier::IntVector::getOne(d_dim)
+#ifdef HAVE_UMPIRE
+                                         , d_allocator
+#endif
+                                         )),
+   d_scalar(new pdat::CellVariable<double>(d_dim, "solution:scalar"
+#ifdef HAVE_UMPIRE
+                                           , d_allocator
+#endif
+                                           )),
+   d_constant_source(new pdat::CellVariable<double>(d_dim, "poisson source"
+#ifdef HAVE_UMPIRE
+                                                    , d_allocator
+#endif
+                                                    )),
+   d_ccoef(new pdat::CellVariable<double>(d_dim, "linear source coefficient"
+#ifdef HAVE_UMPIRE
+                                          , d_allocator
+#endif
+                                          )),
+   d_rhs(new pdat::CellVariable<double>(d_dim, "linear system rhs"
+#ifdef HAVE_UMPIRE
+                                        , d_allocator
+#endif
+                                        )),
+   d_exact(new pdat::CellVariable<double>(d_dim, "solution:exact"
+#ifdef HAVE_UMPIRE
+                                          , d_allocator
+#endif
+                                          )),
+   d_resid(new pdat::CellVariable<double>(d_dim, object_name + "residual"
+#ifdef HAVE_UMPIRE
+                                          , d_allocator
+#endif
+                                          )),
+   d_weight(new pdat::CellVariable<double>(d_dim, "vector weight"
+#ifdef HAVE_UMPIRE
+                                           , d_allocator
+#endif
+                                           )),
    d_lstream(log_stream),
    d_problem_name("sine"),
    d_sps(object_name + "Poisson solver specifications"),
@@ -501,7 +538,11 @@ void AdaptivePoisson::applyGradientDetector(
       pdat::CellData<int>& tag_cell_data = *tag_cell_data_;
       pdat::CellData<double> estimate_data(patch.getBox(),
                                            1,
-                                           hier::IntVector(d_dim, 0));
+                                           hier::IntVector(d_dim, 0)
+#ifdef HAVE_UMPIRE
+ ,     tbox::AllocatorDatabase::getDatabase()->getTagAllocator()
+#endif
+                                           );
       computeAdaptionEstimate(estimate_data,
          soln_cell_data);
       tag_cell_data.fill(0);

--- a/source/test/FAC_adaptive/AdaptivePoisson.h
+++ b/source/test/FAC_adaptive/AdaptivePoisson.h
@@ -234,6 +234,10 @@ private:
 
    //@}
 
+#ifdef HAVE_UMPIRE
+   umpire::Allocator d_allocator;
+#endif
+
    //@{
 
    /*!

--- a/source/test/FAC_staticrefinement/FACPoisson.C
+++ b/source/test/FAC_staticrefinement/FACPoisson.C
@@ -70,6 +70,12 @@ FACPoisson::FACPoisson(
     */
    d_context = vdb->getContext(d_object_name + ":Context");
 
+#ifdef HAVE_UMPIRE
+   umpire::Allocator allocator =
+      umpire::ResourceManager::getInstance().getAllocator(
+         "samrai::data_allocator");
+#endif
+
    /*
     * Register variables with hier::VariableDatabase
     * and get the descriptor indices for those variables.
@@ -78,8 +84,11 @@ FACPoisson::FACPoisson(
    std::shared_ptr<pdat::CellVariable<double> > comp_soln(
       new pdat::CellVariable<double>(
          dim,
-         object_name + ":computed solution",
-         1));
+         object_name + ":computed solution"
+#ifdef HAVE_UMPIRE
+         , allocator
+#endif
+         ));
    d_comp_soln_id =
       vdb->registerVariableAndContext(
          comp_soln,
@@ -89,7 +98,11 @@ FACPoisson::FACPoisson(
    std::shared_ptr<pdat::CellVariable<double> > exact_solution(
       new pdat::CellVariable<double>(
          dim,
-         object_name + ":exact solution"));
+         object_name + ":exact solution"
+#ifdef HAVE_UMPIRE
+         , allocator
+#endif   
+         ));
    d_exact_id =
       vdb->registerVariableAndContext(
          exact_solution,
@@ -100,7 +113,11 @@ FACPoisson::FACPoisson(
       new pdat::CellVariable<double>(
          dim,
          object_name
-         + ":linear system right hand side"));
+         + ":linear system right hand side"
+#ifdef HAVE_UMPIRE
+         , allocator
+#endif   
+         ));
    d_rhs_id =
       vdb->registerVariableAndContext(
          rhs_variable,

--- a/source/test/nonlinear/ModifiedBratuProblem.C
+++ b/source/test/nonlinear/ModifiedBratuProblem.C
@@ -123,33 +123,80 @@ ModifiedBratuProblem::ModifiedBratuProblem(
    d_grid_geometry(grid_geometry),
    d_lambda(tbox::MathUtilities<double>::getSignalingNaN()),
    d_input_dt(tbox::MathUtilities<double>::getSignalingNaN()),
+#ifdef HAVE_UMPIRE
+   d_allocator(umpire::ResourceManager::getInstance().getAllocator("samrai::data_allocator")),
+#endif
    d_solution(new pdat::CellVariable<double>(
-                 dim, object_name + "solution", 1)),
+                 dim, object_name + "solution"
+#ifdef HAVE_UMPIRE
+                 , d_allocator
+#endif
+              )),
    d_source_term(new pdat::CellVariable<double>(
-                    dim, object_name + "source_term", 1)),
+                    dim, object_name + "source_term"
+#ifdef HAVE_UMPIRE
+                    , d_allocator
+#endif
+                 )),
    d_exponential_term(new pdat::CellVariable<double>(
-                         dim, object_name + "exponential_term", 1)),
+                         dim, object_name + "exponential_term"
+#ifdef HAVE_UMPIRE
+                         , d_allocator
+#endif
+                      )),
    d_diffusion_coef(new pdat::SideVariable<double>(
-                       dim, object_name + "diffusion_coef", hier::IntVector::getOne(dim), 1)),
+                       dim, object_name + "diffusion_coef", hier::IntVector::getOne(dim)
+#ifdef HAVE_UMPIRE
+                       , d_allocator
+#endif
+                    )),
    d_flux(new pdat::SideVariable<double>(
-             dim, object_name + "flux", hier::IntVector::getOne(dim), 1)),
+             dim, object_name + "flux", hier::IntVector::getOne(dim)
+#ifdef HAVE_UMPIRE
+             , d_allocator
+#endif
+          )),
    d_coarse_fine_flux(new pdat::OutersideVariable<double>(
-                         dim, object_name + "coarse_fine_flux", 1)),
+                         dim, object_name + "coarse_fine_flux"
+#ifdef HAVE_UMPIRE
+                         , d_allocator
+#endif
+                      )),
    d_jacobian_a(new pdat::CellVariable<double>(
-                   dim, object_name + ":jacobian_a", 1)),
+                   dim, object_name + ":jacobian_a"
+#ifdef HAVE_UMPIRE
+                   , d_allocator
+#endif
+                )),
    d_jacobian_b(new pdat::FaceVariable<double>(
-                   dim, object_name + ":jacobian_b", 1)),
+                   dim, object_name + ":jacobian_b"
+#ifdef HAVE_UMPIRE
+                   , d_allocator
+#endif
+                )),
    d_jacobian_a_id(-1),
    d_jacobian_b_id(-1),
    d_precond_a(new pdat::CellVariable<double>(
-                  dim, object_name + "precond_a", 1)),
+                  dim, object_name + "precond_a"
+#ifdef HAVE_UMPIRE
+                  , d_allocator
+#endif
+               )),
    d_precond_b(new pdat::FaceVariable<double>(
-                  dim, object_name + "precond_b", 1)),
+                  dim, object_name + "precond_b"
+#ifdef HAVE_UMPIRE
+                  , d_allocator
+#endif
+               )),
    d_precond_a_id(-1),
    d_precond_b_id(-1),
    d_nghosts(hier::IntVector(dim, NUM_GHOSTS_U)),
    d_weight(new pdat::CellVariable<double>(
-               dim, object_name + "weight", 1)),
+               dim, object_name + "weight"
+#ifdef HAVE_UMPIRE
+                 , d_allocator
+#endif
+, 1)),
    d_fill_new_level(),
    d_soln_fill(),
    d_flux_coarsen(dim),

--- a/source/test/nonlinear/ModifiedBratuProblem.h
+++ b/source/test/nonlinear/ModifiedBratuProblem.h
@@ -516,6 +516,10 @@ private:
    double d_lambda;      // factor multiplying exponential term
    double d_input_dt;    // time increment
 
+#ifdef HAVE_UMPIRE
+   umpire::Allocator d_allocator;
+#endif
+
    /*
     * *hier::Variable data management.
     *

--- a/source/test/sundials/CVODEModel.C
+++ b/source/test/sundials/CVODEModel.C
@@ -110,7 +110,14 @@ CVODEModel::CVODEModel(
    CoarsenPatchStrategy(),
    d_object_name(object_name),
    d_dim(dim),
-   d_soln_var(new CellVariable<double>(dim, "soln", 1)),
+#ifdef HAVE_UMPIRE
+   d_allocator(umpire::ResourceManager::getInstance().getAllocator("samrai::data_allocator")),
+#endif
+   d_soln_var(new CellVariable<double>(dim, "soln"
+#ifdef HAVE_UMPIRE
+                                       , d_allocator
+#endif
+                                       )),
    d_FAC_solver(fac_solver),
    d_grid_geometry(grid_geom)
 {
@@ -130,7 +137,11 @@ CVODEModel::CVODEModel(
          IntVector(d_dim, 1));
 #ifdef USE_FAC_PRECONDITIONER
    d_diff_var.reset(new SideVariable<double>(d_dim, "diffusion",
-         hier::IntVector::getOne(d_dim), 1));
+         hier::IntVector::getOne(d_dim)
+#ifdef HAVE_UMPIRE
+         , d_allocator
+#endif
+         ));
 
    d_diff_id = variable_db->registerVariableAndContext(d_diff_var,
          d_cur_cxt,
@@ -215,11 +226,19 @@ CVODEModel::CVODEModel(
     * Construct outerface variable to hold boundary flags and Neumann fluxes.
     */
    if (d_use_neumann_bcs) {
-      d_flag_var.reset(new OuterfaceVariable<int>(d_dim, "bdryflag", 1));
+      d_flag_var.reset(new OuterfaceVariable<int>(d_dim, "bdryflag"
+#ifdef HAVE_UMPIRE
+                                                  , d_allocator
+#endif
+                                                  ));
       d_flag_id = variable_db->registerVariableAndContext(d_flag_var,
             d_cur_cxt,
             IntVector(d_dim, 0));
-      d_neuf_var.reset(new OuterfaceVariable<double>(d_dim, "neuflux", 1));
+      d_neuf_var.reset(new OuterfaceVariable<double>(d_dim, "neuflux"
+#ifdef HAVE_UMPIRE
+                                                     , d_allocator
+#endif
+                                                     ));
       d_neuf_id = variable_db->registerVariableAndContext(d_neuf_var,
             d_cur_cxt,
             IntVector(d_dim, 0));

--- a/source/test/sundials/CVODEModel.h
+++ b/source/test/sundials/CVODEModel.h
@@ -532,6 +532,10 @@ private:
     */
    SundialsAbstractVector* d_solution_vector;
 
+#ifdef HAVE_UMPIRE
+   umpire::Allocator d_allocator;
+#endif
+
    /*
     * Variables
     */

--- a/source/test/vector/kvtest.C
+++ b/source/test/vector/kvtest.C
@@ -194,6 +194,12 @@ int main(
       hierarchy->makeNewPatchLevel(0, layer0);
       hierarchy->makeNewPatchLevel(1, layer1);
 
+#ifdef HAVE_UMPIRE
+      umpire::Allocator allocator =
+         umpire::ResourceManager::getInstance().getAllocator(
+            "samrai::data_allocator");
+#endif
+
       // Create instance of hier::Variable database
       hier::VariableDatabase* variable_db = hier::VariableDatabase::getDatabase();
       std::shared_ptr<hier::VariableContext> dummy(
@@ -203,49 +209,93 @@ int main(
       // Make some dummy variables and data on the hierarchy
       std::shared_ptr<pdat::CellVariable<double> > cvar[NCELL_VARS];
       int cvindx[NCELL_VARS];
-      cvar[0].reset(new pdat::CellVariable<double>(dim3d, "cvar0", 2));
+      cvar[0].reset(new pdat::CellVariable<double>(dim3d, "cvar0",
+#ifdef HAVE_UMPIRE
+                                                   allocator,
+#endif
+                                                   2));
       cvindx[0] = variable_db->registerVariableAndContext(
             cvar[0], dummy, no_ghosts);
-      cvar[1].reset(new pdat::CellVariable<double>(dim3d, "cvar1", 2));
+      cvar[1].reset(new pdat::CellVariable<double>(dim3d, "cvar1",
+#ifdef HAVE_UMPIRE
+                                                   allocator,
+#endif
+                                                   2));
       cvindx[1] = variable_db->registerVariableAndContext(
             cvar[1], dummy, no_ghosts);
 
       std::shared_ptr<pdat::CellVariable<double> > cwgt(
-         new pdat::CellVariable<double>(dim3d, "cwgt", 1));
+         new pdat::CellVariable<double>(dim3d, "cwgt",
+#ifdef HAVE_UMPIRE
+                                        allocator,
+#endif
+                                        1));
       int cwgt_id = variable_db->registerVariableAndContext(
             cwgt, dummy, no_ghosts);
 
       std::shared_ptr<pdat::FaceVariable<double> > fvar[NFACE_VARS];
       int fvindx[NFACE_VARS];
-      fvar[0].reset(new pdat::FaceVariable<double>(dim3d, "fvar0", 1));
+      fvar[0].reset(new pdat::FaceVariable<double>(dim3d, "fvar0",
+#ifdef HAVE_UMPIRE
+                                                   allocator,
+#endif
+                                                   1));
       fvindx[0] = variable_db->registerVariableAndContext(
             fvar[0], dummy, no_ghosts);
-      fvar[1].reset(new pdat::FaceVariable<double>(dim3d, "fvar1", 1));
+      fvar[1].reset(new pdat::FaceVariable<double>(dim3d, "fvar1",
+#ifdef HAVE_UMPIRE
+                                                   allocator,
+#endif
+                                                   1));
       fvindx[1] = variable_db->registerVariableAndContext(
             fvar[1], dummy, no_ghosts);
 
       std::shared_ptr<pdat::FaceVariable<double> > fwgt(
-         new pdat::FaceVariable<double>(dim3d, "fwgt", 1));
+         new pdat::FaceVariable<double>(dim3d, "fwgt",
+#ifdef HAVE_UMPIRE
+                                        allocator,
+#endif
+                                        1));
       int fwgt_id = variable_db->registerVariableAndContext(
             fwgt, dummy, no_ghosts);
 
       std::shared_ptr<pdat::NodeVariable<double> > nvar[NNODE_VARS];
       int nvindx[NNODE_VARS];
-      nvar[0].reset(new pdat::NodeVariable<double>(dim3d, "nvar0", 1));
+      nvar[0].reset(new pdat::NodeVariable<double>(dim3d, "nvar0",
+#ifdef HAVE_UMPIRE
+                                                   allocator,
+#endif
+                                                   1));
       nvindx[0] = variable_db->registerVariableAndContext(
             nvar[0], dummy, no_ghosts);
-      nvar[1].reset(new pdat::NodeVariable<double>(dim3d, "nvar1", 1));
+      nvar[1].reset(new pdat::NodeVariable<double>(dim3d, "nvar1",
+#ifdef HAVE_UMPIRE
+                                                   allocator,
+#endif
+                                                   1));
       nvindx[1] = variable_db->registerVariableAndContext(
             nvar[1], dummy, no_ghosts);
-      nvar[2].reset(new pdat::NodeVariable<double>(dim3d, "nvar2", 1));
+      nvar[2].reset(new pdat::NodeVariable<double>(dim3d, "nvar2",
+#ifdef HAVE_UMPIRE
+                                                   allocator,
+#endif
+                                         1));
       nvindx[2] = variable_db->registerVariableAndContext(
             nvar[2], dummy, no_ghosts);
-      nvar[3].reset(new pdat::NodeVariable<double>(dim3d, "nvar3", 1));
+      nvar[3].reset(new pdat::NodeVariable<double>(dim3d, "nvar3",
+#ifdef HAVE_UMPIRE
+                                                   allocator,
+#endif
+                                         1));
       nvindx[3] = variable_db->registerVariableAndContext(
             nvar[3], dummy, no_ghosts);
 
       std::shared_ptr<pdat::NodeVariable<double> > nwgt(
-         new pdat::NodeVariable<double>(dim3d, "nwgt", 1));
+         new pdat::NodeVariable<double>(dim3d, "nwgt",
+#ifdef HAVE_UMPIRE
+                                        allocator,
+#endif
+                                        1));
       int nwgt_id = variable_db->registerVariableAndContext(
             nwgt, dummy, no_ghosts);
 


### PR DESCRIPTION
Creates consistency between persistent and temporary data.  Next step is to provide flexibility to specify the allocator rather than using a default.