### PR TITLE
Remove tag_to_fine ptr from a private method that didn't use it.

### DIFF
--- a/source/SAMRAI/mesh/GriddingAlgorithm.C
+++ b/source/SAMRAI/mesh/GriddingAlgorithm.C
@@ -1390,7 +1390,7 @@ GriddingAlgorithm::regridFinerLevel(
          /*
           * Tagging stuff have been factored out to shorten this method.
           */
-        RANGE_PUSH("doTaggingAfter", 3);
+         RANGE_PUSH("doTaggingAfter", 3);
          regridFinerLevel_doTaggingAfterRecursiveRegrid(
             tag_to_finer,
             tag_ln,
@@ -1476,7 +1476,6 @@ GriddingAlgorithm::regridFinerLevel(
             tag_ln,
             regrid_time,
             tag_to_new,
-            tag_to_finer,
             new_box_level);
 
          if (d_log_metadata_statistics) {
@@ -1797,12 +1796,8 @@ GriddingAlgorithm::regridFinerLevel_createAndInstallNewLevel(
    const int tag_ln,
    const double regrid_time,
    std::shared_ptr<hier::Connector>& tag_to_new,
-   std::shared_ptr<const hier::Connector> tag_to_finer,
    std::shared_ptr<hier::BoxLevel> new_box_level)
 {
-#ifndef DEBUG_CHECK_ASSERTIONS
-   NULL_USE(tag_to_finer);
-#endif
    TBOX_ASSERT(tag_to_new && tag_to_new->hasTranspose());
    TBOX_ASSERT(new_box_level);
 
@@ -1822,8 +1817,6 @@ GriddingAlgorithm::regridFinerLevel_createAndInstallNewLevel(
    const tbox::Dimension& dim = d_hierarchy->getDim();
 
    const int new_ln = tag_ln + 1;
-   TBOX_ASSERT(!d_hierarchy->levelExists(new_ln + 1) || tag_to_finer);
-   TBOX_ASSERT(!d_hierarchy->levelExists(new_ln + 1) || tag_to_finer->hasTranspose());
    const std::shared_ptr<hier::PatchLevel>& tag_level(
       d_hierarchy->getPatchLevel(tag_ln));
 

--- a/source/SAMRAI/mesh/GriddingAlgorithm.h
+++ b/source/SAMRAI/mesh/GriddingAlgorithm.h
@@ -607,15 +607,12 @@ private:
     *
     * @pre tag_to_new && tag_to_new->hasTranspose()
     * @pre new_box_level
-    * @pre !d_hierarchy->levelExists(tag_ln + 2) || tag_to_finer
-    * @pre !d_hierarchy->levelExists(tag_ln + 2) || tag_to_finer->hasTranspose()
     */
    void
    regridFinerLevel_createAndInstallNewLevel(
       const int tag_ln,
       const double regrid_time,
       std::shared_ptr<hier::Connector>& tag_to_new,
-      std::shared_ptr<const hier::Connector> tag_to_finer,
       std::shared_ptr<hier::BoxLevel> new_box_level);
 
    /*!


### PR DESCRIPTION
An assertion in a GriddingAlgorithm private member was testing that a pointer tag_to_finer that was passed as an argument was non-null. However, the pointer was never used in the method outside of the assertion so it didn't matter if it was null. This caused failures in certain cases that used "REFINE_BOXES" to set fixed refinement--those cases did not allocate the pointer and thus failed the assertion, but they also never needed to use the pointer, so the assertion failure was spurious.

This addresses issue #8