### PR TITLE
Add set allocator set method to AsyncCommPeer

### DIFF
--- a/source/SAMRAI/tbox/AsyncCommPeer.h
+++ b/source/SAMRAI/tbox/AsyncCommPeer.h
@@ -12,6 +12,7 @@
 
 #include "SAMRAI/SAMRAI_config.h"
 
+#include "SAMRAI/tbox/AllocatorDatabase.h"
 #include "SAMRAI/tbox/AsyncCommStage.h"
 #include "SAMRAI/tbox/SAMRAI_MPI.h"
 #include "SAMRAI/tbox/Timer.h"
@@ -215,6 +216,17 @@ public:
    {
       return d_mpi;
    }
+
+#ifdef HAVE_UMPIRE
+   /*!
+    * Set Umpire allocator for internal buffer allocations.
+    */
+   void
+   setAllocator(umpire::TypedAllocator<char> allocator)
+   {
+      d_allocator = allocator;
+   }
+#endif
 
    /*!
     * @brief Next task in a current communication operation.
@@ -628,6 +640,10 @@ private:
 
    // Make some temporary variable statuses to avoid repetitious allocations.
    int d_mpi_err;
+
+#ifdef HAVE_UMPIRE
+   umpire::TypedAllocator<char> d_allocator;
+#endif 
 
    std::shared_ptr<Timer> t_send_timer;
    std::shared_ptr<Timer> t_recv_timer;

--- a/source/SAMRAI/tbox/Schedule.C
+++ b/source/SAMRAI/tbox/Schedule.C
@@ -8,6 +8,7 @@
  *
  ************************************************************************/
 #include "SAMRAI/tbox/Schedule.h"
+#include "SAMRAI/tbox/AllocatorDatabase.h"
 #include "SAMRAI/tbox/InputManager.h"
 #include "SAMRAI/tbox/PIO.h"
 #include "SAMRAI/tbox/SAMRAIManager.h"
@@ -538,6 +539,9 @@ Schedule::allocateCommunicationObjects()
       d_coms[counter].setMPITag(d_first_tag, d_second_tag);
       d_coms[counter].setMPI(d_mpi);
       d_coms[counter].limitFirstDataLength(d_first_message_length);
+#ifdef HAVE_UMPIRE
+      d_coms[counter].setAllocator(AllocatorDatabase::getDatabase()->getStreamAllocator());
+#endif
       ++counter;
    }
    for (TransactionSets::iterator ti = d_send_sets.begin();
@@ -548,6 +552,9 @@ Schedule::allocateCommunicationObjects()
       d_coms[counter].setMPITag(d_first_tag, d_second_tag);
       d_coms[counter].setMPI(d_mpi);
       d_coms[counter].limitFirstDataLength(d_first_message_length);
+#ifdef HAVE_UMPIRE
+      d_coms[counter].setAllocator(AllocatorDatabase::getDatabase()->getStreamAllocator());
+#endif
       ++counter;
    }
 }


### PR DESCRIPTION
This is needed because of tbox::Schedule's usage of AsyncCommPeer and MessageStream.  We have promised that MessageStream will create buffers using the stream Allocator held in the AllocatorDatabase, which is a pinned memory allocator by default.  However, MessageStream can also be constructed to use an external buffer passed into the constructor, in which case the buffer could be anywhere and is not necessarily in pinned memory when we give the MessageStream to user code.

In particular, tbox::Schedule takes buffers created inside AsyncCommPeer and gives them to MessageStream as external buffers.  These buffers have been allocated as CPU host buffers, so the MessageStream is provided to user code holding a host buffer rather than a buffer associated with the stream Allocator's promised memory space.

This PR gives AsyncCommPeer an Allocator to hold and use for its internal buffer allocations, and the Allocator can be set by calling code using the setAllocator method.  tbox::Schedule gives its instances of AsyncCommPeer the stream Allocator, so that all buffers allocated in tbox::Schedule by the MessageStreams and AsyncCommPeers in tbox::Schedule use the same stream Allocator.