### PR TITLE
Add allocator set method to AsyncCommPeer

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -4,7 +4,7 @@
   All rights reserved.
 *****************************************************************************
 
-                     Release Notes for SAMRAI v4.0.2
+                     Release Notes for SAMRAI v4.0.3
 
      (notes for previous releases may be found in /SAMRAI/docs/release)
 
@@ -15,12 +15,11 @@ team by sending email to samrai@llnl.gov.
 
 *****************************************************************************
 
-VERSION 4.0.2
+VERSION 4.0.3
 
-Version 4.0.2 contains minor code changes to make SAMRAI compatible with
-RAJA version 0.12.1 and Umpire version 4.0.1.  No new features, bug fixes, nor
-API changes are introduced.  The remainder of these release notes reproduce
-the content of the release notes for SAMRAI versions 4.0.0 and 4.0.1.
+Version 4.0.3 is a minor release update.  This file reproduces to content of
+the release notes since 4.0.0, and new content for version 4.0.3 is
+specfically labeled.
 
 *****************************************************************************
 
@@ -57,6 +56,9 @@ configuration line have been fixed.
 on GPU architectures, using capabilities provided by the Umpire and RAJA
 libraries.
 
+2) NEW for v. 4.0.3 AsyncCommPeer has a new method to set an Umpire
+Allocator to be used for internal buffer allocations.
+ 
 
 -----------------------------------------------------------------------------
                 Summary of what's changed
@@ -66,6 +68,10 @@ libraries.
 uses CMake supplemented with the BLT macro library is the only supported build
 system.  (This change effective as of v. 3.15.0)
 
+2) NEW for v. 4.0.3 The number of threads launched by dimensional RAJA
+policies (Policy1D, Policy2D, Policy3D) for CUDA kernels in
+tbox::ExecutionPolicy have been set to a fixed value of 256,
+which is the product of the tile count in each dimensional direction.
 
 *****************************************************************************
 
@@ -120,6 +126,13 @@ thread-safe operation on the arrays.
 Configuration with Umpire and RAJA is optional, so all previous functionality
 using MPI parallelism is still available.
 
+2) NEW for v. 4.0.3 AsyncCommPeer has a new method to set an Umpire
+Allocator to be used for internal buffer allocations.  This is not likely
+to be directly used by users, but it enables some internal library
+changes which ensure that MessageStreams which are provided to user codes
+during execution of RefineSchedule and CoarsenSchedule operations contain
+buffers that are allocated by the stream Allocator from AllocatorDatabase.  
+
 
                 Details about what's changed
 ----------------------------------------------------------------------------
@@ -134,6 +147,20 @@ system are in the INSTALL-NOTES file.
 
 (This change effective as of v. 3.15.0)
 
+2) NEW for v. 4.0.3 The number of threads launched by dimensional RAJA 
+policies (Policy1D, Policy2D, Policy3D) for CUDA kernels in
+tbox::ExecutionPolicy have been set to a fixed value of 256,
+which is the product of the tile count in each dimensional direction.
+
+This change protects against compile errors that may occur involving
+functions inside of kernels having register counts greater than the number
+of threads.
+
+These policies are used by default in the hier::for_all looping structures
+defined in hier/ForAll.h.  hier::for_all is templated on the policy, so
+users who do not wish to used the policies from tbox::ExecutionPolicy may
+define their own policies and provide them to the hier::for_all<policy>
+template.
 
 =============================================================================
 =============================================================================

--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -73,6 +73,9 @@ policies (Policy1D, Policy2D, Policy3D) for CUDA kernels in
 tbox::ExecutionPolicy have been set to a fixed value of 256,
 which is the product of the tile count in each dimensional direction.
 
+3) NEW for v. 4.0.3 The deprecated method isEmpty() has been removed from
+classes Box and BoxContainer.
+
 *****************************************************************************
 
 -----------------------------------------------------------------------------
@@ -161,6 +164,11 @@ defined in hier/ForAll.h.  hier::for_all is templated on the policy, so
 users who do not wish to used the policies from tbox::ExecutionPolicy may
 define their own policies and provide them to the hier::for_all<policy>
 template.
+
+3) NEW for v. 4.0.3 The deprecated method isEmpty() has been removed from
+classes Box and BoxContainer.  The method empty() provides this functionality.
+Also, there is no longer a DEPRECATED macro defined in SAMRAI.
+
 
 =============================================================================
 =============================================================================

--- a/docs/release/version-4.0.2
+++ b/docs/release/version-4.0.2
@@ -1,0 +1,139 @@
+*****************************************************************************
+  Copyright 1997-2020
+  Lawrence Livermore National Security, LLC.
+  All rights reserved.
+*****************************************************************************
+
+                     Release Notes for SAMRAI v4.0.2
+
+     (notes for previous releases may be found in /SAMRAI/docs/release)
+
+*****************************************************************************
+
+Please direct any questions related to these notes to the SAMRAI development
+team by sending email to samrai@llnl.gov.
+
+*****************************************************************************
+
+VERSION 4.0.2
+
+Version 4.0.2 contains minor code changes to make SAMRAI compatible with
+RAJA version 0.12.1 and Umpire version 4.0.1.  No new features, bug fixes, nor
+API changes are introduced.  The remainder of these release notes reproduce
+the content of the release notes for SAMRAI versions 4.0.0 and 4.0.1.
+
+*****************************************************************************
+
+Where to report Bugs
+--------------------
+
+If a bug is found in the SAMRAI library, we ask that you kindly report
+it to us so that we may fix it.
+
+Please send email to samrai-bugs@llnl.gov or post an issue on github.
+https://github.com/LLNL/SAMRAI
+
+
+
+*****************************************************************************
+
+----------------------------------------------------------------------------
+                Significant bug fixes
+----------------------------------------------------------------------------
+
+1) NEW for v. 4.0.1  Bugs in the CMake configuration that caused Conduit
+and SILO to be excluded from the build even when included in the cmake
+configuration line have been fixed.
+
+*****************************************************************************
+
+
+
+----------------------------------------------------------------------------
+                Summary of what's new
+-----------------------------------------------------------------------------
+
+1) In v4.0.0 SAMRAI is introducing new features to support running applications
+on GPU architectures, using capabilities provided by the Umpire and RAJA
+libraries.
+
+
+-----------------------------------------------------------------------------
+                Summary of what's changed
+-----------------------------------------------------------------------------
+
+1) The old autoconf-based build system has been removed.  The new system that
+uses CMake supplemented with the BLT macro library is the only supported build
+system.  (This change effective as of v. 3.15.0)
+
+
+*****************************************************************************
+
+-----------------------------------------------------------------------------
+                Details about what's new
+-----------------------------------------------------------------------------
+
+1) In v4.0.0 SAMRAI is introducing new features to support running applications
+on GPU architectures, using capabilities provided by the Umpire and RAJA
+libraries.
+
+Umpire:  https://github.com/LLNL/Umpire
+RAJA:  https://github.com/LLNL/RAJA
+
+Umpire provides tools for memory management on multiple-memory architectures,
+such as GPU architectures that use storage in both host and device memory
+spaces.
+
+RAJA provides portable abstractions for loop execution, enabling the use of
+a single code base for multiple modes of running loop kernels on different
+architectures, ranging from ordinary serial loop execution on a CPU, to
+shared-memory multi-threading, to threaded CUDA kernel launches on a GPU.
+
+The key feature used from Umpire is the Allocator, an object that controls
+all aspects of memory allocation and will determine the location of
+the allocation in architectures with multiple memory spaces.  The patch data
+objects in the pdat directory have new overloaded constructors that take
+an umpire::Allocator as an argument.  Additionally a new singleton class
+tbox::AllocatorDatabase manages certain Allocators that are held
+by SAMRAI and used to control allocations that occur internally during
+SAMRAI operations.  Application codes can access these Allocators from the
+AllocatorDatabase and use them to ensure that application-allocated data
+and library-allocated data are allocated in the same way before they interact.
+See the AllocatorDatabase documentation for more information.
+
+RAJA is used to support a portable loop abstraction for looping over the
+index spaces defined by SAMRAI's hier::Box.  The hier::parallel_for_all
+and hier::for_all objects provide a way to write one code implementation
+that can be used to execute the loops as threaded CUDA kernels, threaded
+OpenMP kernels, or regular sequentially-incremented loops.  The execution
+mode for the loops depends on the configuration of the SAMRAI installation
+and the RAJA policy given to the looping structure.  See the RAJA
+documentation for more information on RAJA policies.
+
+To connect the RAJA loop structures with standard SAMRAI patch data types,
+a new class ArrayView has been added to provide a way to access the data
+arrays held within these types using integer (i,j,k) tuples.  The plain
+integers in the tuple are used to index the loop, and they may be threaded,
+so the ArrayView class is a convenient way to access the data for
+thread-safe operation on the arrays.
+
+Configuration with Umpire and RAJA is optional, so all previous functionality
+using MPI parallelism is still available.
+
+
+                Details about what's changed
+----------------------------------------------------------------------------
+
+1) The old autoconf-based build system has been removed.  The new system that
+uses CMake supplemented with the BLT macro library was introduced in version
+3.14.0 and is now the only supported build system.
+
+The new system uses CMake (https://cmake.org) supplemented with the BLT macro
+library (https://github.com/LLNL/blt).  Updated instructions for the build
+system are in the INSTALL-NOTES file.
+
+(This change effective as of v. 3.15.0)
+
+
+=============================================================================
+=============================================================================

--- a/source/SAMRAI/hier/Box.h
+++ b/source/SAMRAI/hier/Box.h
@@ -586,21 +586,6 @@ public:
    /*!
     * @brief Return whether the box is ``empty''.
     *
-    * Archaic syntax.  Synonymous with empty().  Retained for backward
-    * compatibility.
-    *
-    * @see empty()
-    */
-   DEPRECATED(
-      bool
-      isEmpty() const)
-   {
-      return empty();
-   }
-
-   /*!
-    * @brief Return whether the box is ``empty''.
-    *
     * This version follows the naming standards used in STL.
     *
     * A box is empty if any of the lower bounds is greater than the

--- a/source/SAMRAI/hier/BoxContainer.h
+++ b/source/SAMRAI/hier/BoxContainer.h
@@ -672,21 +672,6 @@ private:
    /*!
     * @brief Returns true if there are no boxes in the container.
     *
-    * Archaic syntax.  Synonymous with empty().  Retained for backward
-    * compatibility.
-    *
-    * @see empty()
-    */
-   DEPRECATED(
-      bool
-      isEmpty() const)
-   {
-      return empty();
-   }
-
-   /*!
-    * @brief Returns true if there are no boxes in the container.
-    *
     * This version follows the naming standards used in STL.
     *
     * @return True if the container is empty.

--- a/source/SAMRAI/tbox/AsyncCommPeer.h
+++ b/source/SAMRAI/tbox/AsyncCommPeer.h
@@ -12,6 +12,7 @@
 
 #include "SAMRAI/SAMRAI_config.h"
 
+#include "SAMRAI/tbox/AllocatorDatabase.h"
 #include "SAMRAI/tbox/AsyncCommStage.h"
 #include "SAMRAI/tbox/SAMRAI_MPI.h"
 #include "SAMRAI/tbox/Timer.h"
@@ -215,6 +216,17 @@ public:
    {
       return d_mpi;
    }
+
+#ifdef HAVE_UMPIRE
+   /*!
+    * Set Umpire allocator for internal buffer allocations.
+    */
+   void
+   setAllocator(umpire::TypedAllocator<char> allocator)
+   {
+      d_allocator = allocator;
+   }
+#endif
 
    /*!
     * @brief Next task in a current communication operation.
@@ -628,6 +640,10 @@ private:
 
    // Make some temporary variable statuses to avoid repetitious allocations.
    int d_mpi_err;
+
+#ifdef HAVE_UMPIRE
+   umpire::TypedAllocator<char> d_allocator;
+#endif 
 
    std::shared_ptr<Timer> t_send_timer;
    std::shared_ptr<Timer> t_recv_timer;

--- a/source/SAMRAI/tbox/ExecutionPolicy.h
+++ b/source/SAMRAI/tbox/ExecutionPolicy.h
@@ -67,8 +67,8 @@ struct policy_traits<policy::parallel> {
    using Policy = RAJA::cuda_exec_async<128>;
 
    using Policy1d = RAJA::KernelPolicy<
-      RAJA::statement::CudaKernelAsync<
-         RAJA::statement::Tile<0, RAJA::tile_fixed<128>, RAJA::cuda_block_x_loop,
+      RAJA::statement::CudaKernelFixedAsync<256,
+         RAJA::statement::Tile<0, RAJA::tile_fixed<256>, RAJA::cuda_block_x_loop,
             RAJA::statement::For<0, RAJA::cuda_thread_x_loop,
                RAJA::statement::Lambda<0>
             >
@@ -76,8 +76,10 @@ struct policy_traits<policy::parallel> {
       >
    >;
 
+
+
    using Policy2d = RAJA::KernelPolicy<
-      RAJA::statement::CudaKernelAsync<
+      RAJA::statement::CudaKernelFixedAsync<256,
          RAJA::statement::Tile<1, RAJA::tile_fixed<16>, RAJA::cuda_block_y_loop,
             RAJA::statement::Tile<0, RAJA::tile_fixed<16>, RAJA::cuda_block_x_loop,
                RAJA::statement::For<1, RAJA::cuda_thread_y_loop,
@@ -91,8 +93,8 @@ struct policy_traits<policy::parallel> {
    >;
 
    using Policy3d = RAJA::KernelPolicy<
-      RAJA::statement::CudaKernelAsync<
-         RAJA::statement::Tile<2, RAJA::tile_fixed<8>, RAJA::cuda_block_z_loop,
+      RAJA::statement::CudaKernelFixedAsync<256,
+         RAJA::statement::Tile<2, RAJA::tile_fixed<4>, RAJA::cuda_block_z_loop,
             RAJA::statement::Tile<1, RAJA::tile_fixed<8>, RAJA::cuda_block_y_loop,
                RAJA::statement::Tile<0, RAJA::tile_fixed<8>, RAJA::cuda_block_x_loop,
                   RAJA::statement::For<2, RAJA::cuda_thread_z_loop,

--- a/source/SAMRAI/tbox/Schedule.C
+++ b/source/SAMRAI/tbox/Schedule.C
@@ -8,6 +8,7 @@
  *
  ************************************************************************/
 #include "SAMRAI/tbox/Schedule.h"
+#include "SAMRAI/tbox/AllocatorDatabase.h"
 #include "SAMRAI/tbox/InputManager.h"
 #include "SAMRAI/tbox/PIO.h"
 #include "SAMRAI/tbox/SAMRAIManager.h"
@@ -538,6 +539,9 @@ Schedule::allocateCommunicationObjects()
       d_coms[counter].setMPITag(d_first_tag, d_second_tag);
       d_coms[counter].setMPI(d_mpi);
       d_coms[counter].limitFirstDataLength(d_first_message_length);
+#ifdef HAVE_UMPIRE
+      d_coms[counter].setAllocator(AllocatorDatabase::getDatabase()->getStreamAllocator());
+#endif
       ++counter;
    }
    for (TransactionSets::iterator ti = d_send_sets.begin();
@@ -548,6 +552,9 @@ Schedule::allocateCommunicationObjects()
       d_coms[counter].setMPITag(d_first_tag, d_second_tag);
       d_coms[counter].setMPI(d_mpi);
       d_coms[counter].limitFirstDataLength(d_first_message_length);
+#ifdef HAVE_UMPIRE
+      d_coms[counter].setAllocator(AllocatorDatabase::getDatabase()->getStreamAllocator());
+#endif
       ++counter;
    }
 }

--- a/source/SAMRAI/tbox/Utilities.h
+++ b/source/SAMRAI/tbox/Utilities.h
@@ -366,18 +366,6 @@ typedef int mode_t;
 #endif
 
 /*
- * Macro to indicate deprecated function.  If syntax is known for other
- * preprocessors please add to this list.
- */
-#ifdef __GNUC__
-#define DEPRECATED(func) func __attribute__ ((deprecated))
-#elif defined(_MSC_VER)
-#define DEPRECATED(func) __declspec(deprecated) func
-#else
-#define DEPRECATED(func) func
-#endif
-
-/*
  * Macros defined for host-device compilation.
  */
 #define SAMRAI_INLINE inline


### PR DESCRIPTION
This is needed because of tbox::Schedule's usage of AsyncCommPeer and MessageStream. We have promised that MessageStream will create buffers using the stream Allocator held in the AllocatorDatabase, which is a pinned memory allocator by default. However, MessageStream can also be constructed to use an external buffer passed into the constructor, in which case the buffer could be anywhere and is not necessarily in pinned memory when we give the MessageStream to user code.

In particular, tbox::Schedule takes buffers created inside AsyncCommPeer and gives them to MessageStream as external buffers. These buffers have been allocated as CPU host buffers, so the MessageStream is provided to user code holding a host buffer rather than a buffer associated with the stream Allocator's promised memory space.

This PR gives AsyncCommPeer an Allocator to hold and use for its internal buffer allocations, and the Allocator can be set by calling code using the setAllocator method. tbox::Schedule gives its instances of AsyncCommPeer the stream Allocator, so that all buffers allocated in tbox::Schedule by the MessageStreams and AsyncCommPeers in tbox::Schedule use the same stream Allocator.