### PR TITLE
Remove SAMRAI_HOST_DEVICE from Index and IntVector

### DIFF
--- a/source/SAMRAI/hier/Index.h
+++ b/source/SAMRAI/hier/Index.h
@@ -41,14 +41,12 @@ public:
    /**
     * @brief Creates an uninitialized Index.
     */
-   SAMRAI_HOST_DEVICE
    explicit Index(
       const tbox::Dimension& dim);
 
    /**
     * @brief Construct an Index with all components equal to the argument.
     */
-   SAMRAI_HOST_DEVICE
    Index(
       const tbox::Dimension& dim,
       const int value);
@@ -56,7 +54,6 @@ public:
    /**
     * @brief Construct a two-dimensional Index with the value (i,j).
     */
-   SAMRAI_HOST_DEVICE
    Index(
       const int i,
       const int j);
@@ -64,7 +61,6 @@ public:
    /**
     * @brief Construct a three-dimensional Index with the value (i,j,k).
     */
-   SAMRAI_HOST_DEVICE
    Index(
       const int i,
       const int j,
@@ -85,7 +81,6 @@ public:
    /**
     * @brief The copy constructor creates an Index equal to the argument.
     */
-   SAMRAI_HOST_DEVICE
    Index(
       const Index& rhs);
 
@@ -94,7 +89,6 @@ public:
     *
     * @pre rhs.getNumBlocks() == 1
     */
-   SAMRAI_HOST_DEVICE
    explicit Index(
       const IntVector& rhs);
 
@@ -476,7 +470,6 @@ public:
     *
     * @pre (i >= 0) && (i < getDim().getValue())
     */
-   SAMRAI_HOST_DEVICE
    int&
    operator [] (
       const unsigned int i)
@@ -490,7 +483,6 @@ public:
     *
     * @pre (i >= 0) && (i < getDim().getValue())
     */
-   SAMRAI_HOST_DEVICE
    const int&
    operator [] (
       const unsigned int i) const
@@ -504,7 +496,6 @@ public:
     *
     * @pre (i >= 0) && (i < getDim().getValue())
     */
-   SAMRAI_HOST_DEVICE
    int&
    operator () (
       const unsigned int i)
@@ -518,7 +509,6 @@ public:
     *
     * @pre (i >= 0) && (i < getDim().getValue())
     */
-   SAMRAI_HOST_DEVICE
    const int&
    operator () (
       const unsigned int i) const

--- a/source/SAMRAI/hier/IntVector.C
+++ b/source/SAMRAI/hier/IntVector.C
@@ -34,7 +34,6 @@ IntVector::s_initialize_finalize_handler(
  * *************************************************************************
  */
 
-SAMRAI_HOST_DEVICE
 IntVector::IntVector(
    const tbox::Dimension& dim):
    d_dim(dim),
@@ -48,7 +47,6 @@ IntVector::IntVector(
 #endif
 }
 
-SAMRAI_HOST_DEVICE
 IntVector::IntVector(
    size_t num_blocks,
    const tbox::Dimension& dim):
@@ -64,7 +62,6 @@ IntVector::IntVector(
 #endif
 }
 
-SAMRAI_HOST_DEVICE
 IntVector::IntVector(
    const tbox::Dimension& dim,
    int value,
@@ -92,7 +89,6 @@ IntVector::IntVector(
    }
 }
 
-SAMRAI_HOST_DEVICE
 IntVector::IntVector(
    const tbox::Dimension& dim,
    const int array[],
@@ -109,7 +105,6 @@ IntVector::IntVector(
    }
 }
 
-SAMRAI_HOST_DEVICE
 IntVector::IntVector(
    const IntVector& rhs):
    d_dim(rhs.getDim()),
@@ -119,7 +114,6 @@ IntVector::IntVector(
    TBOX_ASSERT(d_num_blocks >= 1);
 }
 
-SAMRAI_HOST_DEVICE
 IntVector::IntVector(
    const IntVector& rhs,
    size_t num_blocks):
@@ -141,7 +135,6 @@ IntVector::IntVector(
    }
 }
 
-SAMRAI_HOST_DEVICE
 IntVector::IntVector(
    const Index& rhs,
    size_t num_blocks):

--- a/source/SAMRAI/hier/IntVector.h
+++ b/source/SAMRAI/hier/IntVector.h
@@ -56,7 +56,6 @@ public:
     *
     * @param dim
     */
-   SAMRAI_HOST_DEVICE
    explicit IntVector(
       const tbox::Dimension& dim);
 
@@ -68,7 +67,6 @@ public:
     * @param num_blocks
     * @param dim
     */
-   SAMRAI_HOST_DEVICE
    IntVector(
       size_t num_blocks,
       const tbox::Dimension& dim);
@@ -83,7 +81,6 @@ public:
     * @param value
     * @param num_blocks
     */
-   SAMRAI_HOST_DEVICE
    IntVector(
       const tbox::Dimension& dim,
       int value,
@@ -124,7 +121,6 @@ public:
     *               at a length equal to dim.getValue()
     * @param num_blocks
     */
-   SAMRAI_HOST_DEVICE
    IntVector(
       const tbox::Dimension& dim,
       const int array[],
@@ -135,7 +131,6 @@ public:
     *
     * @pre rhs.getNumBlocks() >= 1
     */
-   SAMRAI_HOST_DEVICE
    IntVector(
       const IntVector& rhs);
 
@@ -156,7 +151,6 @@ public:
     * @param rhs
     * @param num_blocks
     */
-   SAMRAI_HOST_DEVICE
    IntVector(
       const IntVector& rhs,
       size_t num_blocks);
@@ -176,7 +170,6 @@ public:
     * @param rhs
     * @param num_blocks
     */
-   SAMRAI_HOST_DEVICE
    IntVector(
       const Index& rhs,
       size_t num_blocks = 1);
@@ -254,7 +247,6 @@ public:
     * @pre (i >= 0) && (i < getDim().getValue())
     * @pre getNumBlocks() == 1
     */
-   SAMRAI_HOST_DEVICE
    int&
    operator [] (
       const unsigned int i)
@@ -271,7 +263,6 @@ public:
     * @pre (i >= 0) && (i < getDim().getValue())
     * @pre getNumBlocks() == 1
     */
-   SAMRAI_HOST_DEVICE
    const int&
    operator [] (
       const unsigned int i) const
@@ -288,7 +279,6 @@ public:
     * @pre (i >= 0) && (i < getDim().getValue())
     * @pre getNumBlocks() == 1
     */
-   SAMRAI_HOST_DEVICE
    int&
    operator () (
       const unsigned int i)
@@ -305,7 +295,6 @@ public:
     * @pre (i >= 0) && (i < getDim().getValue())
     * @pre getNumBlocks() == 1
     */
-   SAMRAI_HOST_DEVICE
    const int&
    operator () (
       const unsigned int i) const


### PR DESCRIPTION
These classes should not be used inside device kernels.