### PR TITLE
Fix computation of data length

### DIFF
--- a/source/SAMRAI/math/HierarchyCellDataOpsReal.C
+++ b/source/SAMRAI/math/HierarchyCellDataOpsReal.C
@@ -1489,6 +1489,8 @@ int64_t HierarchyCellDataOpsReal<TYPE>::getLength(
       && (d_finest_level >= d_coarsest_level)
       && (d_finest_level <= d_hierarchy->getFinestLevelNumber()));
 
+   const tbox::SAMRAI_MPI& mpi(d_hierarchy->getMPI());
+
    int64_t length = 0;
 
    for (int ln = d_coarsest_level; ln <= d_finest_level; ++ln) {
@@ -1514,7 +1516,12 @@ int64_t HierarchyCellDataOpsReal<TYPE>::getLength(
       }
    }
 
-   return length;
+   int64_t global_length = length;
+   if (mpi.getSize() > 1) {
+      mpi.Allreduce(&length, &global_length, 1, MPI_INT64_T, MPI_SUM);
+   }
+   return global_length;
+
 }
 
 

--- a/source/SAMRAI/math/HierarchyEdgeDataOpsReal.C
+++ b/source/SAMRAI/math/HierarchyEdgeDataOpsReal.C
@@ -1544,6 +1544,8 @@ int64_t HierarchyEdgeDataOpsReal<TYPE>::getLength(
       && (d_finest_level >= d_coarsest_level)
       && (d_finest_level <= d_hierarchy->getFinestLevelNumber()));
 
+   const tbox::SAMRAI_MPI& mpi(d_hierarchy->getMPI());
+
    int64_t length = 0;
    tbox::Dimension::dir_t dim_val = d_hierarchy->getDim().getValue();
    hier::Box data_box(d_hierarchy->getDim());
@@ -1572,7 +1574,11 @@ int64_t HierarchyEdgeDataOpsReal<TYPE>::getLength(
       }
    }
 
-   return length;
+   int64_t global_length = length;
+   if (mpi.getSize() > 1) {
+      mpi.Allreduce(&length, &global_length, 1, MPI_INT64_T, MPI_SUM);
+   }
+   return global_length;
 }
 
 }

--- a/source/SAMRAI/math/HierarchyFaceDataOpsReal.C
+++ b/source/SAMRAI/math/HierarchyFaceDataOpsReal.C
@@ -1544,6 +1544,8 @@ int64_t HierarchyFaceDataOpsReal<TYPE>::getLength(
       && (d_finest_level >= d_coarsest_level)
       && (d_finest_level <= d_hierarchy->getFinestLevelNumber()));
 
+   const tbox::SAMRAI_MPI& mpi(d_hierarchy->getMPI());
+
    int64_t length = 0;
    tbox::Dimension::dir_t dim_val = d_hierarchy->getDim().getValue();
    hier::Box data_box(d_hierarchy->getDim());
@@ -1572,7 +1574,11 @@ int64_t HierarchyFaceDataOpsReal<TYPE>::getLength(
       }
    }
 
-   return length;
+   int64_t global_length = length;
+   if (mpi.getSize() > 1) {
+      mpi.Allreduce(&length, &global_length, 1, MPI_INT64_T, MPI_SUM);
+   }
+   return global_length;
 }
 
 

--- a/source/SAMRAI/math/HierarchyNodeDataOpsReal.C
+++ b/source/SAMRAI/math/HierarchyNodeDataOpsReal.C
@@ -1528,6 +1528,8 @@ int64_t HierarchyNodeDataOpsReal<TYPE>::getLength(
       && (d_finest_level >= d_coarsest_level)
       && (d_finest_level <= d_hierarchy->getFinestLevelNumber()));
 
+   const tbox::SAMRAI_MPI& mpi(d_hierarchy->getMPI());
+
    int64_t length = 0;
    hier::Box data_box(d_hierarchy->getDim());
 
@@ -1553,7 +1555,11 @@ int64_t HierarchyNodeDataOpsReal<TYPE>::getLength(
       }
    }
 
-   return length;
+   int64_t global_length = length;
+   if (mpi.getSize() > 1) {
+      mpi.Allreduce(&length, &global_length, 1, MPI_INT64_T, MPI_SUM);
+   }
+   return global_length;
 }
 
 

--- a/source/SAMRAI/math/HierarchySideDataOpsReal.C
+++ b/source/SAMRAI/math/HierarchySideDataOpsReal.C
@@ -1546,6 +1546,8 @@ int64_t HierarchySideDataOpsReal<TYPE>::getLength(
       && (d_finest_level >= d_coarsest_level)
       && (d_finest_level <= d_hierarchy->getFinestLevelNumber()));
 
+   const tbox::SAMRAI_MPI& mpi(d_hierarchy->getMPI());
+
    int64_t length = 0;
    tbox::Dimension::dir_t dim_val = d_hierarchy->getDim().getValue();
    hier::Box data_box(d_hierarchy->getDim());
@@ -1578,7 +1580,11 @@ int64_t HierarchySideDataOpsReal<TYPE>::getLength(
       }
    }
 
-   return length;
+   int64_t global_length = length;
+   if (mpi.getSize() > 1) {
+      mpi.Allreduce(&length, &global_length, 1, MPI_INT64_T, MPI_SUM);
+   }
+   return global_length;
 }
 
 

--- a/source/SAMRAI/tbox/SAMRAI_MPI.h
+++ b/source/SAMRAI/tbox/SAMRAI_MPI.h
@@ -50,6 +50,7 @@ enum {
    MPI_DOUBLE,
    MPI_FLOAT,
    MPI_INT,
+   MPI_INT64_T,
    MPI_LONG,
    MPI_C_DOUBLE_COMPLEX,
    MPI_2INT,


### PR DESCRIPTION
Functions to compute length of a vector of data in Hierarchy*DataOpsReal.C are missing an MPI_Allreduce.
This PR makes it consistent with other functions in these classes. I also satisfy Sundials requirement of a global vector length.
The sundials tests in SAMRAI seem not to be sensitive to that fix and still pass.