### PR TITLE
Schedule: copy before pack flag

### DIFF
--- a/source/SAMRAI/tbox/Schedule.cpp
+++ b/source/SAMRAI/tbox/Schedule.cpp
@@ -211,6 +211,9 @@ Schedule::beginCommunication()
    d_object_timers->t_begin_communication->start();
    allocateCommunicationObjects();
    postReceives();
+   if (d_copy_before_packing) {
+       performLocalCopies();
+   }
    postSends();
    d_object_timers->t_begin_communication->stop();
 }
@@ -225,7 +228,9 @@ void
 Schedule::finalizeCommunication()
 {
    d_object_timers->t_finalize_communication->start();
-   performLocalCopies();
+   if (!d_copy_before_packing) {
+       performLocalCopies();
+   }
 #if defined(HAVE_RAJA)
    parallel_synchronize();
 #endif

--- a/source/SAMRAI/tbox/Schedule.h
+++ b/source/SAMRAI/tbox/Schedule.h
@@ -248,6 +248,21 @@ public:
       d_unpack_in_deterministic_order = flag;
    }
 
+
+   /*!
+    * @brief Set whether to copy local values before packing
+    *
+    * By default copying local values are done after values are packed.
+    * If your results are dependent on copying before packing,
+    * set this flag to true.
+    *
+    * @param [in] flag
+    */
+   void setCopyBeforePackingFlag(bool flag)
+   {
+      d_copy_before_packing = flag;
+   }
+
    /*!
     * @brief Setup names of timers.
     *
@@ -399,6 +414,14 @@ private:
     * @see setDeterministicUnpackOrderingFlag()
     */
    bool d_unpack_in_deterministic_order;
+
+
+   /*!
+    * @brief Whether to copy before packing
+    *
+    * @see setCopyBeforePackingFlag()
+    */
+   bool d_copy_before_packing = false;
 
    static const int s_default_first_tag;
    static const int s_default_second_tag;

--- a/source/SAMRAI/xfer/CoarsenSchedule.cpp
+++ b/source/SAMRAI/xfer/CoarsenSchedule.cpp
@@ -1225,6 +1225,22 @@ CoarsenSchedule::setDeterministicUnpackOrderingFlag(bool flag)
 }
 
 /*
+ **************************************************************************
+ **************************************************************************
+ */
+
+void
+CoarsenSchedule::setCopyBeforePackingFlag(bool flag)
+{
+   if (d_schedule) {
+      d_schedule->setCopyBeforePackingFlag(flag);
+   }
+   if (d_precoarsen_refine_schedule) {
+      d_precoarsen_refine_schedule->setCopyBeforePackingFlag(flag);
+   }
+}
+
+/*
  * ************************************************************************
  *
  * Print coarsen schedule data to the specified output stream.

--- a/source/SAMRAI/xfer/CoarsenSchedule.h
+++ b/source/SAMRAI/xfer/CoarsenSchedule.h
@@ -178,6 +178,20 @@ public:
    setDeterministicUnpackOrderingFlag(
       bool flag);
 
+
+   /*!
+    * @brief Set whether to copy local values before packing
+    *
+    * By default copying local values are done after values are packed.
+    * If your results are dependent on copying before packing,
+    * set this flag to true.
+    *
+    * @param [in] flag
+    */
+   void
+   setCopyBeforePackingFlag(
+      bool flag);
+
    /*!
     * @brief Static function to set box intersection algorithm to use during
     * schedule construction for all CoarsenSchedule objects.

--- a/source/SAMRAI/xfer/RefineSchedule.cpp
+++ b/source/SAMRAI/xfer/RefineSchedule.cpp
@@ -5070,6 +5070,29 @@ RefineSchedule::setDeterministicUnpackOrderingFlag(bool flag)
 
 /*
  **************************************************************************
+ **************************************************************************
+ */
+
+void
+RefineSchedule::setCopyBeforePackingFlag(bool flag)
+{
+   if (d_coarse_priority_level_schedule) {
+      d_coarse_priority_level_schedule->setCopyBeforePackingFlag(flag);
+   }
+   if (d_fine_priority_level_schedule) {
+      d_fine_priority_level_schedule->setCopyBeforePackingFlag(flag);
+   }
+   if (d_coarse_interp_schedule) {
+      d_coarse_interp_schedule->setCopyBeforePackingFlag(flag);
+   }
+   if (d_coarse_interp_encon_schedule) {
+      d_coarse_interp_encon_schedule->setCopyBeforePackingFlag(flag);
+   }
+}
+
+
+/*
+ **************************************************************************
  *
  * Allocate internal data
  *

--- a/source/SAMRAI/xfer/RefineSchedule.h
+++ b/source/SAMRAI/xfer/RefineSchedule.h
@@ -274,6 +274,20 @@ public:
    setDeterministicUnpackOrderingFlag(
       bool flag);
 
+
+   /*!
+    * @brief Set whether to copy local values before packing
+    *
+    * By default copying local values are done after values are packed.
+    * If your results are dependent on copying before packing,
+    * set this flag to true.
+    *
+    * @param [in] flag
+    */
+   void
+   setCopyBeforePackingFlag(
+      bool flag);
+
    /*!
     * @brief Allocated needed data on all internal levels.
     *


### PR DESCRIPTION
Hi,

We've noticed a mismatch on border nodes which propagates via packStream as values are not final until local copies are performed.

As such I have found that for our case, performing local copies before packing values removes this mismatch.

This PR provides a flag, default being the current functionality, but it allows us to copy values before packing them.

The particular case is when a patch is periodic with itself. The mismatch is, in our case at the shared corner at the bottom between patch 0#0 and 1#1

![image](https://user-images.githubusercontent.com/30491/125460748-4fe7a3ee-cbae-4e8e-a6cb-2e6f910bc097.png)


Feel free to PR my branch if it's not all to your liking, or just tell me what to modify.