### PR TITLE
Install the M4 macros for array dimensions.

### DIFF
--- a/source/SAMRAI/pdat/CMakeLists.txt
+++ b/source/SAMRAI/pdat/CMakeLists.txt
@@ -347,3 +347,10 @@ install(TARGETS SAMRAI_pdat
 
 install(FILES ${pdat_headers}
   DESTINATION include/SAMRAI/pdat)
+
+install(FILES
+  fortran/pdat_m4arrdim1d.i
+  fortran/pdat_m4arrdim2d.i
+  fortran/pdat_m4arrdim3d.i
+  fortran/pdat_m4arrdim4d.i
+  DESTINATION include/SAMRAI/pdat/fortran)


### PR DESCRIPTION
These are useful in downstream projects (like IBAMR).