### PR TITLE
Add API allowing user code to set flag for using GPUs

### DIFF
--- a/source/SAMRAI/tbox/CMakeLists.txt
+++ b/source/SAMRAI/tbox/CMakeLists.txt
@@ -19,6 +19,7 @@ set ( tbox_headers
   DatabaseFactory.h
   Dimension.h
   ExecutionPolicy.h
+  GPUUtilities.h
   Grammar.h
   HDFDatabase.h
   HDFDatabaseFactory.h
@@ -81,6 +82,7 @@ set (tbox_sources
   DatabaseBox.C
   DatabaseFactory.C
   Dimension.C
+  GPUUtilities.C
   Grammar.C
   HDFDatabase.C
   HDFDatabaseFactory.C
@@ -146,7 +148,7 @@ if (ENABLE_RAJA)
 endif ()
 
 if (ENABLE_CUDA)
-  set(cuda_sources Schedule.C)
+  set(cuda_sources GPUUtilities.C Schedule.C)
   set_source_files_properties(${cuda_sources} PROPERTIES LANGUAGE CUDA)
 
   if (ENABLE_NVTX_REGIONS)

--- a/source/SAMRAI/tbox/Collectives.h
+++ b/source/SAMRAI/tbox/Collectives.h
@@ -16,6 +16,7 @@
 #include "RAJA/RAJA.hpp"
 
 #include "SAMRAI/tbox/ExecutionPolicy.h"
+#include "SAMRAI/tbox/GPUUtilities.h"
 
 namespace SAMRAI {
 namespace tbox {
@@ -34,8 +35,9 @@ synchronize<policy::parallel>()
 #endif
 
 inline void
-parallel_synchronize() { synchronize<policy::parallel>(); }
-
+parallel_synchronize() {
+   GPUUtilities::parallel_synchronize();
+}
 
 // Reductions see https://raja.readthedocs.io/en/master/feature/reduction.html for these options
 enum class Reduction {

--- a/source/SAMRAI/tbox/GPUUtilities.C
+++ b/source/SAMRAI/tbox/GPUUtilities.C
@@ -1,0 +1,33 @@
+/*************************************************************************
+ *
+ * This file is part of the SAMRAI distribution.  For full copyright
+ * information, see COPYRIGHT and LICENSE.
+ *
+ * Copyright:     (c) 1997-2021 Lawrence Livermore National Security, LLC
+ * Description:   Utility functions for GPUs
+ *
+ ************************************************************************/
+
+#include "SAMRAI/tbox/GPUUtilities.h"
+
+
+namespace SAMRAI {
+namespace tbox {
+
+bool GPUUtilities::s_using_gpu =
+#if defined(HAVE_CUDA)
+   true;
+#else
+   false;
+#endif
+
+void GPUUtilities::setUsingGPU(bool using_gpu)
+{
+   s_using_gpu = using_gpu;
+}
+
+
+
+}
+}
+

--- a/source/SAMRAI/tbox/GPUUtilities.h
+++ b/source/SAMRAI/tbox/GPUUtilities.h
@@ -1,0 +1,67 @@
+/*************************************************************************
+ *
+ * This file is part of the SAMRAI distribution.  For full copyright
+ * information, see COPYRIGHT and LICENSE.
+ *
+ * Copyright:     (c) 1997-2021 Lawrence Livermore National Security, LLC
+ * Description:   Utility functions for GPU
+ *
+ ************************************************************************/
+
+#ifndef included_tbox_GPUUtilities
+#define included_tbox_GPUUtilities
+
+#include "SAMRAI/SAMRAI_config.h"
+
+#if defined(HAVE_RAJA)
+#include "RAJA/RAJA.hpp"
+#endif
+
+namespace SAMRAI {
+namespace tbox {
+
+
+/*!
+ * Utility functions to support running on GPUs.
+ */
+
+struct GPUUtilities {
+
+/*!
+ * @brief Manually set flag telling whether the run is using GPUs.
+ *
+ * Usually the default value of the flag will be correct. This may be used
+ * to set the flag to false if running a GPU-enabled build without access to
+ * GPUs.
+ */
+static void
+setUsingGPU(bool using_gpu);
+
+/*!
+ * @brief Synchronizes GPU threads.
+ *
+ * May be called after RAJA-CUDA loops to ensure data modified inside
+ * kernels is ready for next operation.
+ */
+static void
+parallel_synchronize()
+{
+#if defined(HAVE_CUDA) && defined(HAVE_RAJA)
+   if (s_using_gpu) RAJA::synchronize<RAJA::cuda_synchronize>();
+#endif       
+}
+
+private:
+
+   /*!
+    * Flag indicating wheter the run is using GPUs. This has a default of
+    * true when SAMRAI is compiled for GPUs, false otherwise.
+    */
+   static bool s_using_gpu;
+
+};
+
+}
+}
+
+#endif


### PR DESCRIPTION
This gives applications a way to indicate that their GPU-enabled code is running without GPUs.  We suppress the RAJA/CUDA parallel synchronize in this case.