### PR TITLE
Change variable-sized array to fixed-size

### DIFF
--- a/source/SAMRAI/pdat/ArrayDataOperationUtilities.C
+++ b/source/SAMRAI/pdat/ArrayDataOperationUtilities.C
@@ -714,7 +714,7 @@ inline void ArrayDataOperationUtilities<dcomplex, SumOperation<dcomplex> >::doAr
 #if !defined(HAVE_RAJA)
    const hier::Box& array_d_box(arraydata.getBox());
 
-   int box_w[dim.getValue()];
+   int box_w[SAMRAI::MAX_DIM_VAL];
    int dat_w[SAMRAI::MAX_DIM_VAL];
    int dim_counter[SAMRAI::MAX_DIM_VAL];
    for (tbox::Dimension::dir_t i = 0; i < dim.getValue(); ++i) {


### PR DESCRIPTION
This addresses the error reported in #145 and makes similar sections of the ArrayData code do the same thing.