### PR TITLE
Replace direct cuda synchronize with a wrapper call

### DIFF
--- a/source/SAMRAI/mesh/TileClustering.cpp
+++ b/source/SAMRAI/mesh/TileClustering.cpp
@@ -1088,7 +1088,7 @@ TileClustering::makeCoarsenedTagData(const pdat::CellData<int>& tag_data,
                               hier::IntVector::getZero(tag_data.getDim())));
    coarsened_tag_data->fill(0, 0);
 #if defined(HAVE_CUDA)
-   tbox::parallel_sychronize();
+   tbox::parallel_synchronize();
 #endif
 
    size_t coarse_tag_count = 0;

--- a/source/SAMRAI/mesh/TileClustering.cpp
+++ b/source/SAMRAI/mesh/TileClustering.cpp
@@ -1088,7 +1088,7 @@ TileClustering::makeCoarsenedTagData(const pdat::CellData<int>& tag_data,
                               hier::IntVector::getZero(tag_data.getDim())));
    coarsened_tag_data->fill(0, 0);
 #if defined(HAVE_CUDA)
-   cudaDeviceSynchronize();
+   tbox::parallel_sychronize();
 #endif
 
    size_t coarse_tag_count = 0;

--- a/source/SAMRAI/tbox/GPUUtilities.h
+++ b/source/SAMRAI/tbox/GPUUtilities.h
@@ -47,7 +47,9 @@ static void
 parallel_synchronize()
 {
 #if defined(HAVE_CUDA) && defined(HAVE_RAJA)
-   if (s_using_gpu) RAJA::synchronize<RAJA::cuda_synchronize>();
+   if (s_using_gpu) {
+      RAJA::synchronize<RAJA::cuda_synchronize>();
+   }
 #endif       
 }
 


### PR DESCRIPTION
This gets rid of one stray direct `cudaDeviceSynchronize` call that is inconsistent with other usage.