### PR TITLE
tbox: RestartManager expose filename/dir building to public interface

### DIFF
--- a/source/SAMRAI/tbox/RestartManager.h
+++ b/source/SAMRAI/tbox/RestartManager.h
@@ -122,6 +122,23 @@ public:
    void
    closeRestartFile();
 
+
+   /**
+    * returns a std::string of the path for restart files
+    */
+   std::string
+   getRestartFileDir(
+       const std::string& root_dirname,
+       int restore_num);
+
+   /**
+    * returns a std::string for this procs restart file
+    */
+   std::string
+   getRestartFileFullPath(
+       const std::string& root_dirname,
+       int restore_num);
+
    /**
     * Returns a std::shared_ptr to the root of the database.
     */


### PR DESCRIPTION
we'd like to inject somethings into these files so it would be good to have a way to know the path

if you have any issues accepting this please let me know so we can figure something else out