### PR TITLE
Adjust ArrayView to change in RAJA offset layout

### DIFF
--- a/INSTALL-NOTES
+++ b/INSTALL-NOTES
@@ -298,7 +298,7 @@ graphviz	2.26
 
 Umpire          6.0.0
 
-RAJA            0.14.1
+RAJA            v2022.03.0
 
 
 Visualization Tools:

--- a/source/SAMRAI/pdat/ArrayView.h
+++ b/source/SAMRAI/pdat/ArrayView.h
@@ -70,7 +70,7 @@ struct ArrayView<1, TYPE> : public RAJA::View<TYPE, detail::layout_traits::Layou
          data,
          RAJA::make_permuted_offset_layout(
             std::array<RAJA::Index_type, 1>{ {box.lower()[0]} },
-            std::array<RAJA::Index_type, 1>{ {box.upper()[0]} },
+            std::array<RAJA::Index_type, 1>{ {box.upper()[0]+1} },
             RAJA::as_array<RAJA::PERM_I>::get())){}
 };
 
@@ -84,7 +84,7 @@ struct ArrayView<2, TYPE> : public RAJA::View<TYPE, detail::layout_traits::Layou
          data,
          RAJA::make_permuted_offset_layout(
             std::array<RAJA::Index_type, 2>{ {box.lower()[0], box.lower()[1]} },
-            std::array<RAJA::Index_type, 2>{ {box.upper()[0], box.upper()[1]} },
+            std::array<RAJA::Index_type, 2>{ {box.upper()[0]+1, box.upper()[1]+1} },
             RAJA::as_array<RAJA::PERM_JI>::get())){}
 };
 
@@ -98,7 +98,7 @@ struct ArrayView<3, TYPE> : public RAJA::View<TYPE, detail::layout_traits::Layou
          data,
          RAJA::make_permuted_offset_layout(
             std::array<RAJA::Index_type, 3>{ {box.lower()[0], box.lower()[1], box.lower()[2]} },
-            std::array<RAJA::Index_type, 3>{ {box.upper()[0], box.upper()[1], box.upper()[2]} },
+            std::array<RAJA::Index_type, 3>{ {box.upper()[0]+1, box.upper()[1]+1, box.upper()[2]+1} },
             RAJA::as_array<RAJA::PERM_KJI>::get())){};
 };
 
@@ -112,7 +112,7 @@ struct ArrayView<1, const TYPE> : public RAJA::View<const TYPE, detail::layout_t
          data,
          RAJA::make_permuted_offset_layout(
             std::array<RAJA::Index_type, 1>{ {box.lower()[0]} },
-            std::array<RAJA::Index_type, 1>{ {box.upper()[0]} },
+            std::array<RAJA::Index_type, 1>{ {box.upper()[0]+1} },
             RAJA::as_array<RAJA::PERM_I>::get())){}
 };
 
@@ -126,7 +126,7 @@ struct ArrayView<2, const TYPE> : public RAJA::View<const TYPE, detail::layout_t
          data,
          RAJA::make_permuted_offset_layout(
             std::array<RAJA::Index_type, 2>{ {box.lower()[0], box.lower()[1]} },
-            std::array<RAJA::Index_type, 2>{ {box.upper()[0], box.upper()[1]} },
+            std::array<RAJA::Index_type, 2>{ {box.upper()[0]+1, box.upper()[1]+1} },
             RAJA::as_array<RAJA::PERM_JI>::get())){}
 };
 
@@ -141,7 +141,7 @@ struct ArrayView<3, const TYPE> : public RAJA::View<const TYPE, detail::layout_t
          data,
          RAJA::make_permuted_offset_layout(
             std::array<RAJA::Index_type, 3>{ {box.lower()[0], box.lower()[1], box.lower()[2]} },
-            std::array<RAJA::Index_type, 3>{ {box.upper()[0], box.upper()[1], box.upper()[2]} },
+            std::array<RAJA::Index_type, 3>{ {box.upper()[0]+1, box.upper()[1]+1, box.upper()[2]+1} },
             RAJA::as_array<RAJA::PERM_KJI>::get())){};
 };
 

--- a/source/test/dataops/CMakeLists.txt
+++ b/source/test/dataops/CMakeLists.txt
@@ -21,6 +21,12 @@ blt_add_executable(
 
 
 blt_add_executable(
+  NAME cell_fillall
+  SOURCES cell_fillall.cpp
+  DEPENDS_ON
+    ${dataops_depends})
+
+blt_add_executable(
   NAME cell_patchtest
   SOURCES cell_patchtest.cpp
   DEPENDS_ON

--- a/source/test/dataops/cell_fillall.cpp
+++ b/source/test/dataops/cell_fillall.cpp
@@ -44,32 +44,54 @@ int main(
    int num_failures = 0;
 
    hier::Index lo(0,0);
-   hier::Index hi(1,1);
+   hier::Index hi(9,17);
    hier::IntVector ghosts(dim, 0);
    hier::Box box(lo, hi, hier::BlockId(0));
-   pdat::CellData<double> cdata(box, 1, ghosts);
+   pdat::CellData<int> cdata(box, 1, ghosts);
 
-   cdata.fillAll(-1.0);
-   cdata.print(cdata.getGhostBox(), tbox::pout);
-
-   cdata.fillAll(5.27, cdata.getGhostBox());
+   cdata.fillAll(-1);
 
    pdat::CellIterator icend(pdat::CellGeometry::end(cdata.getGhostBox()));
    for (pdat::CellIterator c(pdat::CellGeometry::begin(cdata.getGhostBox()));
         c != icend; ++c) {
-      if (cdata(*c) < 0.0) {
+      if (cdata(*c) != -1) {
          ++num_failures;
       }
    }
 
-   cdata.print(cdata.getGhostBox(), tbox::pout);
+   cdata.fillAll(5, cdata.getGhostBox());
+
+   for (pdat::CellIterator c(pdat::CellGeometry::begin(cdata.getGhostBox()));
+        c != icend; ++c) {
+      if (cdata(*c) != 5) {
+         ++num_failures;
+      }
+   }
+
+   hier::Index lo_2(3,4);
+   hier::Index hi_2(7,12);
+   hier::Box box_2(lo_2, hi_2, hier::BlockId(0));
+
+   cdata.fillAll(12, box_2);
+
+   for (pdat::CellIterator c(pdat::CellGeometry::begin(cdata.getGhostBox()));
+        c != icend; ++c) {
+      if (box_2.contains(*c)) {
+         if (cdata(*c) != 12) {
+            ++num_failures;
+         }
+      } else {
+         if (cdata(*c) != 5) {
+            ++num_failures;
+         }
+      }
+   }
 
    if (num_failures == 0) {
       tbox::pout << "\nPASSED:  cell fillall" << std::endl;
    } else {
       tbox::perr << "\nFAILED:  cell fillall" << std::endl;
    }
-
 
    tbox::SAMRAIManager::shutdown();
    tbox::SAMRAIManager::finalize();

--- a/source/test/dataops/cell_fillall.cpp
+++ b/source/test/dataops/cell_fillall.cpp
@@ -1,0 +1,80 @@
+/*************************************************************************
+ *
+ * This file is part of the SAMRAI distribution.  For full copyright
+ * information, see COPYRIGHT and LICENSE.
+ *
+ * Copyright:     (c) 1997-2022 Lawrence Livermore National Security, LLC
+ * Description:   Main program to test cell patch data operations.
+ *
+ ************************************************************************/
+
+#include "SAMRAI/SAMRAI_config.h"
+
+#include <typeinfo>
+
+#include "SAMRAI/tbox/SAMRAI_MPI.h"
+#include "SAMRAI/tbox/PIO.h"
+
+#include "SAMRAI/tbox/SAMRAIManager.h"
+
+#include "SAMRAI/hier/Box.h"
+#include "SAMRAI/hier/BoxContainer.h"
+#include "SAMRAI/pdat/CellData.h"
+#include "SAMRAI/pdat/CellIndex.h"
+#include "SAMRAI/pdat/CellIterator.h"
+#include "SAMRAI/hier/Index.h"
+#include "SAMRAI/hier/IntVector.h"
+#include <string>
+
+#include "SAMRAI/tbox/Utilities.h"
+#include "SAMRAI/tbox/MathUtilities.h"
+
+using namespace SAMRAI;
+
+int main(
+   int argc,
+   char* argv[]) {
+
+   tbox::SAMRAI_MPI::init(&argc, &argv);
+   tbox::SAMRAIManager::initialize();
+   tbox::SAMRAIManager::startup();
+
+   const tbox::Dimension dim(2);
+
+   int num_failures = 0;
+
+   hier::Index lo(0,0);
+   hier::Index hi(1,1);
+   hier::IntVector ghosts(dim, 0);
+   hier::Box box(lo, hi, hier::BlockId(0));
+   pdat::CellData<double> cdata(box, 1, ghosts);
+
+   cdata.fillAll(-1.0);
+   cdata.print(cdata.getGhostBox(), tbox::pout);
+
+   cdata.fillAll(5.27, cdata.getGhostBox());
+
+   pdat::CellIterator icend(pdat::CellGeometry::end(cdata.getGhostBox()));
+   for (pdat::CellIterator c(pdat::CellGeometry::begin(cdata.getGhostBox()));
+        c != icend; ++c) {
+      if (cdata(*c) < 0.0) {
+         ++num_failures;
+      }
+   }
+
+   cdata.print(cdata.getGhostBox(), tbox::pout);
+
+   if (num_failures == 0) {
+      tbox::pout << "\nPASSED:  cell fillall" << std::endl;
+   } else {
+      tbox::perr << "\nFAILED:  cell fillall" << std::endl;
+   }
+
+
+   tbox::SAMRAIManager::shutdown();
+   tbox::SAMRAIManager::finalize();
+   tbox::SAMRAI_MPI::finalize();
+
+   return num_failures;
+}
+


### PR DESCRIPTION
This makes things compatible with a recent change in RAJA where the upper bound of a range of indices is no longer automatically included as part of the range, so we needed to add +1 to our calls to keep things working.