### PR TITLE
Make fine connector widths large enough to handle large tag buffers

### DIFF
--- a/source/SAMRAI/algs/TimeRefinementIntegratorConnectorWidthRequestor.cpp
+++ b/source/SAMRAI/algs/TimeRefinementIntegratorConnectorWidthRequestor.cpp
@@ -68,14 +68,19 @@ TimeRefinementIntegratorConnectorWidthRequestor::computeRequiredConnectorWidths(
          patch_hierarchy.getNumberBlocks());
       self_connector_widths.push_back(buffer);
       if (ln < static_cast<size_t>(max_levels-1)) {
-         const hier::IntVector& ratio =
+         const hier::IntVector& ratio_to_coarse =
             patch_hierarchy.getRatioToCoarserLevel(ln+1);
-         for (hier::BlockId::block_t b = 0;
+        for (hier::BlockId::block_t b = 0;
               b < patch_hierarchy.getNumberBlocks(); ++b) {
             for (int d = 0; d < dim.getValue(); ++d) {
-               while (self_connector_widths[ln](b,d) >
-                      fine_connector_widths[ln](b,d) * ratio(b,d)) {
-                  ++fine_connector_widths[ln](b,d);  
+               int& fine_w = fine_connector_widths[ln](b,d);
+               const int& self_w = self_connector_widths[ln](b,d);
+               const int& ratio = ratio_to_coarse(b,d);
+               if (fine_w * ratio < self_w) {
+                  fine_w = self_w / ratio;
+                  if (self_w % ratio) {
+                     ++fine_w;
+                  }
                }
             }
          }

--- a/source/test/applications/Euler/test_inputs/test_buffer.2d.input
+++ b/source/test/applications/Euler/test_inputs/test_buffer.2d.input
@@ -1,0 +1,416 @@
+/*************************************************************************
+ *
+ * This file is part of the SAMRAI distribution.  For full copyright 
+ * information, see COPYRIGHT and LICENSE. 
+ *
+ * Copyright:     (c) 1997-2022 Lawrence Livermore National Security, LLC
+ * Description:   Input file for SAMRAI Euler 2d test problem 
+ *
+ ************************************************************************/
+
+GlobalInputs {
+   // If FALSE, when an error is encountered in serial exit(-1) will be called
+   // instead of SAMRAI_MPI::abort().
+   call_abort_in_serial_instead_of_exit = FALSE
+}
+
+AutoTester {
+   // If true, fluxes will be written out to a .dat file for inspection.
+   // Default is FALSE.
+   test_fluxes = FALSE
+
+   // iteration to carry out test.  Default is 10.
+   test_iter_num = 10
+
+   // if true will write correct patch boxes--useful for rebaselining
+   // Default is FALSE.
+   write_patch_boxes = FALSE
+
+   // if true will read correct patch boxes--set to FALSE to rebaseline
+   // Default is FALSE.
+   read_patch_boxes = FALSE
+
+   // time steps for which correctness of patch boxes will be checked
+   // Required if one of write_patch_boxes or read_patch_boxes is true.
+   // No default.
+   test_patch_boxes_at_steps = 0, 5, 10
+
+   // base name of files containing correct patch boxes
+   // Required if one of write_patch_boxes or read_patch_boxes is true.
+   // No default.
+   test_patch_boxes_filename = "test_inputs/test.2d.boxes"
+
+   // expected correct result
+   // Required if test_fluxes is FALSE.  Unread otherwise.  No default.
+   correct_result =  0.0199217807513, 0.000628605927026, 6.993349008294e-05
+
+   // if true will write corrct result--useful for rebaselining
+   // Default is FALSE.
+   output_correct = FALSE
+}
+
+Euler {
+   // Allow nonuniform workload.  Default is FALSE.
+   use_nonuniform_workload = FALSE
+
+   // Ratio of specific heats.  Not read on restart.  Default is 1.4.
+   gamma            = 1.4
+
+   // Riemann solver used in flux calculation.  Must be one of
+   // "APPROX_RIEM_SOLVE", "EXACT_RIEM_SOLVE", "HLLC_RIEM_SOLVE".
+   // Default is "APPROX_RIEM_SOLVE".
+   riemann_solve        = "APPROX_RIEM_SOLVE"
+//   riemann_solve        = "EXACT_RIEM_SOLVE"
+//   riemann_solve        = "HLLC_RIEM_SOLVE"
+
+   // Order of Goduov slopes (1, 2, or 4).  Default is 1.
+   godunov_order    = 4
+
+   // Type of finite difference approximation for 3d transverse flux
+   // correction.  Allowed values are CORNER_TRANSPORT_1 and
+   // CORNER_TRANSPORT_2.
+   // CORNER_TRANSPORT_1 means to compute numerical approximations to flux
+   // terms using an extension to three dimensions of Collella's corner
+   // transport upwind approach.  
+   // CORNER_TRANSPORT_2 means to compute numerical approximations to flux
+   // terms using John Trangenstein's interpretation of the three-dimensional
+   // version of Collella's corner transport upwind approach.
+   // Default is "CORNER_TRANSPORT_1".
+   corner_transport = "CORNER_TRANSPORT_1"
+
+   // Control of how to refine.
+   Refinement_data {
+      // Refinement criteria and, for each, the parameters controling it.
+      // Refinement criteria may be one or more of DENSITY_DEVIATION,
+      // DENSITY_GRADIENT, DENSITY_SHOCK, DENSITY_RICHARDSON,
+      // PRESSURE_DEVIATION, PRESSURE_GRADIENT, PRESSURE_SHOCK, or
+      // PRESSURE_RICHARDSON.
+      // Input required.  No default.
+      refine_criteria = "PRESSURE_GRADIENT", "PRESSURE_SHOCK"
+
+      // Criteria for PRESSURE_GRADIENT refinement criteria.
+      PRESSURE_GRADIENT {
+         // Array of pressure gradient tagging tolerances, one value per level.
+         // If the number of levels is greater than the number of entries in
+         // this array then the tolerance for all finer levels is the last
+         // array entry.  Gradients greater than this tolerance result in
+         // tagged cells.  No default.
+         grad_tol = 20.0
+
+         // Array of maximum simulation times for which this criteria applies,
+         // one per level.  If the number of levels is greater than the number
+         // of entries in this array then the maximum simulation time for all
+         // finer levels is the last array entry.
+         // Default is all time (maximum double) for all levels.
+//         time_max = 1000000.0
+
+         // Array of minimum simulation times for which this criteria applies,
+         // one per level.  If the number of levels is greater than the number
+         // of entries in this array then the minimum simulation time for all
+         // finer levels is the last array entry.
+         // Default is 0.0 for all levels.
+         time_min = 0.0
+      }
+
+      // Criteria for PRESSURE_SHOCK refinement criteria.
+      PRESSURE_SHOCK {
+         // Array of shock tagging tolerances, one value per level.  If the
+         // number of levels is greater than the number of entries in this
+         // array then the tolerance for all finer levels is the last array
+         // entry.  No default.
+         shock_tol   = 10.0
+
+         // Array of shock tagging onsets, one value per level.  This value is
+         // used to prevent unintended overrefinement of large, smooth
+         // gradients resulting in smooth flow.  If the number of levels is
+         // greater than the number of entries in this array then the onset for
+         // all finer levels is the last array entry. No default.
+         shock_onset = 0.90
+
+         // Array of maximum simulation times for which this criteria applies,
+         // one per level.  If the number of levels is greater than the number
+         // of entries in this array then the maximum simulation time for all
+         // finer levels is the last array entry.
+         // Default is all time (maximum double) for all levels.
+//         time_max = 1000000.0
+
+         // Array of minimum simulation times for which this criteria applies,
+         // one per level.  If the number of levels is greater than the number
+         // of entries in this array then the minimum simulation time for all
+         // finer levels is the last array entry.
+         // Default is 0.0 for all levels.
+         time_min = 0.0
+      }
+
+      // PRESSURE_DEVIATION
+      // dev_tol
+      // An array of pressure deviation tolerances, one value per level.  Cell
+      // is refined if (p - pressure_dev) > dev_tol.  If the number of levels
+      // is greater than the number of entries in this array then the tolerance
+      // for all finer levels is the last array entry.  No default.
+      // pressure_dev
+      // An array of pressure deviations, one value per level.  If the number
+      // of levels is greater than the number of entries in this array then the
+      // deviation of for all finer levels is the last array entry.
+      // No default.
+      // time_max
+      // An array of maximum simulation times for which this criteria applies,
+      // one per level.  If the number of levels is greater than the number of
+      // entries in this array then the maximum simulation time for all finer
+      // levels is the last array entry.  Default is all time (maximum double)
+      // for all levels.
+      // time_min
+      // An array of minimum simulation times for which this criteria applies,
+      // one per level.  If the number of levels is greater than the number of
+      // entries in this array then the minimum simulation time for all finer
+      // levels is the last array entry.  Default is 0.0 for all levels.
+
+      // PRESSURE_RICHARDSON
+      // rich_tol
+      // An array of tolerances on the global error.  Cells in which the global
+      // error exceeds the tolerance are tagged.  If the number of levels is
+      // greater than the number of entries in this array then the tolerance
+      // for all finer levels is the last array entry.  No default.
+      // time_max
+      // An array of maximum simulation times for which this criteria applies,
+      // one per level.  If the number of levels is greater than the number of
+      // entries in this array then the maximum simulation time for all finer
+      // levels is the last array entry.  Default is all time (maximum double)
+      // for all levels.
+      // time_min
+      // An array of minimum simulation times for which this criteria applies,
+      // one per level.  If the number of levels is greater than the number of
+      // entries in this array then the minimum simulation time for all finer
+      // levels is the last array entry.  Default is 0.0 for all levels.
+
+      // DENSITY_GRADIENT inputs are grad_tol, time_max, time_min and are
+      // analogous to those for PRESSURE_GRADIENT.
+
+      // DENSITY_SHOCK input are shock_onset, shock_tol, time_max, time_min and
+      // are analogous to thos pre PRESSURE_SHOCK.
+
+      // DENSITY_DEVIATION inputs are dev_tol, density_dev, time_max, time_min
+      // and are analogous to those for PRESSURE_DEVIATION.
+
+      // DENSITY_RICHARDSON inputs are rich_tol, time_max, time_min and are
+      // analogous to those for PRESSURE_RICHARDSON.
+   }
+
+   // General type of problem and its initial conditions.  Options are "STEP",
+   // "SPHERE", "PIECEWISE_CONSTANT_X", "PIECEWISE_CONSTANT_"Y,
+   // "PIECEWISE_CONSTANT_Z".  Specific Initial_data inputs vary by problem
+   // type.  No default.
+   data_problem      = "STEP"
+   Initial_data {
+      // Initial location of front.
+      front_position = 0.0
+      // Initial conditions on one side of step.
+      interval_0 {
+         density         = 1.4
+         velocity        = 3.0 , 0.0 // vector of length dim
+         pressure        = 1.0
+      }
+      // Initial conditions on other side of step.
+      interval_1 {
+         density         = 1.4
+         velocity        = 3.0 , 0.0 // vector of length dim
+         pressure        = 1.0
+      }
+   }
+
+   // Boundary condition data following the format defined in
+   // appu::CartesianBoundaryUtility[2,3].  Refer to these classes for details.
+   Boundary_data {
+      boundary_edge_xlo {
+         boundary_condition      = "FLOW"
+      }
+      boundary_edge_xhi {
+         boundary_condition      = "REFLECT"
+      }
+      boundary_edge_ylo {
+         boundary_condition      = "REFLECT"
+      }
+      boundary_edge_yhi {
+         boundary_condition      = "REFLECT"
+      }
+
+      // IMPORTANT: If a *REFLECT, *DIRICHLET, or *FLOW condition is given
+      //            for a node, the condition must match that of the
+      //            appropriate adjacent edge above.  This is enforced for
+      //            consistency.  However, note when a REFLECT edge condition
+      //            is given and the other adjacent edge has either a FLOW
+      //            or REFLECT condition, the resulting node boundary values
+      //            will be the same regardless of which edge is used.
+      boundary_node_xlo_ylo {
+         boundary_condition      = "YREFLECT"
+      }
+      boundary_node_xhi_ylo {
+         boundary_condition      = "YREFLECT"
+      }
+      boundary_node_xlo_yhi {
+         boundary_condition      = "YREFLECT"
+      }
+      boundary_node_xhi_yhi {
+         boundary_condition      = "YREFLECT"
+      }
+   }
+
+}
+
+Main {
+   // Dimension of problem.  Required input.  No default.
+   dim = 2
+
+
+   // Base name of log and viz files.  Default is "unnamed".
+   base_name = "test.2d"
+
+
+   // Explicit name of log file.  Default is base_name + ".log"
+   log_filname = "test.2d.log"
+
+
+   // If true all nodes will log to individual files.
+   // If false only node 0 will log.
+   // Default is FALSE.
+   log_all_nodes    = TRUE
+
+
+   // Visualization dump parameters.
+
+   // Frequency at which to dump viz output--zero to turn off.
+   // Default is 0.
+   viz_dump_interval    = 1
+
+   // Directory in which to place viz output.
+   // Default is base_name + ".visit"
+   viz_dump_dirname = "test.2d.visit"
+
+   // Number of processors which write to each viz file.
+   // Default is 1.
+   visit_number_procs_per_file = 1
+
+
+   // Restart dump parameters.
+
+   // Frequency at which to dump restart output--zero to turn off.
+   // Default is 0.
+   restart_interval     = 1      
+
+   // Directory in which to place restart output.
+   // Default is base_name + ".restart"
+   restart_write_dirname = "test.2d.restart"
+
+
+   // If anything but "SYNCHRONIZED" will use refined timestepping.
+   // Default is not "SYNCHRONIZED".
+//   use_refined_timestepping = "SYNCHRONIZED"
+}
+
+// Refer to tbox::TimerManager for input
+TimerManager{
+   print_exclusive      = TRUE   // output exclusive time
+   timer_list               = "apps::main::*",
+                              "apps::Euler::*",
+                              "algs::GriddingAlgorithm::*",
+                              "algs::HyperbolicLevelIntegrator::*"
+}
+
+// Refer to geom::CartesianGridGeometry and its base classes for input
+CartesianGeometry {
+   domain_boxes = [ (0,0) , (9,19) ],
+                  [ (10,4) , (49,19) ]
+   x_lo         = 0.e0 , 0.e0   // lower end of computational domain.
+   x_up         = 2.5e0 , 1.e0  // upper end of computational domain.
+}
+
+// Refer to mesh::StandardTagAndInitialize for input
+StandardTagAndInitialize{
+   tagging_method = "GRADIENT_DETECTOR"
+}
+
+// Refer to hier::PatchHierarchy for input
+PatchHierarchy {
+
+   max_levels = 5         // Maximum number of levels in hierarchy.
+
+   ratio_to_coarser {              // vector ratio to next coarser level
+      level_1            = 2 , 2
+      level_2            = 2 , 2
+      level_3            = 2 , 2
+      level_4            = 2 , 2
+   }
+
+   largest_patch_size {
+      level_0 = 320 , 320
+      // all finer levels will use same values as level_0...
+   }
+
+   smallest_patch_size {
+      level_0 = 8 , 8
+      level_1 = 8 , 8
+      level_2 = 8 , 8
+      level_3 = 12 , 12
+   }
+
+   allow_patches_smaller_than_ghostwidth = TRUE
+   allow_patches_smaller_than_minimum_size_to_prevent_overlaps = TRUE
+
+   proper_nesting_buffer = 1, 1
+
+}
+
+// Refer to mesh::GriddingAlgorithm for input
+GriddingAlgorithm {
+   enforce_proper_nesting = TRUE
+   DEV_extend_to_domain_boundary = TRUE
+   check_nonrefined_tags = "IGNORE"
+   sequentialize_patch_indices = TRUE // Required for plotting.
+
+   check_overlapping_patches = "IGNORE"
+}
+
+// Refer to mesh::BergerRigoutsos for input
+BergerRigoutsos {
+   DEV_algo_advance_mode = "ADVANCE_SOME"
+   DEV_owner_mode = "MOST_OVERLAP"
+   DEV_log_node_history = FALSE
+   sort_output_nodes = TRUE // Makes results repeatable.
+   max_box_size = 100, 100
+   efficiency_tolerance   = 0.75e0    // min % of tag cells in new patch level
+   combine_efficiency     = 0.85e0    // chop box if sum of volumes of smaller
+                                      // boxes < efficiency * vol of large box
+   DEV_log_cluster_summary = FALSE
+   DEV_log_cluster = FALSE
+   DEV_barrier_before = TRUE
+   DEV_barrier_after = TRUE
+}
+
+// Refer to algs::HyperbolicLevelIntegrator for input
+HyperbolicLevelIntegrator {
+   cfl                      = 0.9e0    // max cfl factor used in problem
+   cfl_init                 = 0.1e0    // initial cfl factor
+   lag_dt_computation       = TRUE
+   use_ghosts_to_compute_dt = TRUE
+}
+
+// Refer to algs::TimeRefinementIntegrator for input
+TimeRefinementIntegrator {
+   start_time            = 0.e0    // initial simulation time
+   end_time              = 100.e0  // final simulation time
+   grow_dt               = 1.1e0   // growth factor for timesteps
+   max_integrator_steps  = 10      // max number of simulation timesteps
+   tag_buffer            = 10,10,10,10
+}
+
+// Refer to mesh::TreeLoadBalancer for input
+LoadBalancer {
+   DEV_report_load_balance = FALSE
+   DEV_barrier_before = TRUE
+   DEV_barrier_after = TRUE
+}
+
+// Refer to xfer::RefineSchedule for input
+RefineSchedule {
+   DEV_extra_debug = FALSE
+}

--- a/source/test/applications/Euler/test_inputs/test_buffer.3d.input
+++ b/source/test/applications/Euler/test_inputs/test_buffer.3d.input
@@ -1,0 +1,302 @@
+/*************************************************************************
+ *
+ * This file is part of the SAMRAI distribution.  For full copyright
+ * information, see COPYRIGHT and LICENSE.
+ *
+ * Copyright:     (c) 1997-2022 Lawrence Livermore National Security, LLC
+ * Description:   Input file for SAMRAI Euler example problem (3d box)
+ *
+ ************************************************************************/
+
+// Refer to test2d.input for full description of all input parameters specific
+// to this problem.
+
+GlobalInputs {
+   call_abort_in_serial_instead_of_exit = FALSE
+}
+
+AutoTester {
+   // iteration to carry out test
+   test_iter_num = 10
+
+   // expected correct result
+   correct_result = 0.0463367714649 ,  0.00370820618904 ,   0.000414460472703
+
+   // if true will write corrct result--useful for rebaselining
+   output_correct = FALSE
+
+   // if true will write correct patch boxes--useful for rebaselining
+   write_patch_boxes = FALSE
+
+   // if true will read correct patch boxes--set to FALSE to rebaseline
+   read_patch_boxes = FALSE
+
+   // time steps for which correctness of patch boxes will be checked
+   test_patch_boxes_at_steps = 0, 5, 10
+
+   // base name of files containing correct patch boxes
+   test_patch_boxes_filename = "test_inputs/test.3d.boxes"
+}
+
+Euler {
+   // Ratio of specific heats
+   gamma            = 1.4
+
+   // order of Goduov slopes (1, 2, or 4)
+   godunov_order    = 4
+
+   // Riemann solver used in flux calculation
+   riemann_solve     = "APPROX_RIEM_SOLVE"
+//   riemann_solve    = "EXACT_RIEM_SOLVE"
+//   riemann_solve    = "HLLC_RIEM_SOLVE"
+
+   // type of finite difference approximation for 3d transverse flux correction
+   // Allowed values are CORNER_TRANSPORT_1 and CORNER_TRANSPORT_2.
+   // CORNER_TRANSPORT_1 means to compute numerical approximations to flux
+   // terms using an extension to three dimensions of Collella's corner
+   // transport upwind approach.
+   // CORNER_TRANSPORT_2 means to compute numerical approximations to flux
+   // terms using John Trangenstein's interpretation of the three-dimensional
+   // version of Collella's corner transport upwind approach.
+   corner_transport = "CORNER_TRANSPORT_2"
+
+   // General type of problem and its initial conditions.
+   data_problem      = "SPHERE"
+   Initial_data {
+      radius            = 0.125
+      center            = 0.5 , 0.5 , 0.5 // vector of length dim
+
+      density_inside    = 8.0
+      velocity_inside   = 0.0 , 0.0 , 0.0 // vector of length dim
+      pressure_inside   = 40.0
+
+      density_outside    = 1.0
+      velocity_outside   = 0.0 , 0.0 , 0.0 // vector of length dim
+      pressure_outside   = 1.0
+
+   }
+
+   // Refinement criteria and, for each, the parameters controling it.
+   // Refinement criteria may be one or more of DENSITY_DEVIATION,
+   // DENSITY_GRADIENT, DENSITY_SHOCK, DENSITY_RICHARDSON, PRESSURE_DEVIATION,
+   // PRESSURE_GRADIENT, PRESSURE_SHOCK, or PRESSURE_RICHARDSON.
+   Refinement_data {
+      refine_criteria = "PRESSURE_GRADIENT", "PRESSURE_SHOCK"
+
+      PRESSURE_GRADIENT {
+         grad_tol = 10.0
+      }
+
+      PRESSURE_SHOCK {
+         shock_tol   = 10.0
+         shock_onset = 0.85
+      }
+   }
+
+   // Boundary condition data following the format defined in
+   // appu::CartesianBoundaryUtility[2,3]
+   Boundary_data {
+      boundary_face_xlo {
+         boundary_condition      = "FLOW"
+      }
+      boundary_face_xhi {
+         boundary_condition      = "FLOW"
+      }
+      boundary_face_ylo {
+         boundary_condition      = "FLOW"
+      }
+      boundary_face_yhi {
+         boundary_condition      = "FLOW"
+      }
+      boundary_face_zlo {
+         boundary_condition      = "FLOW"
+      }
+      boundary_face_zhi {
+         boundary_condition      = "FLOW"
+      }
+
+      // IMPORTANT: If a *REFLECT, *DIRICHLET, or *FLOW condition is given
+      //            for an edge, the condition must match that of the
+      //            appropriate adjacent face above.  This is enforced for
+      //            consistency.  However, note when a REFLECT face condition
+      //            is given and the other adjacent face has either a FLOW
+      //            or REFLECT condition, the resulting edge boundary values
+      //            will be the same regardless of which face is used.
+
+      boundary_edge_ylo_zlo { // XFLOW, XREFLECT, XDIRICHLET not allowed
+         boundary_condition      = "ZFLOW"
+      }
+      boundary_edge_yhi_zlo { // XFLOW, XREFLECT, XDIRICHLET not allowed
+         boundary_condition      = "ZFLOW"
+      }
+      boundary_edge_ylo_zhi { // XFLOW, XREFLECT, XDIRICHLET not allowed
+         boundary_condition      = "ZFLOW"
+      }
+      boundary_edge_yhi_zhi { // XFLOW, XREFLECT, XDIRICHLET not allowed
+         boundary_condition      = "ZFLOW"
+      }
+      boundary_edge_xlo_zlo { // YFLOW, YREFLECT, YDIRICHLET not allowed
+         boundary_condition      = "XFLOW"
+      }
+      boundary_edge_xlo_zhi { // YFLOW, YREFLECT, YDIRICHLET not allowed
+         boundary_condition      = "XFLOW"
+      }
+      boundary_edge_xhi_zlo { // YFLOW, YREFLECT, YDIRICHLET not allowed
+         boundary_condition      = "XFLOW"
+      }
+      boundary_edge_xhi_zhi { // YFLOW, YREFLECT, YDIRICHLET not allowed
+         boundary_condition      = "XFLOW"
+      }
+      boundary_edge_xlo_ylo { // ZFLOW, ZREFLECT, ZDIRICHLET not allowed
+         boundary_condition      = "YFLOW"
+      }
+      boundary_edge_xhi_ylo { // ZFLOW, ZREFLECT, ZDIRICHLET not allowed
+         boundary_condition      = "YFLOW"
+      }
+      boundary_edge_xlo_yhi { // ZFLOW, ZREFLECT, ZDIRICHLET not allowed
+         boundary_condition      = "YFLOW"
+      }
+      boundary_edge_xhi_yhi { // ZFLOW, ZREFLECT, ZDIRICHLET not allowed
+         boundary_condition      = "YFLOW"
+      }
+
+      // IMPORTANT: If a *REFLECT, *DIRICHLET, or *FLOW condition is given
+      //            for a node, the condition must match that of the
+      //            appropriate adjacent face above.  This is enforced for
+      //            consistency.  However, note when a REFLECT face condition
+      //            is given and the other adjacent faces have either FLOW
+      //            or REFLECT conditions, the resulting node boundary values
+      //            will be the same regardless of which face is used.
+
+      boundary_node_xlo_ylo_zlo {
+         boundary_condition      = "XFLOW"
+      }
+      boundary_node_xhi_ylo_zlo {
+         boundary_condition      = "XFLOW"
+      }
+      boundary_node_xlo_yhi_zlo {
+         boundary_condition      = "XFLOW"
+      }
+      boundary_node_xhi_yhi_zlo {
+         boundary_condition      = "XFLOW"
+      }
+      boundary_node_xlo_ylo_zhi {
+         boundary_condition      = "XFLOW"
+      }
+      boundary_node_xhi_ylo_zhi {
+         boundary_condition      = "XFLOW"
+      }
+      boundary_node_xlo_yhi_zhi {
+         boundary_condition      = "XFLOW"
+      }
+      boundary_node_xhi_yhi_zhi {
+         boundary_condition      = "XFLOW"
+      }
+
+   }
+
+}
+
+Main {
+   // dimension of problem
+   dim = 3
+
+   // base name of log file
+   base_name = "test.3d"
+
+   // if true all nodes will log to individual files
+   // if false only node 0 will log
+   log_all_nodes    = TRUE
+
+   // visualization dump parameters
+   // frequency at which to dump viz output--zero to turn off
+   viz_dump_interval    = 1
+
+   // restart dump parameters
+   // frequency at which to dump restart output--zero to turn off
+   restart_interval     = 1
+}
+
+// Refer to tbox::TimerManager for input
+TimerManager {
+   print_exclusive      = TRUE   // output exclusive time
+   timer_list               = "apps::main::*",
+                              "apps::Euler::*",
+                              "algs::GriddingAlgorithm::*",
+                              "algs::HyperbolicLevelIntegrator::*"
+}
+
+// Refer to geom::CartesianGridGeometry and its base classes for input
+CartesianGeometry {
+   domain_boxes  = [ (0,0,0) , (12,12,12) ]
+   x_lo          = 0.e0,0.e0,0.e0  // lower end of computational domain.
+   x_up          = 1.e0,1.e0,1.e0  // upper end of computational domain.
+}
+
+// Refer to mesh::StandardTagAndInitialize for input
+StandardTagAndInitialize{
+   tagging_method = "GRADIENT_DETECTOR"
+}
+
+// Refer to hier::PatchHierarchy for input
+PatchHierarchy {
+
+   max_levels = 3         // Maximum number of levels in hierarchy.
+
+   ratio_to_coarser {              // vector ratio to next coarser level
+      level_1            = 2 , 2 , 2
+      level_2            = 2 , 2 , 2
+   }
+
+   largest_patch_size {
+      level_0 = 19, 19, 19  // largest patch allowed in hierarchy
+      // all finer levels will use same values as level_0...
+   }
+
+   smallest_patch_size {
+      level_0 = 8, 8, 8
+      // all finer levels will use same values as level_0...
+   }
+
+}
+
+// Refer to mesh::GriddingAlgorithm for input
+GriddingAlgorithm {
+   DEV_log_metadata_statistics = TRUE
+   DEV_barrier_and_time = TRUE
+}
+
+// Refer to mesh::BergerRigoutsos for input
+BergerRigoutsos {
+   sort_output_nodes = TRUE // Makes results repeatable.
+   efficiency_tolerance   = 0.70e0    // min % of tag cells in new patch level
+   combine_efficiency     = 0.85e0    // chop box if sum of volumes of smaller
+                                      // boxes < efficiency * vol of large box
+}
+
+// Refer to algs::HyperbolicLevelIntegrator for input
+HyperbolicLevelIntegrator {
+   cfl                      = 0.9e0    // max cfl factor used in problem
+   cfl_init                 = 0.1e0    // initial cfl factor
+   lag_dt_computation       = TRUE
+   use_ghosts_to_compute_dt = TRUE
+}
+
+// Refer to algs::TimeRefinementIntegrator for input
+TimeRefinementIntegrator {
+   start_time            = 0.e0    // initial simulation time
+   end_time              = 100.e0  // final simulation time
+   grow_dt               = 1.1e0   // growth factor for timesteps
+   max_integrator_steps  = 10      // max number of simulation timesteps
+   tag_buffer            = 10,10,10,10 
+}
+
+// Refer to mesh::TreeLoadBalancer for input
+LoadBalancer {
+   // using default TreeLoadBalancer configuration
+}
+
+// Refer to xfer::RefineSchedule for input
+RefineSchedule {
+   DEV_extra_debug = FALSE
+}


### PR DESCRIPTION
This fixes a bug where the default intra-level self connector width gets set to a large value due to a relatively large tag buffer size being specified in the input, but the tag buffer had no effect on the inter-level fine connector width.  This caused the possibility of a large difference between the self connector width and the fine connector width, which can cause bridge operations during generation of new levels to fail

The fix is to make sure that the fine connector width is equal to the self connector width divided by the refinement ration (rounded up if there is a remainder).