### PR TITLE
Keep MPI tags in Connector algorithm classes constant

### DIFF
--- a/source/SAMRAI/hier/MappingConnectorAlgorithm.cpp
+++ b/source/SAMRAI/hier/MappingConnectorAlgorithm.cpp
@@ -536,6 +536,8 @@ MappingConnectorAlgorithm::privateModify(
     */
    d_object_timers->t_modify_setup_comm->start();
 
+   s_operation_mpi_tag = 0;
+
    setupCommunication(
       all_comms,
       comm_stage,

--- a/source/SAMRAI/hier/OverlapConnectorAlgorithm.cpp
+++ b/source/SAMRAI/hier/OverlapConnectorAlgorithm.cpp
@@ -1204,6 +1204,8 @@ OverlapConnectorAlgorithm::privateBridge(
       TBOX_ERROR("Errant message detected.");
    }
 
+   s_operation_mpi_tag = 0;
+
    setupCommunication(
       all_comms,
       comm_stage,


### PR DESCRIPTION
MappingConnectorAlgorithm and OverlapConnectorAlgorithm used a constantly increasing static value for the MPI tags used in sends and receives, so that each invocation used a unique value. This may have been necessary in the past, but is not now, since we have strict error-checking to ensure that there are no stray messages lingering for any tag value.  The increasing values risk surpassing upper bounds for valid values of the MPI tags.