### PR TITLE
Add cmake option MIN_TEST_PROCS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ option(ENABLE_SUNDIALS "Enable SUNDIALS" Off)
 # SAMRAI options
 option(ENABLE_SAMRAI_TESTS "Enable SAMRAI Test Programs" On)
 option(ENABLE_PERF_TESTS "Enable Performance Tests." Off)
+set(MIN_TEST_PROCS 1 CACHE INT "Minimum number of procs for tests.")
 set(NUM_PERF_PROCS 8 CACHE INT "Number of processors for performance tests.")
 option(ENABLE_CHECK_ASSERTIONS "Enable assertion checking." On)
 option(ENABLE_CHECK_DEV_ASSERTIONS "Enable SAMRAI developer assertion checking." Off)

--- a/cmake/SAMRAIMacros.cmake
+++ b/cmake/SAMRAIMacros.cmake
@@ -26,30 +26,40 @@ macro (samrai_add_tests)
 
     if (${do_small_tests})
       if(ENABLE_MPI)
-        blt_add_test(NAME ${test_name}
-          COMMAND ${arg_EXECUTABLE} ${command_args}
-          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-          NUM_MPI_TASKS 1)
+        if (${MIN_TEST_PROCS} LESS_EQUAL 1)
+          blt_add_test(NAME ${test_name}
+            COMMAND ${arg_EXECUTABLE} ${command_args}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            NUM_MPI_TASKS 1)
+          list(APPEND active_tests ${test_name})
+        endif()
       else()
         blt_add_test(NAME ${test_name}
           COMMAND ${arg_EXECUTABLE} ${command_args}
           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+        list(APPEND active_tests ${test_name})
       endif()  
     endif()  
  
     if(${arg_PARALLEL})
 
       if (${do_small_tests})
-        set(test_name "${base_name}_${test_label}_${short_test_file}_2")
-        blt_add_test(NAME ${test_name}
-          COMMAND ${arg_EXECUTABLE} ${command_args}
-          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-          NUM_MPI_TASKS 2)
-        set(test_name "${base_name}_${test_label}_${short_test_file}_4")
-        blt_add_test(NAME ${test_name}
-          COMMAND ${arg_EXECUTABLE} ${command_args}
-          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-          NUM_MPI_TASKS 4)
+        if (${MIN_TEST_PROCS} LESS_EQUAL 2)
+          set(test_name "${base_name}_${test_label}_${short_test_file}_2")
+          blt_add_test(NAME ${test_name}
+            COMMAND ${arg_EXECUTABLE} ${command_args}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            NUM_MPI_TASKS 2)
+          list(APPEND active_tests ${test_name})
+        endif()
+        if (${MIN_TEST_PROCS} LESS_EQUAL 4)
+          set(test_name "${base_name}_${test_label}_${short_test_file}_4")
+          blt_add_test(NAME ${test_name}
+            COMMAND ${arg_EXECUTABLE} ${command_args}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            NUM_MPI_TASKS 4)
+          list(APPEND active_tests ${test_name})
+        endif()
       else()
         set(num_perf_procs ${NUM_PERF_PROCS})
         set(test_name "${base_name}_${test_label}_${short_test_file}_${num_perf_procs}")
@@ -57,10 +67,11 @@ macro (samrai_add_tests)
           COMMAND ${arg_EXECUTABLE} ${command_args}
           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
           NUM_MPI_TASKS ${num_perf_procs})
+        list(APPEND active_tests ${test_name})
       endif()
     endif()
 
-    set_tests_properties(${test_name} PROPERTIES PASS_REGULAR_EXPRESSION "PASSED")
+    set_tests_properties(${active_tests} PROPERTIES PASS_REGULAR_EXPRESSION "PASSED")
 
   endforeach ()
 endmacro ()


### PR DESCRIPTION
MIN_TEST_PROCS can be used to reduce the number of parallel executions of the tests during "make test". With default value 1, it runs all of the tests on 1,2,4 procs, as usual.  With value 2, it runs tests on 2 and 4 procs, and with value 4, it runs them only on 4 procs.