### PR TITLE
C++20 compatibility dropping templates on destructor

### DIFF
--- a/source/SAMRAI/pdat/CellData.h
+++ b/source/SAMRAI/pdat/CellData.h
@@ -142,7 +142,7 @@ public:
    /*!
     * @brief The virtual destructor for a cell data object.
     */
-   virtual ~CellData<TYPE>();
+   virtual ~CellData();
 
    /*!
     * @brief Return the depth (e.g., the number of components in each spatial

--- a/source/SAMRAI/pdat/CellDataFactory.h
+++ b/source/SAMRAI/pdat/CellDataFactory.h
@@ -67,7 +67,7 @@ public:
    /**
     * Virtual destructor for the cell data factory class.
     */
-   virtual ~CellDataFactory<TYPE>();
+   virtual ~CellDataFactory();
 
    /**
     * @brief Abstract virtual function to clone a patch data factory.

--- a/source/SAMRAI/pdat/CellVariable.h
+++ b/source/SAMRAI/pdat/CellVariable.h
@@ -64,7 +64,7 @@ public:
    /*!
     * @brief Virtual destructor for cell variable objects.
     */
-   virtual ~CellVariable<TYPE>();
+   virtual ~CellVariable();
 
    /*!
     * @brief Return true indicating that cell data quantities will always

--- a/source/SAMRAI/pdat/NodeData.h
+++ b/source/SAMRAI/pdat/NodeData.h
@@ -145,7 +145,7 @@ public:
    /*!
     * @brief The virtual destructor for a node data object.
     */
-   virtual ~NodeData<TYPE>();
+   virtual ~NodeData();
 
    /*!
     * @brief Return the depth (e.g., the number of components in each spatial

--- a/source/SAMRAI/pdat/NodeDataFactory.h
+++ b/source/SAMRAI/pdat/NodeDataFactory.h
@@ -70,7 +70,7 @@ public:
    /**
     * Virtual destructor for the node data factory class.
     */
-   virtual ~NodeDataFactory<TYPE>();
+   virtual ~NodeDataFactory();
 
    /**
     * @brief Abstract virtual function to clone a patch data factory.

--- a/source/SAMRAI/pdat/NodeVariable.h
+++ b/source/SAMRAI/pdat/NodeVariable.h
@@ -68,7 +68,7 @@ public:
    /*!
     * @brief Virtual destructor for node variable objects.
     */
-   virtual ~NodeVariable<TYPE>();
+   virtual ~NodeVariable();
 
    /*!
     * @brief Return boolean indicating which node data values (coarse

--- a/source/SAMRAI/pdat/OuternodeData.h
+++ b/source/SAMRAI/pdat/OuternodeData.h
@@ -164,7 +164,7 @@ public:
    /*!
     * @brief Virtual destructor for a outernode data object.
     */
-   virtual ~OuternodeData<TYPE>();
+   virtual ~OuternodeData();
 
    /*!
     * @brief Return the depth (e.g., the number of components at each spatial

--- a/source/SAMRAI/pdat/OuternodeDataFactory.h
+++ b/source/SAMRAI/pdat/OuternodeDataFactory.h
@@ -70,7 +70,7 @@ public:
    /*!
     * @brief Virtual destructor for the outernode data factory class.
     */
-   virtual ~OuternodeDataFactory<TYPE>();
+   virtual ~OuternodeDataFactory();
 
    /**
     * @brief Abstract virtual function to clone a patch data factory.


### PR DESCRIPTION
Hi,

We're trying to see if we can upgrade safely to C++20, in doing so I got this error 

```
pdat/NodeDataFactory.h:73:12: error: template-id not allowed for destructor
   73 |    virtual ~NodeDataFactory<TYPE>();
      |            ^
In file included from /path/to/samrai/master/include/SAMRAI/pdat/NodeDataFactory.h:170:
```

There's probably some places remaining that I didn't remove the templates from, but this is what was required to allow us to compile.