### PR TITLE
Remove unneeded template syntax from destructor declarations.

### DIFF
--- a/source/SAMRAI/math/ArrayDataBasicOps.h
+++ b/source/SAMRAI/math/ArrayDataBasicOps.h
@@ -53,7 +53,7 @@ public:
     */
    ArrayDataBasicOps();
 
-   ~ArrayDataBasicOps<TYPE>();
+   ~ArrayDataBasicOps();
 
    /**
     * Set dst = alpha * src, elementwise.

--- a/source/SAMRAI/math/ArrayDataMiscellaneousOpsReal.h
+++ b/source/SAMRAI/math/ArrayDataMiscellaneousOpsReal.h
@@ -55,7 +55,7 @@ public:
     */
    ArrayDataMiscellaneousOpsReal();
 
-   ~ArrayDataMiscellaneousOpsReal<TYPE>();
+   ~ArrayDataMiscellaneousOpsReal();
 
    /**
     * Return 1 if \f$\|data2_i\| > 0\f$ and \f$data1_i * data2_i \leq 0\f$, for

--- a/source/SAMRAI/math/ArrayDataNormOpsReal.h
+++ b/source/SAMRAI/math/ArrayDataNormOpsReal.h
@@ -53,7 +53,7 @@ public:
     */
    ArrayDataNormOpsReal();
 
-   ~ArrayDataNormOpsReal<TYPE>();
+   ~ArrayDataNormOpsReal();
 
    /**
     * Return sum of entries in control volume array.

--- a/source/SAMRAI/math/HierarchyCellDataOpsReal.h
+++ b/source/SAMRAI/math/HierarchyCellDataOpsReal.h
@@ -80,7 +80,7 @@ public:
    /**
     * Virtual destructor for the HierarchyCellDataOpsReal class.
     */
-   virtual ~HierarchyCellDataOpsReal<TYPE>();
+   virtual ~HierarchyCellDataOpsReal();
 
    /**
     * Reset patch hierarchy over which operations occur.

--- a/source/SAMRAI/math/HierarchyDataOpsReal.h
+++ b/source/SAMRAI/math/HierarchyDataOpsReal.h
@@ -56,7 +56,7 @@ public:
    /**
     * Virtual destructor for the HierarchyDataOpsReal class.
     */
-   virtual ~HierarchyDataOpsReal<TYPE>();
+   virtual ~HierarchyDataOpsReal();
 
    /**
     * Reset patch hierarchy over which operations occur.

--- a/source/SAMRAI/math/HierarchyEdgeDataOpsReal.h
+++ b/source/SAMRAI/math/HierarchyEdgeDataOpsReal.h
@@ -80,7 +80,7 @@ public:
    /**
     * Virtual destructor for the HierarchyEdgeDataOpsReal class.
     */
-   virtual ~HierarchyEdgeDataOpsReal<TYPE>();
+   virtual ~HierarchyEdgeDataOpsReal();
 
    /**
     * Reset patch hierarchy over which operations occur.

--- a/source/SAMRAI/math/HierarchyFaceDataOpsReal.h
+++ b/source/SAMRAI/math/HierarchyFaceDataOpsReal.h
@@ -80,7 +80,7 @@ public:
    /**
     * Virtual destructor for the HierarchyFaceDataOpsReal class.
     */
-   virtual ~HierarchyFaceDataOpsReal<TYPE>();
+   virtual ~HierarchyFaceDataOpsReal();
 
    /**
     * Reset patch hierarchy over which operations occur.

--- a/source/SAMRAI/math/HierarchyNodeDataOpsReal.h
+++ b/source/SAMRAI/math/HierarchyNodeDataOpsReal.h
@@ -80,7 +80,7 @@ public:
    /**
     * Virtual destructor for the HierarchyNodeDataOpsReal class.
     */
-   virtual ~HierarchyNodeDataOpsReal<TYPE>();
+   virtual ~HierarchyNodeDataOpsReal();
 
    /**
     * Reset patch hierarchy over which operations occur.

--- a/source/SAMRAI/math/HierarchySideDataOpsReal.h
+++ b/source/SAMRAI/math/HierarchySideDataOpsReal.h
@@ -81,7 +81,7 @@ public:
    /**
     * Virtual destructor for the HierarchySideDataOpsReal class.
     */
-   virtual ~HierarchySideDataOpsReal<TYPE>();
+   virtual ~HierarchySideDataOpsReal();
 
    /**
     * Reset patch hierarchy over which operations occur.

--- a/source/SAMRAI/math/PatchCellDataBasicOps.h
+++ b/source/SAMRAI/math/PatchCellDataBasicOps.h
@@ -54,7 +54,7 @@ public:
     */
    PatchCellDataBasicOps();
 
-   virtual ~PatchCellDataBasicOps<TYPE>();
+   virtual ~PatchCellDataBasicOps();
 
    /**
     * Set dst = alpha * src, elementwise.

--- a/source/SAMRAI/math/PatchCellDataMiscellaneousOpsReal.h
+++ b/source/SAMRAI/math/PatchCellDataMiscellaneousOpsReal.h
@@ -64,7 +64,7 @@ public:
     */
    PatchCellDataMiscellaneousOpsReal();
 
-   virtual ~PatchCellDataMiscellaneousOpsReal<TYPE>();
+   virtual ~PatchCellDataMiscellaneousOpsReal();
 
    /**
     * Return 1 if \f$\|data2_i\| > 0\f$ and \f$data1_i * data2_i \leq 0\f$, for

--- a/source/SAMRAI/math/PatchCellDataNormOpsReal.h
+++ b/source/SAMRAI/math/PatchCellDataNormOpsReal.h
@@ -64,7 +64,7 @@ public:
     */
    PatchCellDataNormOpsReal();
 
-   virtual ~PatchCellDataNormOpsReal<TYPE>();
+   virtual ~PatchCellDataNormOpsReal();
 
    /**
     * Return the number of data values for the cell-centered data object

--- a/source/SAMRAI/math/PatchCellDataOpsReal.h
+++ b/source/SAMRAI/math/PatchCellDataOpsReal.h
@@ -61,7 +61,7 @@ public:
     */
    PatchCellDataOpsReal();
 
-   virtual ~PatchCellDataOpsReal<TYPE>() {
+   virtual ~PatchCellDataOpsReal() {
    }
 
    /**

--- a/source/SAMRAI/math/PatchEdgeDataBasicOps.h
+++ b/source/SAMRAI/math/PatchEdgeDataBasicOps.h
@@ -54,7 +54,7 @@ public:
     */
    PatchEdgeDataBasicOps();
 
-   virtual ~PatchEdgeDataBasicOps<TYPE>();
+   virtual ~PatchEdgeDataBasicOps();
 
    /**
     * Set dst = alpha * src, elementwise.

--- a/source/SAMRAI/math/PatchEdgeDataMiscellaneousOpsReal.h
+++ b/source/SAMRAI/math/PatchEdgeDataMiscellaneousOpsReal.h
@@ -64,7 +64,7 @@ public:
     */
    PatchEdgeDataMiscellaneousOpsReal();
 
-   virtual ~PatchEdgeDataMiscellaneousOpsReal<TYPE>();
+   virtual ~PatchEdgeDataMiscellaneousOpsReal();
 
    /**
     * Return 1 if \f$\|data2_i\| > 0\f$ and \f$data1_i * data2_i \leq 0\f$, for

--- a/source/SAMRAI/math/PatchEdgeDataNormOpsReal.h
+++ b/source/SAMRAI/math/PatchEdgeDataNormOpsReal.h
@@ -63,7 +63,7 @@ public:
     */
    PatchEdgeDataNormOpsReal();
 
-   virtual ~PatchEdgeDataNormOpsReal<TYPE>();
+   virtual ~PatchEdgeDataNormOpsReal();
 
    /**
     * Return the number of data values for the edge-centered data object

--- a/source/SAMRAI/math/PatchEdgeDataOpsReal.h
+++ b/source/SAMRAI/math/PatchEdgeDataOpsReal.h
@@ -60,7 +60,7 @@ public:
     */
    PatchEdgeDataOpsReal();
 
-   virtual ~PatchEdgeDataOpsReal<TYPE>() {
+   virtual ~PatchEdgeDataOpsReal() {
    }
 
    /**

--- a/source/SAMRAI/math/PatchFaceDataBasicOps.h
+++ b/source/SAMRAI/math/PatchFaceDataBasicOps.h
@@ -55,7 +55,7 @@ public:
     */
    PatchFaceDataBasicOps();
 
-   virtual ~PatchFaceDataBasicOps<TYPE>();
+   virtual ~PatchFaceDataBasicOps();
 
    /**
     * Set dst = alpha * src, elementwise.

--- a/source/SAMRAI/math/PatchFaceDataMiscellaneousOpsReal.h
+++ b/source/SAMRAI/math/PatchFaceDataMiscellaneousOpsReal.h
@@ -64,7 +64,7 @@ public:
     */
    PatchFaceDataMiscellaneousOpsReal();
 
-   virtual ~PatchFaceDataMiscellaneousOpsReal<TYPE>();
+   virtual ~PatchFaceDataMiscellaneousOpsReal();
 
    /**
     * Return 1 if \f$\|data2_i\| > 0\f$ and \f$data1_i * data2_i \leq 0\f$, for

--- a/source/SAMRAI/math/PatchFaceDataNormOpsReal.h
+++ b/source/SAMRAI/math/PatchFaceDataNormOpsReal.h
@@ -64,7 +64,7 @@ public:
     */
    PatchFaceDataNormOpsReal();
 
-   virtual ~PatchFaceDataNormOpsReal<TYPE>();
+   virtual ~PatchFaceDataNormOpsReal();
 
    /**
     * Return the number of data values for the face-centered data object

--- a/source/SAMRAI/math/PatchFaceDataOpsReal.h
+++ b/source/SAMRAI/math/PatchFaceDataOpsReal.h
@@ -61,7 +61,7 @@ public:
     */
    PatchFaceDataOpsReal();
 
-   virtual ~PatchFaceDataOpsReal<TYPE>() {
+   virtual ~PatchFaceDataOpsReal() {
    }
 
    /**

--- a/source/SAMRAI/math/PatchNodeDataBasicOps.h
+++ b/source/SAMRAI/math/PatchNodeDataBasicOps.h
@@ -55,7 +55,7 @@ public:
     */
    PatchNodeDataBasicOps();
 
-   virtual ~PatchNodeDataBasicOps<TYPE>();
+   virtual ~PatchNodeDataBasicOps();
 
    /**
     * Set dst = alpha * src, elementwise.

--- a/source/SAMRAI/math/PatchNodeDataMiscellaneousOpsReal.h
+++ b/source/SAMRAI/math/PatchNodeDataMiscellaneousOpsReal.h
@@ -64,7 +64,7 @@ public:
     */
    PatchNodeDataMiscellaneousOpsReal();
 
-   virtual ~PatchNodeDataMiscellaneousOpsReal<TYPE>();
+   virtual ~PatchNodeDataMiscellaneousOpsReal();
 
    /**
     * Return 1 if \f$\|data2_i\| > 0\f$ and \f$data1_i * data2_i \leq 0\f$, for

--- a/source/SAMRAI/math/PatchNodeDataNormOpsReal.h
+++ b/source/SAMRAI/math/PatchNodeDataNormOpsReal.h
@@ -64,7 +64,7 @@ public:
     */
    PatchNodeDataNormOpsReal();
 
-   virtual ~PatchNodeDataNormOpsReal<TYPE>();
+   virtual ~PatchNodeDataNormOpsReal();
 
    /**
     * Return the number of data values for the node-centered data object

--- a/source/SAMRAI/math/PatchNodeDataOpsReal.h
+++ b/source/SAMRAI/math/PatchNodeDataOpsReal.h
@@ -61,7 +61,7 @@ public:
     */
    PatchNodeDataOpsReal();
 
-   virtual ~PatchNodeDataOpsReal<TYPE>() {
+   virtual ~PatchNodeDataOpsReal() {
    }
 
    /**

--- a/source/SAMRAI/math/PatchSideDataBasicOps.h
+++ b/source/SAMRAI/math/PatchSideDataBasicOps.h
@@ -54,7 +54,7 @@ public:
     */
    PatchSideDataBasicOps();
 
-   virtual ~PatchSideDataBasicOps<TYPE>();
+   virtual ~PatchSideDataBasicOps();
 
    /**
     * Set dst = alpha * src, elementwise.

--- a/source/SAMRAI/math/PatchSideDataMiscellaneousOpsReal.h
+++ b/source/SAMRAI/math/PatchSideDataMiscellaneousOpsReal.h
@@ -64,7 +64,7 @@ public:
     */
    PatchSideDataMiscellaneousOpsReal();
 
-   virtual ~PatchSideDataMiscellaneousOpsReal<TYPE>();
+   virtual ~PatchSideDataMiscellaneousOpsReal();
 
    /**
     * Return 1 if \f$\|data2_i\| > 0\f$ and \f$data1_i * data2_i \leq 0\f$, for

--- a/source/SAMRAI/math/PatchSideDataNormOpsReal.h
+++ b/source/SAMRAI/math/PatchSideDataNormOpsReal.h
@@ -63,7 +63,7 @@ public:
     */
    PatchSideDataNormOpsReal();
 
-   virtual ~PatchSideDataNormOpsReal<TYPE>();
+   virtual ~PatchSideDataNormOpsReal();
 
    /**
     * Return the number of data values for the side-centered data object

--- a/source/SAMRAI/math/PatchSideDataOpsReal.h
+++ b/source/SAMRAI/math/PatchSideDataOpsReal.h
@@ -61,7 +61,7 @@ public:
     */
    PatchSideDataOpsReal();
 
-   virtual ~PatchSideDataOpsReal<TYPE>();
+   virtual ~PatchSideDataOpsReal();
 
    /**
     * Copy dst data to src data over given box.

--- a/source/SAMRAI/pdat/CellData.h
+++ b/source/SAMRAI/pdat/CellData.h
@@ -142,7 +142,7 @@ public:
    /*!
     * @brief The virtual destructor for a cell data object.
     */
-   virtual ~CellData<TYPE>();
+   virtual ~CellData();
 
    /*!
     * @brief Return the depth (e.g., the number of components in each spatial

--- a/source/SAMRAI/pdat/CellDataFactory.h
+++ b/source/SAMRAI/pdat/CellDataFactory.h
@@ -67,7 +67,7 @@ public:
    /**
     * Virtual destructor for the cell data factory class.
     */
-   virtual ~CellDataFactory<TYPE>();
+   virtual ~CellDataFactory();
 
    /**
     * @brief Abstract virtual function to clone a patch data factory.

--- a/source/SAMRAI/pdat/CellVariable.h
+++ b/source/SAMRAI/pdat/CellVariable.h
@@ -64,7 +64,7 @@ public:
    /*!
     * @brief Virtual destructor for cell variable objects.
     */
-   virtual ~CellVariable<TYPE>();
+   virtual ~CellVariable();
 
    /*!
     * @brief Return true indicating that cell data quantities will always

--- a/source/SAMRAI/pdat/EdgeData.h
+++ b/source/SAMRAI/pdat/EdgeData.h
@@ -158,7 +158,7 @@ public:
    /*!
     * @brief The virtual destructor for an edge data object.
     */
-   virtual ~EdgeData<TYPE>();
+   virtual ~EdgeData();
 
    /*!
     * @brief Return the depth (e.g., the number of components in each spatial

--- a/source/SAMRAI/pdat/EdgeDataFactory.h
+++ b/source/SAMRAI/pdat/EdgeDataFactory.h
@@ -71,7 +71,7 @@ public:
    /**
     * Virtual destructor for the edge data factory class.
     */
-   virtual ~EdgeDataFactory<TYPE>();
+   virtual ~EdgeDataFactory();
 
    /**
     * @brief Abstract virtual function to clone a patch data factory.

--- a/source/SAMRAI/pdat/EdgeVariable.h
+++ b/source/SAMRAI/pdat/EdgeVariable.h
@@ -57,7 +57,7 @@ public:
    /*!
     * @brief Virtual destructor for edge variable objects.
     */
-   virtual ~EdgeVariable<TYPE>();
+   virtual ~EdgeVariable();
 
    /*!
     * @brief Return boolean indicating which edge data values (coarse

--- a/source/SAMRAI/pdat/FaceData.h
+++ b/source/SAMRAI/pdat/FaceData.h
@@ -162,7 +162,7 @@ public:
    /*!
     * @brief The virtual destructor for a face data object.
     */
-   virtual ~FaceData<TYPE>();
+   virtual ~FaceData();
 
    /*!
     * @brief Return the depth (e.g., the number of components in each spatial

--- a/source/SAMRAI/pdat/FaceDataFactory.h
+++ b/source/SAMRAI/pdat/FaceDataFactory.h
@@ -70,7 +70,7 @@ public:
    /**
     * Virtual destructor for the face data factory class.
     */
-   virtual ~FaceDataFactory<TYPE>();
+   virtual ~FaceDataFactory();
 
    /**
     * @brief Abstract virtual function to clone a patch data factory.

--- a/source/SAMRAI/pdat/FaceVariable.h
+++ b/source/SAMRAI/pdat/FaceVariable.h
@@ -74,7 +74,7 @@ public:
    /*!
     * @brief Virtual destructor for face variable objects.
     */
-   virtual ~FaceVariable<TYPE>();
+   virtual ~FaceVariable();
 
    /*!
     * @brief Return boolean indicating which face data values (coarse

--- a/source/SAMRAI/pdat/IndexData.h
+++ b/source/SAMRAI/pdat/IndexData.h
@@ -122,7 +122,7 @@ public:
    /**
     * The virtual destructor for an IndexData object.
     */
-   virtual ~IndexData<TYPE, BOX_GEOMETRY>();
+   virtual ~IndexData();
 
    /**
     * A fast copy between the source and destination.  All data is copied
@@ -554,18 +554,18 @@ public:
    friend class IndexData<TYPE, BOX_GEOMETRY>;
    friend class IndexIterator<TYPE, BOX_GEOMETRY>;
 
-   IndexDataNode<TYPE, BOX_GEOMETRY>(
+   IndexDataNode(
       const hier::Index & index,
       const size_t d_offset,
       TYPE & t,
       IndexDataNode<TYPE, BOX_GEOMETRY>* n,
       IndexDataNode<TYPE, BOX_GEOMETRY>* p);
 
-   virtual ~IndexDataNode<TYPE, BOX_GEOMETRY>();
+   virtual ~IndexDataNode();
 
 private:
    // Unimplemented default constructor.
-   IndexDataNode<TYPE, BOX_GEOMETRY>();
+   IndexDataNode();
 
    hier::Index d_index;
    size_t d_offset;
@@ -616,14 +616,14 @@ public:
    /**
     * Assignment operator for the index list iterator.
     */
-   IndexIterator<TYPE, BOX_GEOMETRY>&
+   IndexIterator&
    operator = (
       const IndexIterator<TYPE, BOX_GEOMETRY>& iterator);
 
    /**
     * Destructor for the index list iterator.
     */
-   ~IndexIterator<TYPE, BOX_GEOMETRY>();
+   ~IndexIterator();
 
    /**
     * Return a reference to the current item in the irregular index set.

--- a/source/SAMRAI/pdat/IndexDataFactory.h
+++ b/source/SAMRAI/pdat/IndexDataFactory.h
@@ -49,7 +49,7 @@ public:
    /**
     * Virtual destructor for the irregular data factory class.
     */
-   virtual ~IndexDataFactory<TYPE, BOX_GEOMETRY>();
+   virtual ~IndexDataFactory();
 
    /**
     * @brief Abstract virtual function to clone a patch data factory.

--- a/source/SAMRAI/pdat/IndexVariable.h
+++ b/source/SAMRAI/pdat/IndexVariable.h
@@ -55,7 +55,7 @@ public:
    /**
     * Virtual destructor for index variable objects.
     */
-   virtual ~IndexVariable<TYPE, BOX_GEOMETRY>();
+   virtual ~IndexVariable();
 
    /**
     * Return true so that the index data quantities will always be treated as cell-

--- a/source/SAMRAI/pdat/NodeData.h
+++ b/source/SAMRAI/pdat/NodeData.h
@@ -145,7 +145,7 @@ public:
    /*!
     * @brief The virtual destructor for a node data object.
     */
-   virtual ~NodeData<TYPE>();
+   virtual ~NodeData();
 
    /*!
     * @brief Return the depth (e.g., the number of components in each spatial

--- a/source/SAMRAI/pdat/NodeDataFactory.h
+++ b/source/SAMRAI/pdat/NodeDataFactory.h
@@ -70,7 +70,7 @@ public:
    /**
     * Virtual destructor for the node data factory class.
     */
-   virtual ~NodeDataFactory<TYPE>();
+   virtual ~NodeDataFactory();
 
    /**
     * @brief Abstract virtual function to clone a patch data factory.

--- a/source/SAMRAI/pdat/NodeVariable.h
+++ b/source/SAMRAI/pdat/NodeVariable.h
@@ -68,7 +68,7 @@ public:
    /*!
     * @brief Virtual destructor for node variable objects.
     */
-   virtual ~NodeVariable<TYPE>();
+   virtual ~NodeVariable();
 
    /*!
     * @brief Return boolean indicating which node data values (coarse

--- a/source/SAMRAI/pdat/OuteredgeData.h
+++ b/source/SAMRAI/pdat/OuteredgeData.h
@@ -192,7 +192,7 @@ public:
    /*!
     * @brief Virtual destructor for a outeredge data object.
     */
-   virtual ~OuteredgeData<TYPE>();
+   virtual ~OuteredgeData();
 
    /*!
     * @brief Return the depth (i.e., the number of data values for

--- a/source/SAMRAI/pdat/OuteredgeDataFactory.h
+++ b/source/SAMRAI/pdat/OuteredgeDataFactory.h
@@ -72,7 +72,7 @@ public:
     * @brief
     * Virtual destructor for the outeredge data factory class.
     */
-   virtual ~OuteredgeDataFactory<TYPE>();
+   virtual ~OuteredgeDataFactory();
 
    /**
     * @brief Abstract virtual function to clone a patch data factory.

--- a/source/SAMRAI/pdat/OuteredgeVariable.h
+++ b/source/SAMRAI/pdat/OuteredgeVariable.h
@@ -55,7 +55,7 @@ public:
    /*!
     * @brief Virtual destructor for outeredge variable objects.
     */
-   virtual ~OuteredgeVariable<TYPE>();
+   virtual ~OuteredgeVariable();
 
    /*!
     * @brief Return a boolean true value indicating that fine patch

--- a/source/SAMRAI/pdat/OuterfaceData.h
+++ b/source/SAMRAI/pdat/OuterfaceData.h
@@ -150,7 +150,7 @@ public:
    /*!
     * @brief Virtual destructor for a outerface data object.
     */
-   virtual ~OuterfaceData<TYPE>();
+   virtual ~OuterfaceData();
 
    /*!
     * @brief Return the depth (i.e., the number of data values for

--- a/source/SAMRAI/pdat/OuterfaceDataFactory.h
+++ b/source/SAMRAI/pdat/OuterfaceDataFactory.h
@@ -68,7 +68,7 @@ public:
    /**
     * Virtual destructor for the outerface data factory class.
     */
-   virtual ~OuterfaceDataFactory<TYPE>();
+   virtual ~OuterfaceDataFactory();
 
    /**
     * @brief Abstract virtual function to clone a patch data factory.

--- a/source/SAMRAI/pdat/OuterfaceVariable.h
+++ b/source/SAMRAI/pdat/OuterfaceVariable.h
@@ -72,7 +72,7 @@ public:
    /*!
     * @brief Virtual destructor for outerface variable objects.
     */
-   virtual ~OuterfaceVariable<TYPE>();
+   virtual ~OuterfaceVariable();
 
    /*!
     * @brief Return a boolean true value indicating that fine patch

--- a/source/SAMRAI/pdat/OuternodeData.h
+++ b/source/SAMRAI/pdat/OuternodeData.h
@@ -164,7 +164,7 @@ public:
    /*!
     * @brief Virtual destructor for a outernode data object.
     */
-   virtual ~OuternodeData<TYPE>();
+   virtual ~OuternodeData();
 
    /*!
     * @brief Return the depth (e.g., the number of components at each spatial

--- a/source/SAMRAI/pdat/OuternodeDataFactory.h
+++ b/source/SAMRAI/pdat/OuternodeDataFactory.h
@@ -70,7 +70,7 @@ public:
    /*!
     * @brief Virtual destructor for the outernode data factory class.
     */
-   virtual ~OuternodeDataFactory<TYPE>();
+   virtual ~OuternodeDataFactory();
 
    /**
     * @brief Abstract virtual function to clone a patch data factory.

--- a/source/SAMRAI/pdat/OuternodeVariable.h
+++ b/source/SAMRAI/pdat/OuternodeVariable.h
@@ -56,7 +56,7 @@ public:
    /*!
     * @brief Virtual destructor for outernode variable objects.
     */
-   virtual ~OuternodeVariable<TYPE>();
+   virtual ~OuternodeVariable();
 
    /*!
     * @brief Return a boolean true value indicating that fine patch

--- a/source/SAMRAI/pdat/OutersideData.h
+++ b/source/SAMRAI/pdat/OutersideData.h
@@ -149,7 +149,7 @@ public:
    /*!
     * @brief Virtual destructor for a outerside data object.
     */
-   virtual ~OutersideData<TYPE>();
+   virtual ~OutersideData();
 
    /*!
     * @brief Return the depth (i.e., the number of data values for

--- a/source/SAMRAI/pdat/OutersideDataFactory.h
+++ b/source/SAMRAI/pdat/OutersideDataFactory.h
@@ -68,7 +68,7 @@ public:
    /**
     * Virtual destructor for the outerside data factory class.
     */
-   virtual ~OutersideDataFactory<TYPE>();
+   virtual ~OutersideDataFactory();
 
    /**
     * @brief Abstract virtual function to clone a patch data factory.

--- a/source/SAMRAI/pdat/OutersideVariable.h
+++ b/source/SAMRAI/pdat/OutersideVariable.h
@@ -72,7 +72,7 @@ public:
    /*!
     * @brief Virtual destructor for outerside variable objects.
     */
-   virtual ~OutersideVariable<TYPE>();
+   virtual ~OutersideVariable();
 
    /*!
     * @brief Return a boolean true value indicating that fine patch

--- a/source/SAMRAI/pdat/SideData.h
+++ b/source/SAMRAI/pdat/SideData.h
@@ -209,7 +209,7 @@ public:
    /*!
     * @brief The virtual destructor for a side data object.
     */
-   virtual ~SideData<TYPE>();
+   virtual ~SideData();
 
    /*!
     * @brief Return constant reference to vector describing which coordinate

--- a/source/SAMRAI/pdat/SideDataFactory.h
+++ b/source/SAMRAI/pdat/SideDataFactory.h
@@ -120,7 +120,7 @@ public:
    /**
     * Virtual destructor for the side data factory class.
     */
-   virtual ~SideDataFactory<TYPE>();
+   virtual ~SideDataFactory();
 
    /**
     * @brief Abstract virtual function to clone a patch data factory.

--- a/source/SAMRAI/pdat/SideVariable.h
+++ b/source/SAMRAI/pdat/SideVariable.h
@@ -105,7 +105,7 @@ public:
    /*!
     * @brief Virtual destructor for side variable objects.
     */
-   virtual ~SideVariable<TYPE>();
+   virtual ~SideVariable();
 
    /*!
     * @brief Return constant reference to vector describing which coordinate

--- a/source/SAMRAI/pdat/SparseDataFactory.h
+++ b/source/SAMRAI/pdat/SparseDataFactory.h
@@ -53,7 +53,7 @@ public:
    /*!
     * @brief Default destructor
     */
-   ~SparseDataFactory<BOX_GEOMETRY>();
+   ~SparseDataFactory();
 
    /*!
     * @brief Clone a patch data factory

--- a/source/SAMRAI/solv/PETSc_SAMRAIVectorReal.h
+++ b/source/SAMRAI/solv/PETSc_SAMRAIVectorReal.h
@@ -135,7 +135,7 @@ protected:
     * member function destroyPETScVector, which is used to destroy the PETSc
     * vector and associated "wrapper".
     */
-   virtual ~PETSc_SAMRAIVectorReal<TYPE>();
+   virtual ~PETSc_SAMRAIVectorReal();
 
 private:
    /*

--- a/source/SAMRAI/solv/SAMRAIVectorReal.h
+++ b/source/SAMRAI/solv/SAMRAIVectorReal.h
@@ -141,7 +141,7 @@ public:
     * some pre-existing patch data objects that must live beyond the
     * destruction of the vector object.
     */
-   virtual ~SAMRAIVectorReal<TYPE>();
+   virtual ~SAMRAIVectorReal();
 
    /**
     * Set std::string identifier for this vector object.


### PR DESCRIPTION
This removes the template type syntax that was added to destructor declarations inside class definitions throughout the library, such as:

      `virtual ~NodeDataFactory<TYPE>();`

This syntax is nonstandard and was starting to cause compiler errors when using C++20.

Addresses https://github.com/LLNL/SAMRAI/issues/236
Extends the changes from https://github.com/LLNL/SAMRAI/pull/232 to all affected classes.