### PR TITLE
Add flattened hierarchy version of automatic blueprint generation 

### DIFF
--- a/source/SAMRAI/hier/BlueprintUtils.h
+++ b/source/SAMRAI/hier/BlueprintUtils.h
@@ -37,6 +37,7 @@ namespace hier {
  */
 
 class PatchHierarchy;
+class FlattenedHierarchy;
 
 class BlueprintUtils
 {
@@ -58,10 +59,11 @@ public:
    /*!
     * @brief Put topology and coordinates to the database
     *
-    * Combined with a BlueprintUtilsStrategy, this loops over a hierarchy,
-    * fills blueprint topology and coordinate entries, calls back to user code
-    * for specific types of coordinates recognized by the blueprint:
-    * uniform, rectilinear, or explicit
+    * Using the BlueprintUtilsStrategy given to the constructor of this
+    * object, this loops over a hierarchy, fills blueprint topology and
+    * and coordinate entries, and calls back to user code to specify the
+    * coordinates using the types of coordinates recognized by the
+    * blueprint:  uniform, rectilinear, or explicit.
     *
     * @param blueprint_db  Top-level blueprint database holding all local
     *                      domain information
@@ -71,6 +73,32 @@ public:
    void putTopologyAndCoordinatesToDatabase(
       const std::shared_ptr<tbox::Database>& blueprint_db,
       const PatchHierarchy& hierarchy,
+      const std::string& topology_name) const;
+
+   /*!
+    * @brief Put topology and coordinates to the database
+    *
+    * Using the BlueprintUtilsStrategy given to the constructor of this
+    * object, this loops over a hierarchy, fills blueprint topology and
+    * and coordinate entries, and calls back to user code to specify the
+    * coordinates using the types of coordinates recognized by the
+    * blueprint:  uniform, rectilinear, or explicit.
+    *
+    * This overloaded version of the method includes a FlattenedHierarchy
+    * argument to restrict the filling of coordinates to the finest available
+    * level of resulation as represented by the flattened version of the
+    * hierarchy.
+    *
+    * @param blueprint_db    Top-level blueprint database holding all local
+    *                        domain information
+    * @param hierarchy       The full AMR hierarchy being described
+    * @param flat_hierarchy  The flattened version of the AMR hierarchy.  
+    * @param topology_name Name of the topology
+    */
+   void putTopologyAndCoordinatesToDatabase(
+      const std::shared_ptr<tbox::Database>& blueprint_db,
+      const PatchHierarchy& hierarchy,
+      const FlattenedHierarchy& flat_hierarchy,
       const std::string& topology_name) const;
 
    /*!

--- a/source/SAMRAI/hier/BlueprintUtilsStrategy.h
+++ b/source/SAMRAI/hier/BlueprintUtilsStrategy.h
@@ -54,10 +54,13 @@ public:
     *
     * @param coords_db   Database to hold coordinate information
     * @param patch       Patch for which coordinates will be described
+    * @param box         Coordinate information should be described for
+    *                    intersection of this box and the patch's box
     */
    virtual void putCoordinatesToDatabase(
       std::shared_ptr<tbox::Database>& coords_db,
-      const Patch& patch) = 0;
+      const Patch& patch,
+      const Box& box) = 0;
 
 private:
 

--- a/source/SAMRAI/hier/PatchHierarchy.cpp
+++ b/source/SAMRAI/hier/PatchHierarchy.cpp
@@ -9,6 +9,7 @@
  ************************************************************************/
 #include "SAMRAI/hier/PatchHierarchy.h"
 
+#include "SAMRAI/hier/FlattenedHierarchy.h"
 #include "SAMRAI/hier/IntVector.h"
 #include "SAMRAI/hier/OverlapConnectorAlgorithm.h"
 #include "SAMRAI/hier/PeriodicShiftCatalog.h"
@@ -1242,6 +1243,85 @@ PatchHierarchy::makeBlueprintDatabase(
 
    bp_utils.putTopologyAndCoordinatesToDatabase(blueprint_db, *this, "mesh");
 }
+
+void
+PatchHierarchy::makeFlattenedBlueprintDatabase(
+   const std::shared_ptr<tbox::Database>& blueprint_db,
+   const BlueprintUtils& bp_utils) const
+{
+   TBOX_ASSERT(blueprint_db);
+
+   hier::FlattenedHierarchy flat_hier(*this, 0, d_number_levels-1);
+
+   std::vector<int> first_patch_id;
+   first_patch_id.push_back(0);
+
+   int patch_count = 0;
+   for (int i = 1; i < d_number_levels; ++i) {
+      patch_count += d_patch_levels[i-1]->getNumberOfPatches();
+      first_patch_id.push_back(patch_count); 
+   }
+
+   std::vector< std::shared_ptr<BoxLevel> > flat_box_level(d_number_levels);
+   for (int i = 0; i < d_number_levels; ++i) {
+      const std::shared_ptr<hier::PatchLevel>& level = d_patch_levels[i];
+
+      flat_box_level[i] =
+         std::make_shared<BoxLevel>(
+            level->getBoxLevel()->getRefinementRatio(),
+            d_grid_geometry,
+            getMPI());
+
+      for (PatchLevel::Iterator p(level->begin()); p != level->end();
+           ++p) {
+
+         const std::shared_ptr<hier::Patch>& patch = *p;
+         const Box& patch_box = patch->getBox();
+
+         const auto& flat_boxes = flat_hier.getVisibleBoxes(patch_box, i);
+
+         for (auto& domain_box : flat_boxes) {
+            int domain_id = domain_box.getLocalId().getValue();
+            std::string domain_name =
+               "domain_" + tbox::Utilities::intToString(domain_id, 6);
+
+            std::shared_ptr<tbox::Database> domain_db(
+               blueprint_db->putDatabase(domain_name));
+
+            std::shared_ptr<tbox::Database> state_db(
+               domain_db->putDatabase("state"));
+
+            state_db->putInteger("domain_id", domain_id);
+            state_db->putInteger("level_id", i);
+
+            std::shared_ptr<tbox::Database> topologies_db(
+               domain_db->putDatabase("topologies"));
+
+            std::shared_ptr<tbox::Database> topo_db(
+               topologies_db->putDatabase("mesh"));
+
+            std::shared_ptr<tbox::Database> elem_db(
+               topo_db->putDatabase("elements"));
+            std::shared_ptr<tbox::Database> origin_db(
+               elem_db->putDatabase("origin"));
+            origin_db->putInteger("i0", domain_box.lower(0));
+            if (d_dim.getValue() > 1) {
+               origin_db->putInteger("j0", domain_box.lower(1));
+            }
+            if (d_dim.getValue() > 2) {
+               origin_db->putInteger("k0", domain_box.lower(2));
+            }
+
+            flat_box_level[i]->addBoxWithoutUpdate(domain_box);
+         }
+      }
+      flat_box_level[i]->finalize();
+   }
+
+   makeAdjacencySets(blueprint_db, flat_hier, flat_box_level, "mesh");
+
+   bp_utils.putTopologyAndCoordinatesToDatabase(blueprint_db, *this, flat_hier,  "mesh");
+}
 #endif
 
 void
@@ -1362,6 +1442,7 @@ PatchHierarchy::makeNestingSets(
 
                      window_db->putString("domain_type", "child");
                      window_db->putInteger("domain_id", child_id);
+                     window_db->putInteger("level_id", i);
    
                      std::shared_ptr<tbox::Database> ratio_db(
                         window_db->putDatabase("ratio"));
@@ -1497,6 +1578,7 @@ PatchHierarchy::makeNestingSets(
 
                      window_db->putString("domain_type", "parent");
                      window_db->putInteger("domain_id", parent_id);
+                     window_db->putInteger("level_id", i);
 
                      std::shared_ptr<tbox::Database> ratio_db(
                         window_db->putDatabase("ratio"));
@@ -1537,6 +1619,8 @@ PatchHierarchy::makeNestingSets(
 void
 PatchHierarchy::makeAdjacencySets(
    const std::shared_ptr<tbox::Database>& blueprint_db,
+   const FlattenedHierarchy& flat_hierarchy,
+   const std::vector< std::shared_ptr<BoxLevel> >& flat_box_level,
    const std::string& topology_name) const
 {
 
@@ -1558,10 +1642,10 @@ PatchHierarchy::makeAdjacencySets(
       std::shared_ptr<hier::BoxLevel> this_level(
          level->getBoxLevel());
 
-      const Connector& self_to_self =
-         this_level->findConnector(
-            *this_level,
-            getRequiredConnectorWidth(i,i),
+      const Connector& flat_self_to_self =
+         flat_box_level[i]->findConnector(
+            *flat_box_level[i],
+            IntVector::getOne(d_dim),
             CONNECTOR_CREATE,
             true);
 
@@ -1570,124 +1654,125 @@ PatchHierarchy::makeAdjacencySets(
 
          std::shared_ptr<Patch> patch(*p);
          const Box& pbox = patch->getBox();
-         const BoxId& box_id = pbox.getBoxId();
-         const LocalId& local_id = box_id.getLocalId();
 
-         int domain_id = first_patch_id[i] + local_id.getValue();
-         std::string domain_name =
-            "domain_" + tbox::Utilities::intToString(domain_id, 6);
+         const auto& flat_boxes = flat_hierarchy.getVisibleBoxes(pbox, i);
 
-         std::shared_ptr<tbox::Database> domain_db;
-         if (blueprint_db->keyExists(domain_name)) {
-            domain_db = blueprint_db->getDatabase(domain_name);
-         } else {
-            domain_db = blueprint_db->putDatabase(domain_name);
-         }
+         for (auto& domain_box : flat_boxes) {
+            int domain_id = domain_box.getLocalId().getValue();
+            std::string domain_name =
+               "domain_" + tbox::Utilities::intToString(domain_id, 6);
 
-         std::shared_ptr<tbox::Database> adjsets_db;
-
-         Connector::ConstNeighborhoodIterator nbh =
-            self_to_self.findLocal(box_id);
-         if (nbh == self_to_self.end())  {
-            continue;
-         }
-
-         Box node_pbox(pbox);
-         node_pbox.setUpper(node_pbox.upper()+IntVector::getOne(d_dim));
-
-         for (Connector::ConstNeighborIterator na = self_to_self.begin(nbh);
-              na != self_to_self.end(nbh); ++na) {
-
-            const Box& nbr_box = *na;
-            const BoxId& nbr_box_id = nbr_box.getBoxId();
-            if (box_id == nbr_box_id) {
-               continue;
-            }
-            if (nbr_box_id.getPeriodicId().getPeriodicValue() != 0) {
-               continue;
-            }
-
-            int nbr_id =
-               first_patch_id[i] + nbr_box.getBoxId().getLocalId().getValue();
-
-            Box node_nbox(nbr_box);
-            node_nbox.setUpper(node_nbox.upper()+IntVector::getOne(d_dim));
-
-            Box node_ovlp(d_dim);
-            Box tnode_ovlp(d_dim);
-
-            if (nbr_box.getBlockId() == pbox.getBlockId()) {
-
-               node_ovlp = node_pbox * node_nbox;
-               tnode_ovlp = node_ovlp;
+            std::shared_ptr<tbox::Database> domain_db;
+            if (blueprint_db->keyExists(domain_name)) {
+               domain_db = blueprint_db->getDatabase(domain_name);
             } else {
-               Box transform_box(nbr_box);
-               d_grid_geometry->transformBox(transform_box,
-                                             i,
-                                             pbox.getBlockId(),
-                                             nbr_box.getBlockId());
-               transform_box.setUpper(
-                  transform_box.upper() + IntVector::getOne(d_dim));
-
-               node_ovlp = node_pbox * transform_box;
-
-               transform_box = pbox;
-               d_grid_geometry->transformBox(transform_box,
-                                             i,
-                                             nbr_box.getBlockId(),
-                                             pbox.getBlockId());
-
-               transform_box.setUpper(
-                  transform_box.upper() + IntVector::getOne(d_dim));
-
-               tnode_ovlp = node_nbox * transform_box;
-
-               TBOX_ASSERT(node_ovlp.empty() == tnode_ovlp.empty());
+               domain_db = blueprint_db->putDatabase(domain_name);
             }
 
-            if (!node_ovlp.empty()) {
+            std::shared_ptr<tbox::Database> adjsets_db;
 
-               if (domain_db->keyExists("adjsets")) {
-                  adjsets_db = domain_db->getDatabase("adjsets");
+            Box node_dbox(domain_box);
+            node_dbox.setUpper(node_dbox.upper()+IntVector::getOne(d_dim));
+
+            auto nbh = flat_self_to_self.findLocal(domain_box.getBoxId());
+            if (nbh == flat_self_to_self.end())  {
+               continue;
+            }
+
+            for (auto na = flat_self_to_self.begin(nbh);
+                 na != flat_self_to_self.end(nbh); ++na) {
+
+               const Box& nbr_box = *na;
+               const BoxId& nbr_box_id = nbr_box.getBoxId();
+               if (domain_box.getBoxId() == nbr_box_id) {
+                  continue;
+               }
+               if (nbr_box_id.getPeriodicId().getPeriodicValue() != 0) {
+                  continue;
+               }
+
+               int nbr_id = nbr_box.getLocalId().getValue();
+
+               Box node_nbox(nbr_box);
+               node_nbox.setUpper(node_nbox.upper()+IntVector::getOne(d_dim));
+               Box node_ovlp(d_dim);
+               Box tnode_ovlp(d_dim);
+
+               if (nbr_box.getBlockId() == pbox.getBlockId()) {
+
+                  node_ovlp = node_dbox * node_nbox;
+                  tnode_ovlp = node_ovlp;
                } else {
-                  adjsets_db = domain_db->putDatabase("adjsets");
+                  Box transform_box(nbr_box);
+                  d_grid_geometry->transformBox(transform_box,
+                                                i,
+                                                domain_box.getBlockId(),
+                                                nbr_box.getBlockId());
+                  transform_box.setUpper(
+                     transform_box.upper() + IntVector::getOne(d_dim));
+
+                  node_ovlp = node_dbox * transform_box;
+
+                  transform_box = domain_box;
+                  d_grid_geometry->transformBox(transform_box,
+                                                i,
+                                                nbr_box.getBlockId(),
+                                                domain_box.getBlockId());
+
+                  transform_box.setUpper(
+                     transform_box.upper() + IntVector::getOne(d_dim));
+
+                  tnode_ovlp = node_nbox * transform_box;
+
                }
 
-               std::shared_ptr<tbox::Database> set_db;
-               if (adjsets_db->keyExists("adjset")) {
-                  set_db = adjsets_db->getDatabase("adjset");
-               } else {
-                  set_db = adjsets_db->putDatabase("adjset");
+	       if (node_ovlp.empty() != tnode_ovlp.empty()) {
+                  node_ovlp.setEmpty();
+                  tnode_ovlp.setEmpty();
                }
 
-               if (!set_db->keyExists("association")) {
-                  set_db->putString("association", "vertex");
-               }
-               if (!set_db->keyExists("topology")) {
-                  set_db->putString("topology", topology_name);
-               }
+               if (!node_ovlp.empty()) {
 
-               std::shared_ptr<tbox::Database> groups_db;
-               if (set_db->keyExists("groups")) {
-                  groups_db = set_db->getDatabase("groups");
-               } else {
-                  groups_db = set_db->putDatabase("groups");
-               }
+                  if (domain_db->keyExists("adjsets")) {
+                     adjsets_db = domain_db->getDatabase("adjsets");
+                  } else {
+                     adjsets_db = domain_db->putDatabase("adjsets");
+                  }
 
-               std::shared_ptr<tbox::Database> group_db;
-               std::string group_name =
-                  "group_" + tbox::Utilities::intToString(nbr_id, 6);
-               if (groups_db->keyExists(group_name)) {
-                  group_db = groups_db->getDatabase(group_name);
-               } else {
-                  group_db = groups_db->putDatabase(group_name);
-               }
+                  std::shared_ptr<tbox::Database> set_db;
+                  if (adjsets_db->keyExists("adjset")) {
+                     set_db = adjsets_db->getDatabase("adjset");
+                  } else {
+                     set_db = adjsets_db->putDatabase("adjset");
+                  }
 
-               int neighbors[2] = {domain_id, nbr_id};
-               group_db->putIntegerArray("neighbors", neighbors, 2);
+                  if (!set_db->keyExists("association")) {
+                     set_db->putString("association", "vertex");
+                  }
+                  if (!set_db->keyExists("topology")) {
+                     set_db->putString("topology", topology_name);
+                  }
 
-               if (d_number_blocks > 1) {
+                  std::shared_ptr<tbox::Database> groups_db;
+                  if (set_db->keyExists("groups")) {
+                     groups_db = set_db->getDatabase("groups");
+                  } else {
+                     groups_db = set_db->putDatabase("groups");
+                  }
 
+                  std::shared_ptr<tbox::Database> group_db;
+                  std::string group_name =
+                     "group_" + tbox::Utilities::intToString(nbr_id, 6);
+                  if (groups_db->keyExists(group_name)) {
+                     group_db = groups_db->getDatabase(group_name);
+                  } else {
+                     group_db = groups_db->putDatabase(group_name);
+                  }
+
+                  int neighbors[2] = {domain_id, nbr_id};
+                  group_db->putIntegerArray("neighbors", neighbors, 2);
+
+                  group_db->putInteger("rank", nbr_box.getOwnerRank());
 
                   std::shared_ptr<tbox::Database> windows_db(
                      group_db->putDatabase("windows"));
@@ -1702,6 +1787,9 @@ PatchHierarchy::makeAdjacencySets(
                   std::shared_ptr<tbox::Database> window_b_db(
                      windows_db->putDatabase(window_b_name));
 
+                  window_a_db->putInteger("level_id", i);
+                  window_b_db->putInteger("level_id", i);
+
                   std::shared_ptr<tbox::Database> origin_a_db(
                      window_a_db->putDatabase("origin"));
                   std::shared_ptr<tbox::Database> origin_b_db(
@@ -1712,24 +1800,35 @@ PatchHierarchy::makeAdjacencySets(
                   std::shared_ptr<tbox::Database> width_b_db(
                      window_b_db->putDatabase("dims"));
 
+                  std::shared_ptr<tbox::Database> ratio_a_db(
+                     window_a_db->putDatabase("ratio"));
+                  std::shared_ptr<tbox::Database> ratio_b_db(
+                     window_b_db->putDatabase("ratio"));
+
                   IntVector a_width(node_ovlp.numberCells());
                   IntVector b_width(tnode_ovlp.numberCells());
 
                   origin_a_db->putInteger("i", node_ovlp.lower(0));
                   width_a_db->putInteger("i", a_width[0]);
+                  ratio_a_db->putInteger("i", 1);
                   origin_b_db->putInteger("i", tnode_ovlp.lower(0));
                   width_b_db->putInteger("i", b_width[0]);
+                  ratio_b_db->putInteger("i", 1);
                   if (d_dim.getValue() > 1) {
                      origin_a_db->putInteger("j", node_ovlp.lower(1));
                      width_a_db->putInteger("j", a_width[1]);
+                     ratio_a_db->putInteger("j", 1);
                      origin_b_db->putInteger("j", tnode_ovlp.lower(1));
                      width_b_db->putInteger("j", b_width[1]);
+                     ratio_b_db->putInteger("j", 1);
                   }
                   if (d_dim.getValue() > 2) {
-                     origin_a_db->putInteger("j", node_ovlp.lower(2));
-                     width_a_db->putInteger("j", a_width[2]);
+                     origin_a_db->putInteger("k", node_ovlp.lower(2));
+                     width_a_db->putInteger("k", a_width[2]);
+                     ratio_a_db->putInteger("k", 1);
                      origin_b_db->putInteger("k", tnode_ovlp.lower(2));
                      width_b_db->putInteger("k", b_width[2]);
+                     ratio_b_db->putInteger("k", 1);
                   }
 
                   if (pbox.getBlockId() != nbr_box.getBlockId()) {
@@ -1741,6 +1840,456 @@ PatchHierarchy::makeAdjacencySets(
                         orientation, rotation);
 
                      group_db->putIntegerVector("orientation", orientation);
+                  }
+               }
+            }
+         }
+      }
+
+      if (i + 1 < d_number_levels) {
+
+         std::shared_ptr<hier::BoxLevel> fine_level(
+            d_patch_levels[i+1]->getBoxLevel());
+
+         const Connector& flat_c_to_f =
+            flat_box_level[i]->findConnector(
+               *flat_box_level[i+1],
+                  IntVector::getOne(d_dim),
+                  CONNECTOR_CREATE,
+                  true);
+
+         const IntVector& ratio = flat_c_to_f.getRatio();
+
+         for (PatchLevel::Iterator p(level->begin()); p != level->end();
+              ++p) {
+
+            std::shared_ptr<Patch> patch(*p);
+            const Box& pbox = patch->getBox();
+
+            const auto& flat_boxes = flat_hierarchy.getVisibleBoxes(pbox, i);
+
+            for (auto& domain_box : flat_boxes) {
+               int domain_id = domain_box.getLocalId().getValue();
+               std::string domain_name =
+                  "domain_" + tbox::Utilities::intToString(domain_id, 6);
+
+               std::shared_ptr<tbox::Database> domain_db;
+               if (blueprint_db->keyExists(domain_name)) {
+                  domain_db = blueprint_db->getDatabase(domain_name);
+               } else {
+                  domain_db = blueprint_db->putDatabase(domain_name);
+               }
+
+               std::shared_ptr<tbox::Database> adjsets_db;
+
+               Box node_dbox(domain_box);
+               node_dbox.setUpper(node_dbox.upper()+IntVector::getOne(d_dim));
+
+               auto nbh = flat_c_to_f.findLocal(domain_box.getBoxId());
+               if (nbh == flat_c_to_f.end())  {
+                  continue;
+               }
+
+               for (auto na = flat_c_to_f.begin(nbh);
+                    na != flat_c_to_f.end(nbh); ++na) {
+
+                  const Box& nbr_box = *na;
+                  const BoxId& nbr_box_id = nbr_box.getBoxId();
+                  if (nbr_box_id.getPeriodicId().getPeriodicValue() != 0) {
+                     continue;
+                  }
+
+                  int nbr_id = nbr_box.getLocalId().getValue();
+
+                  Box node_nbox(nbr_box);
+                  node_nbox.setUpper(
+                     node_nbox.upper()+IntVector::getOne(d_dim));
+
+                  Box node_ovlp(d_dim);
+                  Box tnode_ovlp(d_dim);
+
+                  if (nbr_box.getBlockId() == pbox.getBlockId()) {
+                     Box node_crse_nbox(nbr_box);
+                     node_crse_nbox.coarsen(ratio);
+                     node_crse_nbox.setUpper(
+                        node_crse_nbox.upper()+IntVector::getOne(d_dim));
+
+                     node_ovlp = node_dbox * node_crse_nbox;
+
+                     Box node_fine_dbox(domain_box);
+                     node_fine_dbox.refine(ratio);
+                     node_fine_dbox.setUpper(
+                        node_fine_dbox.upper()+IntVector::getOne(d_dim));
+                     tnode_ovlp = node_nbox * node_fine_dbox;
+                  } else {
+                     Box transform_box(nbr_box);
+                     transform_box.coarsen(ratio);
+                     d_grid_geometry->transformBox(transform_box,
+                                                   i,
+                                                   domain_box.getBlockId(),
+                                                   nbr_box.getBlockId());
+                     transform_box.setUpper(
+                        transform_box.upper() + IntVector::getOne(d_dim));
+
+                     node_ovlp = node_dbox * transform_box;
+
+                     transform_box = domain_box;
+                     transform_box.refine(ratio);
+                     d_grid_geometry->transformBox(transform_box,
+                                                   i+1,
+                                                   nbr_box.getBlockId(),
+                                                   domain_box.getBlockId());
+
+                     transform_box.setUpper(
+                        transform_box.upper() + IntVector::getOne(d_dim));
+
+                     tnode_ovlp = node_nbox * transform_box;
+
+                  }
+                  if (node_ovlp.empty() != tnode_ovlp.empty()) {
+                     node_ovlp.setEmpty();
+                     tnode_ovlp.setEmpty();
+                  }
+
+
+                  if (!node_ovlp.empty()) {
+
+                     if (domain_db->keyExists("adjsets")) {
+                        adjsets_db = domain_db->getDatabase("adjsets");
+                     } else {
+                        adjsets_db = domain_db->putDatabase("adjsets");
+                     }
+
+                     std::shared_ptr<tbox::Database> set_db;
+                     if (adjsets_db->keyExists("adjset")) {
+                        set_db = adjsets_db->getDatabase("adjset");
+                     } else {
+                        set_db = adjsets_db->putDatabase("adjset");
+                     }
+
+                     if (!set_db->keyExists("association")) {
+                        set_db->putString("association", "vertex");
+                     }
+                     if (!set_db->keyExists("topology")) {
+                        set_db->putString("topology", topology_name);
+                     }
+
+                     std::shared_ptr<tbox::Database> groups_db;
+                     if (set_db->keyExists("groups")) {
+                        groups_db = set_db->getDatabase("groups");
+                     } else {
+                        groups_db = set_db->putDatabase("groups");
+                     }
+
+                     std::shared_ptr<tbox::Database> group_db;
+                     std::string group_name =
+                        "group_" + tbox::Utilities::intToString(nbr_id, 6);
+                     if (groups_db->keyExists(group_name)) {
+                        group_db = groups_db->getDatabase(group_name);
+                     } else {
+                        group_db = groups_db->putDatabase(group_name);
+                     }
+
+                     int neighbors[2] = {domain_id, nbr_id};
+                     group_db->putIntegerArray("neighbors", neighbors, 2);
+
+                     group_db->putInteger("rank", nbr_box.getOwnerRank());
+
+                     std::shared_ptr<tbox::Database> windows_db(
+                        group_db->putDatabase("windows"));
+
+                     std::string window_a_name =
+                        "window_" + tbox::Utilities::intToString(domain_id, 6);
+                     std::string window_b_name =
+                        "window_" + tbox::Utilities::intToString(nbr_id, 6);
+
+                     std::shared_ptr<tbox::Database> window_a_db(
+                        windows_db->putDatabase(window_a_name));
+                     std::shared_ptr<tbox::Database> window_b_db(
+                        windows_db->putDatabase(window_b_name));
+
+                     window_a_db->putInteger("level_id", i);
+                     window_b_db->putInteger("level_id", i+1);
+
+                     std::shared_ptr<tbox::Database> origin_a_db(
+                        window_a_db->putDatabase("origin"));
+                     std::shared_ptr<tbox::Database> origin_b_db(
+                        window_b_db->putDatabase("origin"));
+
+                     std::shared_ptr<tbox::Database> width_a_db(
+                        window_a_db->putDatabase("dims"));
+                     std::shared_ptr<tbox::Database> width_b_db(
+                        window_b_db->putDatabase("dims"));
+                     std::shared_ptr<tbox::Database> ratio_a_db(
+                        window_a_db->putDatabase("ratio"));
+                     std::shared_ptr<tbox::Database> ratio_b_db(
+                        window_b_db->putDatabase("ratio"));
+
+                     IntVector a_width(node_ovlp.numberCells());
+                     IntVector b_width(tnode_ovlp.numberCells());
+                     IntVector a_ratio(ratio.getBlockVector(domain_box.getBlockId()));
+                     IntVector b_ratio(ratio.getBlockVector(nbr_box.getBlockId()));
+
+                     origin_a_db->putInteger("i", node_ovlp.lower(0));
+                     width_a_db->putInteger("i", a_width[0]);
+                     ratio_a_db->putInteger("i", a_ratio[0]);
+                     origin_b_db->putInteger("i", tnode_ovlp.lower(0));
+                     width_b_db->putInteger("i", b_width[0]);
+                     ratio_b_db->putInteger("i", a_ratio[0]);
+                     if (d_dim.getValue() > 1) {
+                        origin_a_db->putInteger("j", node_ovlp.lower(1));
+                        width_a_db->putInteger("j", a_width[1]);
+                        ratio_a_db->putInteger("j", a_ratio[1]);
+                        origin_b_db->putInteger("j", tnode_ovlp.lower(1));
+                        width_b_db->putInteger("j", b_width[1]);
+                        ratio_b_db->putInteger("j", b_ratio[1]);
+                     }
+                     if (d_dim.getValue() > 2) {
+                        origin_a_db->putInteger("k", node_ovlp.lower(2));
+                        width_a_db->putInteger("k", a_width[2]);
+                        ratio_a_db->putInteger("k", a_ratio[2]);
+                        origin_b_db->putInteger("k", tnode_ovlp.lower(2));
+                        width_b_db->putInteger("k", b_width[2]);
+                        ratio_b_db->putInteger("k", b_ratio[2]);
+                     }
+
+                     if (pbox.getBlockId() != nbr_box.getBlockId()) {
+                        Transformation::RotationIdentifier rotation =
+                           d_grid_geometry->getRotationIdentifier(
+                              nbr_box.getBlockId(), pbox.getBlockId());
+                        std::vector<int> orientation(3);
+                        Transformation::setOrientationVector(
+                           orientation, rotation);
+
+                        group_db->putIntegerVector("orientation", orientation);
+                        window_a_db->putIntegerVector("orientation", orientation);
+                        window_b_db->putIntegerVector("orientation", orientation);
+                     }
+                  }
+               }
+            }
+         }
+      }
+ 
+      if (i > 0) {
+
+         std::shared_ptr<hier::BoxLevel> coarse_level(
+            d_patch_levels[i-1]->getBoxLevel());
+
+         const Connector& flat_f_to_c =
+            flat_box_level[i]->findConnector(
+               *flat_box_level[i-1],
+               IntVector::getOne(d_dim),
+               CONNECTOR_CREATE,
+               true);
+
+         const IntVector& ratio = flat_f_to_c.getRatio();
+
+         for (PatchLevel::Iterator p(level->begin()); p != level->end();
+              ++p) {
+
+            std::shared_ptr<Patch> patch(*p);
+            const Box& pbox = patch->getBox();
+
+            std::shared_ptr<tbox::Database> adjsets_db;
+
+            const auto& flat_boxes = flat_hierarchy.getVisibleBoxes(pbox, i);
+
+            for (auto& domain_box : flat_boxes) {
+               int domain_id = domain_box.getLocalId().getValue();
+               std::string domain_name =
+                  "domain_" + tbox::Utilities::intToString(domain_id, 6);
+
+               std::shared_ptr<tbox::Database> domain_db;
+               if (blueprint_db->keyExists(domain_name)) {
+                  domain_db = blueprint_db->getDatabase(domain_name);
+               } else {
+                  domain_db = blueprint_db->putDatabase(domain_name);
+               }
+
+               std::shared_ptr<tbox::Database> adjsets_db;
+
+               Box node_dbox(domain_box);
+               node_dbox.setUpper(node_dbox.upper()+IntVector::getOne(d_dim));
+
+               auto nbh = flat_f_to_c.findLocal(domain_box.getBoxId());
+               if (nbh == flat_f_to_c.end())  {
+                  continue;
+               }
+
+               for (auto na = flat_f_to_c.begin(nbh);
+                    na != flat_f_to_c.end(nbh); ++na) {
+
+                  const Box& nbr_box = *na;
+                  const BoxId& nbr_box_id = nbr_box.getBoxId();
+                  if (nbr_box_id.getPeriodicId().getPeriodicValue() != 0) {
+                     continue;
+                  }
+
+                  int nbr_id = nbr_box.getLocalId().getValue();
+
+                  Box node_nbox(nbr_box);
+                  node_nbox.setUpper(
+                     node_nbox.upper()+IntVector::getOne(d_dim));
+
+                  Box node_ovlp(d_dim);
+                  Box tnode_ovlp(d_dim);
+
+                  if (nbr_box.getBlockId() == pbox.getBlockId()) {
+                     Box node_fine_nbox(nbr_box);
+                     node_fine_nbox.refine(ratio);
+                     node_fine_nbox.setUpper(
+                        node_fine_nbox.upper() + IntVector::getOne(d_dim));
+
+                     node_ovlp = node_dbox * node_fine_nbox;
+
+                     Box node_crse_dbox(domain_box);
+                     node_crse_dbox.coarsen(ratio);
+                     node_crse_dbox.setUpper(
+                        node_crse_dbox.upper() + IntVector::getOne(d_dim));
+                     tnode_ovlp = node_nbox * node_crse_dbox;
+                  } else {
+                     Box transform_box(nbr_box);
+                     transform_box.refine(ratio);
+                     d_grid_geometry->transformBox(transform_box,
+                                                   i,
+                                                   domain_box.getBlockId(),
+                                                   nbr_box.getBlockId());
+                     transform_box.setUpper(
+                        transform_box.upper() + IntVector::getOne(d_dim));
+
+                     node_ovlp = node_dbox * transform_box;
+
+                     transform_box = domain_box;
+                     transform_box.coarsen(ratio);
+                     d_grid_geometry->transformBox(transform_box,
+                                                   i-1,
+                                                   nbr_box.getBlockId(),
+                                                   domain_box.getBlockId());
+
+                     transform_box.setUpper(
+                        transform_box.upper() + IntVector::getOne(d_dim));
+
+                     tnode_ovlp = node_nbox * transform_box;
+                  }
+
+                  if (node_ovlp.empty() != tnode_ovlp.empty()) {
+                     node_ovlp.setEmpty();
+                     tnode_ovlp.setEmpty();
+                  }
+
+
+                  if (!node_ovlp.empty()) {
+
+                     if (domain_db->keyExists("adjsets")) {
+                        adjsets_db = domain_db->getDatabase("adjsets");
+                     } else {
+                        adjsets_db = domain_db->putDatabase("adjsets");
+                     }
+
+                     std::shared_ptr<tbox::Database> set_db;
+                     if (adjsets_db->keyExists("adjset")) {
+                        set_db = adjsets_db->getDatabase("adjset");
+                     } else {
+                        set_db = adjsets_db->putDatabase("adjset");
+                     }
+
+                     if (!set_db->keyExists("association")) {
+                        set_db->putString("association", "vertex");
+                     }
+                     if (!set_db->keyExists("topology")) {
+                        set_db->putString("topology", topology_name);
+                     }
+
+                     std::shared_ptr<tbox::Database> groups_db;
+                     if (set_db->keyExists("groups")) {
+                        groups_db = set_db->getDatabase("groups");
+                     } else {
+                        groups_db = set_db->putDatabase("groups");
+                     }
+
+                     std::shared_ptr<tbox::Database> group_db;
+                     std::string group_name =
+                        "group_" + tbox::Utilities::intToString(nbr_id, 6);
+                     if (groups_db->keyExists(group_name)) {
+                        group_db = groups_db->getDatabase(group_name);
+                     } else {
+                        group_db = groups_db->putDatabase(group_name);
+                     }
+
+                     int neighbors[2] = {domain_id, nbr_id};
+                     group_db->putIntegerArray("neighbors", neighbors, 2);
+
+                     group_db->putInteger("rank", nbr_box.getOwnerRank());
+
+                     std::shared_ptr<tbox::Database> windows_db(
+                        group_db->putDatabase("windows"));
+
+                     std::string window_a_name =
+                        "window_" + tbox::Utilities::intToString(domain_id, 6);
+                     std::string window_b_name =
+                        "window_" + tbox::Utilities::intToString(nbr_id, 6);
+
+                     std::shared_ptr<tbox::Database> window_a_db(
+                        windows_db->putDatabase(window_a_name));
+                     std::shared_ptr<tbox::Database> window_b_db(
+                        windows_db->putDatabase(window_b_name));
+
+                     window_a_db->putInteger("level_id", i);
+                     window_b_db->putInteger("level_id", i-1);
+
+                     std::shared_ptr<tbox::Database> origin_a_db(
+                        window_a_db->putDatabase("origin"));
+                     std::shared_ptr<tbox::Database> origin_b_db(
+                        window_b_db->putDatabase("origin"));
+
+                     std::shared_ptr<tbox::Database> width_a_db(
+                        window_a_db->putDatabase("dims"));
+                     std::shared_ptr<tbox::Database> width_b_db(
+                        window_b_db->putDatabase("dims"));
+                     std::shared_ptr<tbox::Database> ratio_a_db(
+                        window_a_db->putDatabase("ratio"));
+                     std::shared_ptr<tbox::Database> ratio_b_db(
+                        window_b_db->putDatabase("ratio"));
+
+                     IntVector a_width(node_ovlp.numberCells());
+                     IntVector b_width(tnode_ovlp.numberCells());
+                     IntVector a_ratio(ratio.getBlockVector(domain_box.getBlockId()));
+                     IntVector b_ratio(ratio.getBlockVector(nbr_box.getBlockId()));
+
+                     origin_a_db->putInteger("i", node_ovlp.lower(0));
+                     width_a_db->putInteger("i", a_width[0]);
+                     ratio_a_db->putInteger("i", a_ratio[0]);
+                     origin_b_db->putInteger("i", tnode_ovlp.lower(0));
+                     width_b_db->putInteger("i", b_width[0]);
+                     ratio_b_db->putInteger("i", a_ratio[0]);
+                     if (d_dim.getValue() > 1) {
+                        origin_a_db->putInteger("j", node_ovlp.lower(1));
+                        width_a_db->putInteger("j", a_width[1]);
+                        ratio_a_db->putInteger("j", a_ratio[1]);
+                        origin_b_db->putInteger("j", tnode_ovlp.lower(1));
+                        width_b_db->putInteger("j", b_width[1]);
+                        ratio_b_db->putInteger("j", b_ratio[1]);
+                     }
+                     if (d_dim.getValue() > 2) {
+                        origin_a_db->putInteger("k", node_ovlp.lower(2));
+                        width_a_db->putInteger("k", a_width[2]);
+                        ratio_a_db->putInteger("k", a_ratio[2]);
+                        origin_b_db->putInteger("k", tnode_ovlp.lower(2));
+                        width_b_db->putInteger("k", b_width[2]);
+                        ratio_b_db->putInteger("k", b_ratio[2]);
+                     }
+
+                     if (pbox.getBlockId() != nbr_box.getBlockId()) {
+                        Transformation::RotationIdentifier rotation =
+                           d_grid_geometry->getRotationIdentifier(
+                              nbr_box.getBlockId(), pbox.getBlockId());
+                        std::vector<int> orientation(3);
+                        Transformation::setOrientationVector(
+                           orientation, rotation);
+
+                        group_db->putIntegerVector("orientation", orientation);
+                     }
                   }
                }
             }

--- a/source/SAMRAI/hier/PatchHierarchy.cpp
+++ b/source/SAMRAI/hier/PatchHierarchy.cpp
@@ -1315,10 +1315,14 @@ PatchHierarchy::makeNestingSets(
                     na != c_to_f.end(nbh); ++na) {
 
                   const Box& nbr_box = *na;
+                  if (nbr_box.getBlockId() != pbox.getBlockId()) {
+                     continue;
+                  }
+
                   Box crse_nbr(nbr_box);
                   crse_nbr.coarsen(ratio);
-
                   Box overlap(crse_nbr*pbox);
+
                   if (!overlap.empty()) {
 
                      if (domain_db->keyExists("nestsets")) {
@@ -1370,16 +1374,17 @@ PatchHierarchy::makeNestingSets(
 
                      IntVector box_width(overlap.numberCells());
 
-                     ratio_db->putInteger("i", ratio[0]);
+                     IntVector block_ratio(ratio.getBlockVector(pbox.getBlockId()));
+                     ratio_db->putInteger("i", block_ratio[0]);
                      origin_db->putInteger("i", overlap.lower(0)-pbox.lower(0));
                      width_db->putInteger("i", box_width[0]);
                      if (d_dim.getValue() > 1) {
-                        ratio_db->putInteger("j", ratio[1]);
+                        ratio_db->putInteger("j", block_ratio[1]);
                         origin_db->putInteger("j", overlap.lower(1)-pbox.lower(1));
                         width_db->putInteger("j", box_width[1]);
                      }
                      if (d_dim.getValue() > 2) {
-                        ratio_db->putInteger("k", ratio[2]);
+                        ratio_db->putInteger("k", block_ratio[2]);
                         origin_db->putInteger("k", overlap.lower(2)-pbox.lower(2));
                         width_db->putInteger("k", box_width[2]);
                      }
@@ -1445,10 +1450,14 @@ PatchHierarchy::makeNestingSets(
                     na != f_to_c.end(nbh); ++na) {
 
                   const Box& nbr_box = *na;
+                  if (nbr_box.getBlockId() != pbox.getBlockId()) {
+                     continue;
+                  }
+
                   Box fine_nbr(nbr_box);
                   fine_nbr.refine(ratio);
-
                   Box overlap(fine_nbr*pbox);
+
                   if (!overlap.empty()) {
 
                      std::shared_ptr<tbox::Database> nestsets_db;
@@ -1500,16 +1509,18 @@ PatchHierarchy::makeNestingSets(
 
                      IntVector box_width(overlap.numberCells());
 
-                     ratio_db->putInteger("i", ratio[0]);
+                     IntVector block_ratio(ratio.getBlockVector(pbox.getBlockId()));
+
+                     ratio_db->putInteger("i", block_ratio[0]);
                      origin_db->putInteger("i", overlap.lower(0)-pbox.lower(0));
                      width_db->putInteger("i", box_width[0]);
                      if (d_dim.getValue() > 1) {
-                        ratio_db->putInteger("j", ratio[1]);
+                        ratio_db->putInteger("j", block_ratio[1]);
                         origin_db->putInteger("j", overlap.lower(1)-pbox.lower(1));
                         width_db->putInteger("j", box_width[1]);
                      }
                      if (d_dim.getValue() > 2) {
-                        ratio_db->putInteger("k", ratio[2]);
+                        ratio_db->putInteger("k", block_ratio[2]);
                         origin_db->putInteger("k", overlap.lower(2)-pbox.lower(2));
                         width_db->putInteger("k", box_width[2]);
                      }

--- a/source/SAMRAI/hier/PatchHierarchy.h
+++ b/source/SAMRAI/hier/PatchHierarchy.h
@@ -1009,15 +1009,21 @@ public:
 
 #ifdef SAMRAI_HAVE_CONDUIT
    /*!
-    * @brief Make a database holding a description of the hierarchy in the Conduit blueprint
-    * format.
+    * @brief Make a database holding a description of the hierarchy in the
+    * Conduit blueprint format.
     *
-    * The blueprint is a portable format for description of a mesh and its data. See
-    * https://llnl-conduit.readthedocs.io for the Conduit library.
+    * The blueprint is a portable format for description of a mesh and its data.
+    * See https://llnl-conduit.readthedocs.io for the Conduit library.
     *
-    * Some parts of the blueprint can be constructed directly from evaluating the PatchHierarchy,
-    * and others require application-specific information.  This method fills the database with as much
-    * as it can from the PatchHierarchy and then uses the BlueprintUtils class to add the remainder.
+    * Some parts of the blueprint can be constructed directly from evaluating
+    * the PatchHierarchy, and others require application-specific information.
+    * This method fills the database with as much as it can from the
+    * PatchHierarchy and then uses the BlueprintUtils class to add the
+    * remainder.
+    *
+    * The blueprint description will contain a domain, as defined in the
+    * blueprint format, that corresponds directly to each patch in the
+    * PatchHierarchy.
     *
     * @param[out]  Database to hold the blueprint 
     * @param[in]   Utility class that adds data to the blueprint
@@ -1026,6 +1032,34 @@ public:
    makeBlueprintDatabase(
       const std::shared_ptr<tbox::Database>& blueprint_db,
       const BlueprintUtils& bp_utils) const; 
+
+   /*!
+    * @brief Make a database holding a description of the a flattened
+    * version of this hierarchy in the Conduit blueprint format.
+    *
+    * @see FlattenedHierarchy
+    *
+    * This creates a database in the blueprint format that describes a
+    * flattened version of this hierarchy. The flattened version is
+    * a representation of the hierarchy that only uses the parts of the
+    * hierarchy that represent the finest available mesh at any location.
+    *
+    * Some parts of the blueprint can be constructed directly from evaluating
+    * the PatchHierarchy, and others require application-specific information.
+    * This method fills the database with as much as it can from the
+    * PatchHierarchy and then uses the BlueprintUtils class to add the
+    * remainder.
+    *
+    * This method will create a blueprint domain for each logically-rectangular
+    * "visible box" as defined in the FlattenedHierarchy class. A visible box
+    * may represent only a part of the index space of a patch, if part of the
+    * patch represents the finest available mesh, and other part of the patch
+    * are covered by finer levels.
+    */
+   void
+   makeFlattenedBlueprintDatabase(
+      const std::shared_ptr<tbox::Database>& blueprint_db,
+      const BlueprintUtils& bp_utils) const;
 #endif
 
    /*!
@@ -1054,6 +1088,8 @@ public:
    void
    makeAdjacencySets(
       const std::shared_ptr<tbox::Database>& blueprint_db,
+      const FlattenedHierarchy& flat_hierarchy,
+      const std::vector< std::shared_ptr<BoxLevel> >& flat_box_level,
       const std::string& topology_name) const;
 
    /*!

--- a/source/SAMRAI/tbox/ConduitDatabase.cpp
+++ b/source/SAMRAI/tbox/ConduitDatabase.cpp
@@ -308,7 +308,7 @@ ConduitDatabase::putBoolArray(
 {
    deleteKeyIfFound(key);
    std::vector<conduit::uint8> uint8_vec(nelements, 0);
-   for (int i = 0; i < nelements; ++i) {
+   for (unsigned int i = 0; i < nelements; ++i) {
       if (data[i]) {
          uint8_vec[i] = 1;
       }
@@ -426,7 +426,7 @@ ConduitDatabase::putDatabaseBoxArray(
    std::vector<conduit::uint8> dim_vec(nelements);
    std::vector<int> lo_vec(nelements * SAMRAI::MAX_DIM_VAL);
    std::vector<int> hi_vec(nelements * SAMRAI::MAX_DIM_VAL);
-   for (int i = 0; i < nelements; ++i) {
+   for (unsigned int i = 0; i < nelements; ++i) {
       dim_vec[i] = data[i].getDimVal();
 
       for (int d = 0; d < dim_vec[i]; ++d) {

--- a/source/SAMRAI/tbox/Database.cpp
+++ b/source/SAMRAI/tbox/Database.cpp
@@ -1142,11 +1142,7 @@ Database::toConduitNode(conduit::Node& node)
          std::memcpy(node[key].data_ptr(), &(char_vec[0]), size*sizeof(char));
       } else if (my_type == SAMRAI_INT) {
          std::vector<int> int_vec(getIntegerVector(key));
-         node[key].set(conduit::DataType::int64(size));
-         conduit::int64_array fill_array = node[key].as_int64_array();
-         for (size_t i = 0; i < size; ++i) {
-            fill_array[i] = int_vec[i];
-         }
+         node[key].set(int_vec);
       } else if (my_type == SAMRAI_COMPLEX) {
          std::vector<dcomplex> cplx_vec(getComplexVector(key));
          node[key].set(conduit::DataType::c_double(2*size));
@@ -1165,13 +1161,13 @@ Database::toConduitNode(conduit::Node& node)
             node[key].set(str_vec[0]);
          } else {
             size_t num_chars = 0;
-            for (int i = 0; i < size; ++i) {
+            for (size_t i = 0; i < size; ++i) {
                num_chars += str_vec[i].size();
                ++num_chars;
             }
             node[key].set(conduit::DataType::c_char(num_chars));
             char* char_ptr = static_cast<char*>(node[key].data_ptr());
-            for (int i = 0; i < size; ++i) {
+            for (size_t i = 0; i < size; ++i) {
                std::memcpy(char_ptr, str_vec[i].c_str(), (str_vec[i].size()+1)*sizeof(char));
                char_ptr += (str_vec[i].size()+1);
             }

--- a/source/test/applications/LinAdv/LinAdv.cpp
+++ b/source/test/applications/LinAdv/LinAdv.cpp
@@ -359,9 +359,9 @@ void LinAdv::registerModelVariables(
       "CONSERVATIVE_COARSEN",
       "NO_REFINE");
 
+#ifdef HAVE_HDF5
    hier::VariableDatabase* vardb = hier::VariableDatabase::getDatabase();
 
-#ifdef HAVE_HDF5
    if (d_visit_writer) {
       d_visit_writer->
       registerPlotQuantity("U",
@@ -3189,8 +3189,10 @@ LinAdv::checkNewPatchTagData(
 void
 LinAdv::putCoordinatesToDatabase(
    std::shared_ptr<tbox::Database>& coords_db,
-   const hier::Patch& patch)
+   const hier::Patch& patch,
+   const hier::Box& box)
 {
+   NULL_USE(box);
 
    std::shared_ptr<geom::CartesianPatchGeometry> pgeom(
       SAMRAI_SHARED_PTR_CAST<geom::CartesianPatchGeometry, hier::PatchGeometry>(

--- a/source/test/applications/LinAdv/LinAdv.h
+++ b/source/test/applications/LinAdv/LinAdv.h
@@ -363,7 +363,8 @@ public:
    void
    putCoordinatesToDatabase(
       std::shared_ptr<tbox::Database>& coords_db,
-      const hier::Patch& patch);
+      const hier::Patch& patch,
+      const hier::Box& box);
 
 #ifdef SAMRAI_HAVE_CONDUIT
    void addFields(

--- a/source/test/communication/CommTester.cpp
+++ b/source/test/communication/CommTester.cpp
@@ -741,8 +741,10 @@ void CommTester::setupHierarchy(
 void
 CommTester::putCoordinatesToDatabase(
    std::shared_ptr<tbox::Database>& coords_db,
-   const hier::Patch& patch)
+   const hier::Patch& patch,
+   const hier::Box& box)
 {
+   NULL_USE(box);
 
    std::shared_ptr<geom::CartesianPatchGeometry> pgeom(
       SAMRAI_SHARED_PTR_CAST<geom::CartesianPatchGeometry, hier::PatchGeometry>(

--- a/source/test/communication/CommTester.h
+++ b/source/test/communication/CommTester.h
@@ -276,7 +276,8 @@ public:
    void
    putCoordinatesToDatabase(
       std::shared_ptr<tbox::Database>& coords_db,
-      const hier::Patch& patch);
+      const hier::Patch& patch,
+      const hier::Box& box);
 
    /*!
     * @brief Return the dimension of this object.


### PR DESCRIPTION
This uses the FlattenedHierarchy class to set up a Conduit blueprint description of a flattened version of a PatchHierarchy. The "visible boxes" of the FlattenedHierarchy are the boxes that represent the finest available resolution at all locations of the mesh. The visible boxes for a particular patch may represent only a subset of the patch, as part of a patch may be covered by finer AMR levels.

To map the FlattenedHierarchy to the blueprint, each visible box in the flattened hierarchy is given a unique LocalId, which becomes the domain_id for each blueprint domain.