### PR TITLE
Fix rebalance of Level 0 so that it can use non-uniform option

### DIFF
--- a/source/SAMRAI/mesh/CascadePartitioner.cpp
+++ b/source/SAMRAI/mesh/CascadePartitioner.cpp
@@ -387,14 +387,18 @@ CascadePartitioner::loadBalanceBoxLevel(
       const hier::Connector& current_to_reference = 
          current_level->getBoxLevel()->findConnector(
             workload_to_reference->getHead(),
-            hierarchy->getRequiredConnectorWidth(level_number, level_number-1),
+            hierarchy->getRequiredConnectorWidth(
+               level_number,
+               tbox::MathUtilities<int>::Max(level_number-1, 0)),
             hier::CONNECTOR_CREATE,
             true);
 
       const hier::Connector& reference_to_current =
          workload_to_reference->getHead().findConnector(
             *current_level->getBoxLevel(),
-            hierarchy->getRequiredConnectorWidth(level_number-1, level_number),
+            hierarchy->getRequiredConnectorWidth(
+               tbox::MathUtilities<int>::Max(level_number-1, 0),
+               level_number),
             hier::CONNECTOR_CREATE,
             true);
 

--- a/source/SAMRAI/mesh/GriddingAlgorithm.cpp
+++ b/source/SAMRAI/mesh/GriddingAlgorithm.cpp
@@ -512,10 +512,6 @@ GriddingAlgorithm::makeCoarsestLevel(
       zero_to_new->computeTransposeOf(*new_to_zero,
                                       new_box_level->getMPI());
 
-      //new_to_zero = std::make_shared<hier::Connector>(domain_to_zero);
-      //new_to_zero->setBase(*new_box_level, true);
-      //zero_to_new = std::make_shared<hier::Connector>(zero_to_domain);
-      //zero_to_new->setHead(*new_box_level, true);
       new_to_zero->setTranspose(zero_to_new.get(), false);
    }
 

--- a/source/SAMRAI/mesh/GriddingAlgorithm.cpp
+++ b/source/SAMRAI/mesh/GriddingAlgorithm.cpp
@@ -473,9 +473,55 @@ GriddingAlgorithm::makeCoarsestLevel(
 
    TBOX_ASSERT(!new_box_level->getMPI().hasReceivableMessage());    // Check errant messages.
 
+   std::shared_ptr<hier::Connector> new_to_zero;
+   std::shared_ptr<hier::Connector> zero_to_new;
+   if (level_zero_exists) {
+      /*
+       * If level zero exists, that means we are rebalancing level zero.
+       *
+       * Most calls to loadBalanceBoxLevel pass as the second argument
+       * a pointer to a "balance_to_reference" Connector, which is a
+       * Connector between the BoxLevel to be load balanced (here,
+       * new_box_levle) and a reference level -- that is a BoxLevel that
+       * will not be changed during the loadBalanceBoxLevel call.  When load
+       * balancing a finer level in the AMR hierarchy, the reference level
+       * is typically the current next coarser level, level N-1 when balancing
+       * level N.
+       *
+       * As there is no level N-1 when balancing level zero, here we use
+       * the current level zero as the reference level and construct the
+       * needed Connector.
+       *
+       * If level zero doesn't exist, this section is skipped and a null
+       * pointer is passed to loadBalanceBoxLevel.  A null pointer is a
+       * valid argument when creating the first instance of level zero.
+       */
+
+      hier::IntVector connector_width(
+         hier::IntVector::max(
+            d_hierarchy->getRequiredConnectorWidth(0, 0),
+            hier::IntVector::getOne(dim)));
+
+      new_to_zero = std::make_shared<hier::Connector>(
+         *new_box_level,
+         *(d_hierarchy->getPatchLevel(0)->getBoxLevel()),
+         connector_width);
+      d_oca0.findOverlaps_assumedPartition(*new_to_zero);
+
+      zero_to_new = std::make_shared<hier::Connector>(dim);
+      zero_to_new->computeTransposeOf(*new_to_zero,
+                                      new_box_level->getMPI());
+
+      //new_to_zero = std::make_shared<hier::Connector>(domain_to_zero);
+      //new_to_zero->setBase(*new_box_level, true);
+      //zero_to_new = std::make_shared<hier::Connector>(zero_to_domain);
+      //zero_to_new->setHead(*new_box_level, true);
+      new_to_zero->setTranspose(zero_to_new.get(), false);
+   }
+
    d_load_balancer0->loadBalanceBoxLevel(
       *new_box_level,
-      0,
+      new_to_zero.get(),
       d_hierarchy,
       ln,
       smallest_patch,

--- a/source/test/applications/LinAdv/main.cpp
+++ b/source/test/applications/LinAdv/main.cpp
@@ -310,6 +310,11 @@ int main(
             }
          }
 
+         bool rebalance_coarsest = false;
+         if (main_db->keyExists("rebalance_coarsest")) {
+            rebalance_coarsest = main_db->getBool("rebalance_coarsest");
+         }
+
 #if (TESTING == 1) && !defined(HAVE_HDF5)
          /*
           * If we are autotesting on a system w/o HDF5, the read from
@@ -496,7 +501,9 @@ int main(
                        << std::endl;
             tbox::pout << "Simulation time is " << loop_time << std::endl;
 
-            double dt_new = time_integrator->advanceHierarchy(dt_now);
+            double dt_new = time_integrator->advanceHierarchy(
+               dt_now,
+               rebalance_coarsest);
 
             loop_time += dt_now;
             dt_now = dt_new;

--- a/source/test/applications/LinAdv/test_inputs/test_nonuniform_rebalance.2d.input
+++ b/source/test/applications/LinAdv/test_inputs/test_nonuniform_rebalance.2d.input
@@ -1,0 +1,362 @@
+/*************************************************************************
+ *
+ * This file is part of the SAMRAI distribution.  For full copyright
+ * information, see COPYRIGHT and LICENSE.
+ *
+ * Copyright:     (c) 1997-2023 Lawrence Livermore National Security, LLC
+ * Description:   Input file for SAMRAI LinAdv example problem
+ *
+ ************************************************************************/
+
+GlobalInputs {
+   // If FALSE, when an error is encountered in serial exit(-1) will be called
+   // instead of SAMRAI_MPI::abort().
+   call_abort_in_serial_instead_of_exit = FALSE
+}
+
+AutoTester {
+   // If true, fluxes will be written out to a .dat file for inspection.
+   // Default is FALSE.
+   test_fluxes = FALSE
+
+   // iteration to carry out test.  Default is 10.
+   test_iter_num = 10
+
+   // if true will write correct patch boxes--useful for rebaselining
+   // Default is FALSE.
+   write_patch_boxes = FALSE
+
+   // if true will read correct patch boxes--set to FALSE to rebaseline
+   // Default is FALSE.
+   read_patch_boxes = FALSE
+
+   // time steps for which correctness of patch boxes will be checked
+   // Required if one of write_patch_boxes or read_patch_boxes is true.
+   // No default.
+   test_patch_boxes_at_steps = 0, 5, 10
+
+   // base name of files containing correct patch boxes
+   // Required if one of write_patch_boxes or read_patch_boxes is true.
+   // No default.
+   test_patch_boxes_filename = "test_inputs/test.2d.boxes"
+
+   // expected correct result
+   // Required if test_fluxes is FALSE.  Unread otherwise.  No default.
+   correct_result = 4.5, 0.028125, 0.028125
+
+   // if true will write corrct result--useful for rebaselining
+   // Default is FALSE.
+   output_correct = FALSE
+}
+
+LinAdv {
+   // Allow nonuniform workload.  Default is FALSE.
+   use_nonuniform_workload = TRUE
+
+   // Linear advection velocity vector--vector of length dim.
+   // No default.
+   advection_velocity = 2.0e0 , 1.0e0
+
+   // Order of Goduov slopes (1, 2, or 4).  Default is 1.
+   godunov_order    = 2
+
+   write_coord_values = TRUE
+
+   // Type of finite difference approximation for 3d transverse flux
+   // correction.  Allowed values are CORNER_TRANSPORT_1 and
+   // CORNER_TRANSPORT_2.
+   // CORNER_TRANSPORT_1 means to compute numerical approximations to flux
+   // terms using an extension to three dimensions of Collella's corner
+   // transport upwind approach.
+   // CORNER_TRANSPORT_2 means to compute numerical approximations to flux
+   // terms using John Trangenstein's interpretation of the three-dimensional
+   // version of Collella's corner transport upwind approach.
+   // Default is "CORNER_TRANSPORT_1".
+   corner_transport = "CORNER_TRANSPORT_1"
+
+   // Control of how to refine.
+   Refinement_data {
+      // Refinement criteria and, for each, the parameters controling it.
+      // Refinement criteria may be one or more of UVAL_DEVIATION,
+      // UVAL_GRADIENT, UVAL_SHOCK, or UVAL_RICHARDSON.  No default.
+      refine_criteria = "UVAL_GRADIENT", "UVAL_SHOCK"
+
+      // Criteria for UVAL_GRADIENT refinement criteria.
+      UVAL_GRADIENT {
+         // Array of variable gradient tagging tolerances, one value per level.
+         // If the number of levels is greater than the number of entries in
+         // this array then the tolerance for all finer levels is the last
+         // array entry.  Gradients greater than this tolerance result in
+         // tagged cells.  No default.
+         grad_tol = 10.0
+
+         // Array of maximum simulation times for which this criteria applies,
+         // one per level.  If the number of levels is greater than the number
+         // of entries in this array then the maximum simulation time for all
+         // finer levels is the last array entry.
+         // Default is all time (maximum double) for all levels.
+//         time_max = 1000000.0
+
+         // Array of minimum simulation times for which this criteria applies,
+         // one per level.  If the number of levels is greater than the number
+         // of entries in this array then the minimum simulation time for all
+         // finer levels is the last array entry.
+         // Default is 0.0 for all levels.
+         time_min = 0.0
+      }
+
+      // Criteria for UVAL_SHOCK refinement criteria.
+      UVAL_SHOCK {
+         // Array of shock tagging tolerances, one value per level.  If the
+         // number of levels is greater than the number of entries in this
+         // array then the tolerance for all finer levels is the last array
+         // entry.  No default.
+         shock_tol   = 0.10
+
+         // Array of shock tagging onsets, one value per level.  This value is
+         // used to prevent unintended overrefinement of large, smooth
+         // gradients resulting in smooth flow.  If the number of levels is
+         // greater than the number of entries in this array then the onset for
+         // all finer levels is the last array entry. No default.
+         shock_onset = 0.85
+
+         // Array of maximum simulation times for which this criteria applies,
+         // one per level.  If the number of levels is greater than the number
+         // of entries in this array then the maximum simulation time for all
+         // finer levels is the last array entry.
+         // Default is all time (maximum double) for all levels.
+//         time_max = 1000000.0
+
+         // Array of minimum simulation times for which this criteria applies,
+         // one per level.  If the number of levels is greater than the number
+         // of entries in this array then the minimum simulation time for all
+         // finer levels is the last array entry.
+         // Default is 0.0 for all levels.
+         time_min = 0.0
+      }
+
+      // UVAL_DEVIATION
+      // dev_tol
+      // An array of uval deviation tolerances, one value per level.  Cell
+      // is refined if (p - uval_dev) > dev_tol.  If the number of levels
+      // is greater than the number of entries in this array then the tolerance
+      // for all finer levels is the last array entry.  No default.
+      // uval_dev
+      // An array of uval deviations, one value per level.  If the number of
+      // levels is greater than the number of entries in this array then the
+      // deviation of for all finer levels is the last array entry.
+      // No default.
+      // time_max
+      // An array of maximum simulation times for which this criteria applies,
+      // one per level.  If the number of levels is greater than the number of
+      // entries in this array then the maximum simulation time for all finer
+      // levels is the last array entry.  Default is all time (maximum double)
+      // for all levels.
+      // time_min
+      // An array of minimum simulation times for which this criteria applies,
+      // one per level.  If the number of levels is greater than the number of
+      // entries in this array then the minimum simulation time for all finer
+      // levels is the last array entry.  Default is 0.0 for all levels.
+
+      // UVAL_RICHARDSON
+      // rich_tol
+      // An array of tolerances on the global error.  Cells in which the global
+      // error exceeds the tolerance are tagged.  If the number of levels is
+      // greater than the number of entries in this array then the tolerance
+      // for all finer levels is the last array entry.  No default.
+      // time_max
+      // An array of maximum simulation times for which this criteria applies,
+      // one per level.  If the number of levels is greater than the number of
+      // entries in this array then the maximum simulation time for all finer
+      // levels is the last array entry.  Default is all time (maximum double)
+      // for all levels.
+      // time_min
+      // An array of minimum simulation times for which this criteria applies,
+      // one per level.  If the number of levels is greater than the number of
+      // entries in this array then the minimum simulation time for all finer
+      // levels is the last array entry.  Default is 0.0 for all levels.
+   }
+
+   // General type of problem and its initial conditions.  Options are
+   // "SPHERE", "PIECEWISE_CONSTANT_X", "PIECEWISE_CONSTANT_"Y,
+   // "PIECEWISE_CONSTANT_Z", "SINE_CONSTANT_X", "SINE_CONSTANT_Y",
+   // "SINE_CONSTANT_Z".  Specific Initial_data inputs vary by problem type.
+   // No default.
+   data_problem      = "SPHERE"
+   Initial_data {
+      // Radius of sphere.  No default.
+      radius            = 2.9
+
+      // Center of sphere.  No default.
+      center            = 22.5 , 5.5
+
+      // uval inside of sphere.  No default.
+      uval_inside       = 80.0
+
+      // uval outside of sphere.  No default.
+      uval_outside      = 5.0
+
+   }
+
+   // Boundary condition data following the format defined in
+   // appu::CartesianBoundaryUtility[2,3].  Refer to these classes for details.
+   Boundary_data {
+      boundary_edge_xlo {
+         boundary_condition      = "FLOW"
+      }
+      boundary_edge_xhi {
+         boundary_condition      = "FLOW"
+      }
+      boundary_edge_ylo {
+         boundary_condition      = "FLOW"
+      }
+      boundary_edge_yhi {
+         boundary_condition      = "FLOW"
+      }
+
+      // IMPORTANT: If a *REFLECT, *DIRICHLET, or *FLOW condition is given
+      //            for a node, the condition must match that of the
+      //            appropriate adjacent edge above.  This is enforced for
+      //            consistency.  However, note when a REFLECT edge condition
+      //            is given and the other adjacent edge has either a FLOW
+      //            or REFLECT condition, the resulting node boundary values
+      //            will be the same regardless of which edge is used.
+      boundary_node_xlo_ylo {
+         boundary_condition      = "XFLOW"
+      }
+      boundary_node_xhi_ylo {
+         boundary_condition      = "XFLOW"
+      }
+      boundary_node_xlo_yhi {
+         boundary_condition      = "XFLOW"
+      }
+      boundary_node_xhi_yhi {
+         boundary_condition      = "XFLOW"
+      }
+   }
+}
+
+Main {
+   // Dimension of problem.  No default.
+   dim = 2
+
+
+   // Base name of log and viz files.  Default is "unnamed".
+   base_name = "test.2d"
+
+   // Rebalance coarsest level at each timestep
+   rebalance_coarsest = TRUE
+
+   // Explicit name of log file.  Default is base_name + ".log"
+   log_filename = "test.2d.log"
+
+
+   // If true all nodes will log to individual files
+   // If false only node 0 will log
+   // Default is FALSE.
+   log_all_nodes    = TRUE
+
+
+   // Visualization dump parameters.
+
+   // Frequency at which to dump viz output--zero to turn off
+   // Default is 0.
+   viz_dump_interval    = 1
+
+   // Directory in which to place viz output.
+   // Default is base_name + ".visit"
+   viz_dump_dirname     = "viz-test-2d"
+
+   write_blueprint      = TRUE
+
+   // Restart dump parameters.
+
+   // Frequency at which to dump restart output--zero to turn off
+   // Default is 0.
+   restart_interval     = 1  
+
+   // Directory in which to place restart output.
+   // Default is base_name + ".restart"
+   restart_write_dirname = "test.2d.restart"
+
+
+   // If anything but "SYNCHRONIZED" will use refined timestepping.
+   // Default is not "SYNCHRONIZED".
+//   use_refined_timestepping = "SYNCHRONIZED"
+
+}
+
+// Refer to geom::CartesianGridGeometry and its base classes for input
+CartesianGeometry{
+   domain_boxes	= [(0,0),(29,19)]
+
+   x_lo = 0.e0 , 0.e0   // lower end of computational domain.
+   x_up = 30.e0 , 20.e0 // upper end of computational domain.
+
+   periodic_dimension = 1,0
+}
+
+// Refer to hier::PatchHierarchy for input
+PatchHierarchy {
+   max_levels = 3        // Maximum number of levels in hierarchy.
+
+   ratio_to_coarser {             // vector ratio to next coarser level
+      level_1 = 4 , 4
+      // SGS TODO this was added for DistributedGriddingAlgorthm
+      level_2 = 4 , 4
+      // all finer levels will use same values as level_0...
+   }
+
+   largest_patch_size {
+      level_0 = 40 , 40  // largest patch allowed in hierarchy
+      // all finer levels will use same values as level_0...
+   }
+
+   smallest_patch_size {
+      level_0 = 5, 5
+      level_1 = 16, 16
+      // all finer levels will use same values as level_0...
+   }
+
+}
+
+// Refer to mesh::GriddingAlgorithm for input
+GriddingAlgorithm{
+   sequentialize_patch_indices = TRUE // Required for plotting.
+
+   print_mapped_box_level_hierarchy = 'y'
+}
+
+// Refer to mesh::BergerRigoutsos for input
+BergerRigoutsos {
+   sort_output_nodes = TRUE // Makes results repeatable.
+   efficiency_tolerance   = 0.85e0    // min % of tag cells in new patch level
+   combine_efficiency     = 0.95e0    // chop box if sum of volumes of smaller
+                                      // boxes < efficiency * vol of large box
+}
+
+// Refer to mesh::StandardTagAndInitialize for input
+StandardTagAndInitialize {
+   tagging_method = "GRADIENT_DETECTOR"
+}
+
+// Refer to algs::HyperbolicLevelIntegrator for input
+HyperbolicLevelIntegrator{
+   cfl                       = 0.9e0    // max cfl factor used in problem
+   cfl_init                  = 0.9e0    // initial cfl factor
+   lag_dt_computation        = TRUE
+   use_ghosts_to_compute_dt  = TRUE
+}
+
+// Refer to algs::TimeRefinementIntegrator for input
+TimeRefinementIntegrator{
+   start_time           = 0.e0     // initial simulation time
+   end_time             = 100.e0   // final simulation time
+   grow_dt              = 1.1e0    // growth factor for timesteps
+   max_integrator_steps = 10       // max number of simulation timesteps
+}
+
+// Refer to mesh::TreeLoadBalancer for input
+LoadBalancer {
+   // using default TreeLoadBalancer configuration
+}

--- a/source/test/applications/LinAdv/test_inputs/test_nonuniform_rebalance.3d.input
+++ b/source/test/applications/LinAdv/test_inputs/test_nonuniform_rebalance.3d.input
@@ -1,0 +1,292 @@
+/*************************************************************************
+ *
+ * This file is part of the SAMRAI distribution.  For full copyright
+ * information, see COPYRIGHT and LICENSE.
+ *
+ * Copyright:     (c) 1997-2023 Lawrence Livermore National Security, LLC
+ * Description:   Input file for SAMRAI LinAdv example problem
+ *
+ ************************************************************************/
+
+// Refer to test2d.input for full description of all input parameters specific
+// to this problem.
+
+GlobalInputs {
+   call_abort_in_serial_instead_of_exit = FALSE
+}
+
+AutoTester {
+   // iteration to carry out test
+   test_iter_num = 10
+
+   // expected correct result
+   correct_result = 9.0, 0.225, 0.225
+
+   // if true will write corrct result--useful for rebaselining
+   output_correct = FALSE
+
+   // if true will write correct patch boxes--useful for rebaselining
+   write_patch_boxes = FALSE
+
+   // if true will read correct patch boxes--set to FALSE to rebaseline
+   read_patch_boxes = FALSE
+
+   // time steps for which correctness of patch boxes will be checked
+   test_patch_boxes_at_steps = 0, 5, 10
+
+   // base name of files containing correct patch boxes
+   test_patch_boxes_filename = "test_inputs/test.3d.boxes"
+
+}
+
+LinAdv {
+   use_nonuniform_workload = TRUE
+
+   // Linear advection velocity vector--vector of length dim
+   advection_velocity = 2.0e0 , 1.0e0 , 1.0e0
+
+   // order of Goduov slopes (1, 2, or 4)
+   godunov_order    = 2
+
+   // type of finite difference approximation for 3d transverse flux correction
+   // Allowed values are CORNER_TRANSPORT_1 and CORNER_TRANSPORT_2.
+   // CORNER_TRANSPORT_1 means to compute numerical approximations to flux
+   // terms using an extension to three dimensions of Collella's corner
+   // transport upwind approach.
+   // CORNER_TRANSPORT_2 means to compute numerical approximations to flux
+   // terms using John Trangenstein's interpretation of the three-dimensional
+   // version of Collella's corner transport upwind approach.
+   corner_transport = "CORNER_TRANSPORT_1"
+
+   // General type of problem and its initial conditions.
+   data_problem      = "SPHERE"
+   Initial_data {
+      radius            = 2.9
+      center            = 5.5 , 5.5 , 5.5
+
+      uval_inside       = 80.0
+      uval_outside      = 5.0
+
+   }
+
+   // Refinement criteria and, for each, the parameters controling it.
+   // Refinement criteria may be one or more of UVAL_DEVIATION, UVAL_GRADIENT,
+   // UVAL_SHOCK, or UVAL_RICHARDSON.
+   Refinement_data {
+      refine_criteria = "UVAL_GRADIENT", "UVAL_SHOCK"
+
+      UVAL_GRADIENT {
+         grad_tol = 10.0
+      }
+
+      UVAL_SHOCK {
+         shock_tol   = 10.0
+         shock_onset = 0.85
+      }
+   }
+
+   // Boundary condition data following the format defined in
+   // appu::CartesianBoundaryUtility[2,3]
+   Boundary_data {
+      boundary_face_xlo {
+         boundary_condition      = "FLOW"
+      }
+      boundary_face_xhi {
+         boundary_condition      = "FLOW"
+      }
+      boundary_face_ylo {
+         boundary_condition      = "FLOW"
+      }
+      boundary_face_yhi {
+         boundary_condition      = "FLOW"
+      }
+      boundary_face_zlo {
+         boundary_condition      = "FLOW"
+      }
+      boundary_face_zhi {
+         boundary_condition      = "FLOW"
+      }
+
+      // IMPORTANT: If a *REFLECT, *DIRICHLET, or *FLOW condition is given
+      //            for an edge, the condition must match that of the
+      //            appropriate adjacent face above.  This is enforced for
+      //            consistency.  However, note when a REFLECT face condition
+      //            is given and the other adjacent face has either a FLOW
+      //            or REFLECT condition, the resulting edge boundary values
+      //            will be the same regardless of which face is used.
+
+      boundary_edge_ylo_zlo { // XFLOW, XREFLECT, XDIRICHLET not allowed
+         boundary_condition      = "ZFLOW"
+      }
+      boundary_edge_yhi_zlo { // XFLOW, XREFLECT, XDIRICHLET not allowed
+         boundary_condition      = "ZFLOW"
+      }
+      boundary_edge_ylo_zhi { // XFLOW, XREFLECT, XDIRICHLET not allowed
+         boundary_condition      = "ZFLOW"
+      }
+      boundary_edge_yhi_zhi { // XFLOW, XREFLECT, XDIRICHLET not allowed
+         boundary_condition      = "ZFLOW"
+      }
+      boundary_edge_xlo_zlo { // YFLOW, YREFLECT, YDIRICHLET not allowed
+         boundary_condition      = "XFLOW"
+      }
+      boundary_edge_xlo_zhi { // YFLOW, YREFLECT, YDIRICHLET not allowed
+         boundary_condition      = "XFLOW"
+      }
+      boundary_edge_xhi_zlo { // YFLOW, YREFLECT, YDIRICHLET not allowed
+         boundary_condition      = "XFLOW"
+      }
+      boundary_edge_xhi_zhi { // YFLOW, YREFLECT, YDIRICHLET not allowed
+         boundary_condition      = "XFLOW"
+      }
+      boundary_edge_xlo_ylo { // ZFLOW, ZREFLECT, ZDIRICHLET not allowed
+         boundary_condition      = "YFLOW"
+      }
+      boundary_edge_xhi_ylo { // ZFLOW, ZREFLECT, ZDIRICHLET not allowed
+         boundary_condition      = "YFLOW"
+      }
+      boundary_edge_xlo_yhi { // ZFLOW, ZREFLECT, ZDIRICHLET not allowed
+         boundary_condition      = "YFLOW"
+      }
+      boundary_edge_xhi_yhi { // ZFLOW, ZREFLECT, ZDIRICHLET not allowed
+         boundary_condition      = "YFLOW"
+      }
+
+      // IMPORTANT: If a *REFLECT, *DIRICHLET, or *FLOW condition is given
+      //            for a node, the condition must match that of the
+      //            appropriate adjacent face above.  This is enforced for
+      //            consistency.  However, note when a REFLECT face condition
+      //            is given and the other adjacent faces have either FLOW
+      //            or REFLECT conditions, the resulting node boundary values
+      //            will be the same regardless of which face is used.
+
+      boundary_node_xlo_ylo_zlo {
+         boundary_condition      = "XFLOW"
+      }
+      boundary_node_xhi_ylo_zlo {
+         boundary_condition      = "XFLOW"
+      }
+      boundary_node_xlo_yhi_zlo {
+         boundary_condition      = "XFLOW"
+      }
+      boundary_node_xhi_yhi_zlo {
+         boundary_condition      = "XFLOW"
+      }
+      boundary_node_xlo_ylo_zhi {
+         boundary_condition      = "XFLOW"
+      }
+      boundary_node_xhi_ylo_zhi {
+         boundary_condition      = "XFLOW"
+      }
+      boundary_node_xlo_yhi_zhi {
+         boundary_condition      = "XFLOW"
+      }
+      boundary_node_xhi_yhi_zhi {
+         boundary_condition      = "XFLOW"
+      }
+
+   }
+
+}
+
+Main {
+   // dimension of problem
+   dim = 3
+
+   // base name of log file
+   base_name = "test.3d"
+
+   // Rebalance coarsest level at each timestep
+   rebalance_coarsest = TRUE
+
+   // if true all nodes will log to individual files
+   // if false only node 0 will log
+   log_all_nodes    = TRUE
+
+   // visualization dump parameters
+   // frequency at which to dump viz output--zero to turn off
+   viz_dump_interval    = 0
+   // directory in which to place viz output
+   viz_dump_dirname     = "viz-test-3d"
+
+   // restart dump parameters
+   // frequency at which to dump restart output--zero to turn off
+   restart_interval     = 1
+}
+
+// Refer to geom::CartesianGridGeometry and its base classes for input
+CartesianGeometry{
+   domain_boxes	= [ (0,0,0) , (14,9,9) ]
+
+   x_lo = 0.e0 , 0.e0 , 0.e0    // lower end of computational domain.
+   x_up = 30.e0 , 20.e0 , 20.e0 // upper end of computational domain.
+}
+
+// Refer to hier::PatchHierarchy for input
+PatchHierarchy {
+   max_levels = 3        // Maximum number of levels in hierarchy.
+
+// Note: For the following regridding information, data is required for each
+//       potential in the patch hierarchy; i.e., levels 0 thru max_levels-1.
+//       If more data values than needed are given, only the number required
+//       will be read in.  If fewer values are given, an error will result.
+//
+// Specify coarsening ratios for each level 1 through max_levels-1
+
+   ratio_to_coarser {             // vector ratio to next coarser level
+      level_1 = 2 , 2 , 2
+      level_2 = 2 , 2 , 2
+      level_3 = 2 , 2 , 2
+   }
+
+   largest_patch_size {
+      level_0 = 40 , 40 , 40  // largest patch allowed in hierarchy
+      // all finer levels will use same values as level_0...
+   }
+
+   smallest_patch_size {
+      level_0 = 4 , 4 , 4
+      level_1 = 9 , 9 , 9
+      // all finer levels will use same values as level_0...
+   }
+
+}
+
+// Refer to mesh::GriddingAlgorithm for input
+GriddingAlgorithm{
+}
+
+// Refer to mesh::BergerRigoutsos for input
+BergerRigoutsos {
+   sort_output_nodes = TRUE // Makes results repeatable.
+   efficiency_tolerance   = 0.85e0    // min % of tag cells in new patch level
+   combine_efficiency     = 0.95e0    // chop box if sum of volumes of smaller
+                                      // boxes < efficiency * vol of large box
+}
+
+// Refer to mesh::StandardTagAndInitialize for input
+StandardTagAndInitialize {
+   tagging_method = "GRADIENT_DETECTOR"
+}
+
+
+// Refer to algs::HyperbolicLevelIntegrator for input
+HyperbolicLevelIntegrator{
+   cfl                       = 0.9e0    // max cfl factor used in problem
+   cfl_init                  = 0.9e0    // initial cfl factor
+   lag_dt_computation        = TRUE
+   use_ghosts_to_compute_dt  = TRUE
+}
+
+// Refer to algs::TimeRefinementIntegrator for input
+TimeRefinementIntegrator{
+   start_time           = 0.e0     // initial simulation time
+   end_time             = 100.e0   // final simulation time
+   grow_dt              = 1.1e0    // growth factor for timesteps
+   max_integrator_steps = 10       // max number of simulation timesteps
+}
+
+// Refer to mesh::TreeLoadBalancer for input
+LoadBalancer {
+   // using default TreeLoadBalancer configuration
+}


### PR DESCRIPTION
`GriddingAlgorithm::makeCoarsestLevel` can be called after Level 0 already exists to invoke a rebalance of the coarsest level.  This PR makes sure that all necessary Connectors are created prior to calling the load balancer, so that non-uniform load balancing options such as those in `CascadePartitioner` will work.