### PR TITLE
  Rebuild Connectors when Level 0 is rebalanced

### DIFF
--- a/source/SAMRAI/mesh/GriddingAlgorithm.cpp
+++ b/source/SAMRAI/mesh/GriddingAlgorithm.cpp
@@ -681,6 +681,13 @@ GriddingAlgorithm::makeCoarsestLevel(
 
       old_level.reset();
 
+      if (d_hierarchy->getNumberOfLevels() > 1) {
+         d_hierarchy->getPatchLevel(0)->findConnectorWithTranspose(
+            *(d_hierarchy->getPatchLevel(1)),
+            d_hierarchy->getRequiredConnectorWidth(0,1),
+            d_hierarchy->getRequiredConnectorWidth(1,0),
+            hier::CONNECTOR_CREATE);
+      }
    }
 
    std::shared_ptr<hier::PatchLevel> new_level(


### PR DESCRIPTION
A rebalancing of level 0 wiped out the Connectors between Levels 0 and 1 as well as the "self connector" of Level 0 to itself.  This PR rebuilds them so that they are present just as they are in all other cases when a PatchHierarchy is created and/or regridded by GriddingAlgorithm.  For #256 