### PR TITLE
vector interop

### DIFF
--- a/source/SAMRAI/hier/BoxContainer.h
+++ b/source/SAMRAI/hier/BoxContainer.h
@@ -84,6 +84,7 @@ class BoxContainer
    friend class BoxContainerConstIterator;
 
 public:
+   typedef const Box value_type;
    class BoxContainerIterator;
 
    /*!


### PR DESCRIPTION
it's nice to have this to work directly on the box container without needing to use the iterators

for instance, we have a function like so to count some variables based on some input

```
template<typename Container, typename F>
auto sum_from(Container&& container, F fn)
{
    using value_type  = typename std::decay_t<Container>::value_type;
    using return_type = std::decay_t<std::result_of_t<F const&(value_type const&)>>;
    return_type sum   = 0;
    for (auto const& el : container)
        sum += fn(el);
    return sum;
}
```

this PR would let us work with box containers in this context as if they were vectors