### PR TITLE
Add ArrayData::fillSequential

### DIFF
--- a/source/SAMRAI/mesh/GriddingAlgorithm.cpp
+++ b/source/SAMRAI/mesh/GriddingAlgorithm.cpp
@@ -3323,9 +3323,7 @@ GriddingAlgorithm::bufferTagsOnLevel(
       buf_tag_box.grow(hier::IntVector(dim, buffer_size));
 
       boolean_tag_data->fillAll(not_tag);
-#if defined(HAVE_RAJA)
-      tbox::parallel_synchronize();
-#endif
+
       pdat::CellIterator icend(pdat::CellGeometry::end(buf_tag_box));
       for (pdat::CellIterator ic(pdat::CellGeometry::begin(buf_tag_box));
            ic != icend; ++ic) {
@@ -3333,14 +3331,9 @@ GriddingAlgorithm::bufferTagsOnLevel(
             hier::Box buf_box(*ic - buffer_size,
                               *ic + buffer_size,
                               tag_box_block_id);
-            //TODO:  check on this change
-            //boolean_tag_data->fill(tag_value, buf_box);
-            boolean_tag_data->getArrayData().fill(tag_value, buf_box);
+            boolean_tag_data->getArrayData().fillSequential(tag_value, buf_box);
          }
       }
-#if defined(HAVE_RAJA)
-      tbox::parallel_synchronize();
-#endif
    }
    SAMRAI_CALI_MARK_END("bufferBCdata");
 

--- a/source/SAMRAI/pdat/ArrayData.cpp
+++ b/source/SAMRAI/pdat/ArrayData.cpp
@@ -1200,6 +1200,64 @@ void ArrayData<TYPE>::fill(
    }
 }
 
+template <class TYPE>
+void ArrayData<TYPE>::fillSequential(
+    const TYPE& t,
+    const hier::Box& box,
+    const unsigned int d)
+{
+   const tbox::Dimension& dim = box.getDim();
+   if (dim.getValue() > 3) {
+      fill(t, box, d);
+   } else {
+      hier::Box fill_box(box * d_box);
+      const hier::Index& b_lower = fill_box.lower();
+      const hier::Index b_upper = fill_box.upper();
+      int b_ilo = b_lower(0);
+      int b_ihi = b_upper(0);
+      int b_jlo = 0;
+      int b_jhi = 0;
+      int b_klo = 0;
+      int b_khi = 0;
+      if (dim.getValue() > 1) {
+         b_jlo = b_lower(1);
+         b_jhi = b_upper(1);
+      }
+      if (dim.getValue() == 3) {
+         b_klo = b_lower(2);
+         b_khi = b_upper(2);
+      }
+
+      const hier::Index& dbox_lower = d_box.lower();
+      const hier::Index& dbox_upper = d_box.upper();
+      int iwidth = dbox_upper(0)-dbox_lower(0) + 1;
+      int jwidth = 0;
+      int dbox_ilo = dbox_lower(0);
+      int dbox_jlo = 0;
+      int dbox_klo = 0;
+      if (dim.getValue() > 1) {
+         jwidth = dbox_upper(1) - dbox_lower(1) + 1;
+         dbox_jlo = dbox_lower(1);
+      }
+      if (dim.getValue() == 3) {
+         dbox_klo = dbox_lower(2);
+      }
+
+      for (int k = b_klo; k <= b_khi; ++k) { 
+         int koffset = (d * d_offset) + (k - dbox_klo) * iwidth * jwidth; 
+         for (int j = b_jlo; j <= b_jhi; ++j) {
+            int joffset = (j - dbox_jlo) * iwidth;
+            for (int i = b_ilo; i <= b_ihi; ++i) {
+               int ioffset = i - dbox_ilo;
+               d_array[ioffset+joffset+koffset] = t;
+            }
+         }
+      }
+   }
+
+}
+
+
 /*
  *************************************************************************
  *

--- a/source/SAMRAI/pdat/ArrayData.h
+++ b/source/SAMRAI/pdat/ArrayData.h
@@ -615,6 +615,21 @@ public:
       const unsigned int d = 0);
 
    /*!
+    * @brief Fill all arrray values associated with depth component d
+    * with the box with the value t
+    *
+    * This is equivalent to the fill() method with the same signature, with an
+    * implementation that never uses parallel threading.
+    *
+    * @pre (d >= 0) && (d < getDepth())
+    */
+   void
+   fillSequential(
+      const TYPE& t,
+      const hier::Box& box,
+      const unsigned int d = 0);
+
+   /*!
     * Check to make sure that the class version and restart file
     * version are equal.  If so, read in data from restart database.
     *


### PR DESCRIPTION
This adds a method that is equivalent to ArrayData::fill but is implemented to never use RAJA abstractions or any thread parallelism, for use in calls on small chunks of data in the tag buffer filling code in GriddingAlgorithm.