### PR TITLE
Change some config macros to have SAMRAI_ prefix to avoid name conflicts

### DIFF
--- a/cmake/CMakeConfigureFile.cmake
+++ b/cmake/CMakeConfigureFile.cmake
@@ -48,11 +48,11 @@ check_function_exists(mallinfo HAVE_MALLINFO)
 #HAVE_MALLOC_H
 check_include_files(malloc.h HAVE_MALLOC_H)
 
-#HAVE_SYS_TIMES_H
-check_include_files(sys/times.h HAVE_SYS_TIMES_H)
+#SAMRAI_HAVE_SYS_TIMES_H
+check_include_files(sys/times.h SAMRAI_HAVE_SYS_TIMES_H)
 
-#HAVE_UNISTD_H
-check_include_files(unistd.h HAVE_UNISTD_H)
+#SAMRAI_HAVE_UNISTD_H
+check_include_files(unistd.h SAMRAI_HAVE_UNISTD_H)
 
 #IOMANIP_HEADER_FILE
 set(IOSTREAM_HEADER_FILE "<iomanip>")

--- a/config/SAMRAI_config.h.cmake.in
+++ b/config/SAMRAI_config.h.cmake.in
@@ -191,7 +191,7 @@
 #cmakedefine HAVE_SYS_STAT_H
 
 /* Define to 1 if you have the <sys/times.h> header file. */
-#cmakedefine HAVE_SYS_TIMES_H
+#cmakedefine SAMRAI_HAVE_SYS_TIMES_H
 
 /* Define to 1 if you have the <sys/types.h> header file. */
 #cmakedefine HAVE_SYS_TYPES_H
@@ -206,7 +206,7 @@
 #undef HAVE_TEMPLATE_COMPLEX
 
 /* Define to 1 if you have the <unistd.h> header file. */
-#cmakedefine HAVE_UNISTD_H
+#cmakedefine SAMRAI_HAVE_UNISTD_H
 
 /* HAVE_VAMPIR */
 #undef HAVE_VAMPIR

--- a/source/SAMRAI/tbox/Clock.cpp
+++ b/source/SAMRAI/tbox/Clock.cpp
@@ -15,7 +15,7 @@
 namespace SAMRAI {
 namespace tbox {
 
-#ifdef HAVE_SYS_TIMES_H
+#ifdef SAMRAI_HAVE_SYS_TIMES_H
 struct tms Clock::s_tms_buffer;
 #endif
 clock_t Clock::s_null_clock_t;

--- a/source/SAMRAI/tbox/Clock.h
+++ b/source/SAMRAI/tbox/Clock.h
@@ -19,11 +19,11 @@
 #include <ctime>
 #endif
 
-#ifdef HAVE_SYS_TIMES_H
+#ifdef SAMRAI_HAVE_SYS_TIMES_H
 #include <sys/times.h>
 #endif
 
-#ifdef HAVE_UNISTD_H
+#ifdef SAMRAI_HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 
@@ -79,7 +79,7 @@ struct Clock {
    initialize(
       clock_t& clock)
    {
-#ifdef HAVE_SYS_TIMES_H
+#ifdef SAMRAI_HAVE_SYS_TIMES_H
       clock = times(&s_tms_buffer);
 #endif
    }
@@ -105,7 +105,7 @@ struct Clock {
       clock_t& sys,
       double& wall)
    {
-#ifdef HAVE_SYS_TIMES_H
+#ifdef SAMRAI_HAVE_SYS_TIMES_H
       s_null_clock_t = times(&s_tms_buffer);
       wall = SAMRAI_MPI::Wtime();
       sys = s_tms_buffer.tms_stime;
@@ -128,7 +128,7 @@ struct Clock {
    }
 
 private:
-#ifdef HAVE_SYS_TIMES_H
+#ifdef SAMRAI_HAVE_SYS_TIMES_H
    static struct tms s_tms_buffer;
 #endif
    static clock_t s_null_clock_t;

--- a/source/SAMRAI/tbox/SAMRAI_MPI.cpp
+++ b/source/SAMRAI/tbox/SAMRAI_MPI.cpp
@@ -10,11 +10,11 @@
 
 #include "SAMRAI/tbox/SAMRAI_MPI.h"
 
-#ifdef HAVE_SYS_TIMES_H
+#ifdef SAMRAI_HAVE_SYS_TIMES_H
 #include <sys/times.h>
 #endif
 
-#ifdef HAVE_UNISTD_H
+#ifdef SAMRAI_HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 
@@ -598,7 +598,7 @@ SAMRAI_MPI::Wtime()
 {
    double rval = 0.0;
    if (!s_mpi_is_initialized) {
-#ifdef HAVE_SYS_TIMES_H
+#ifdef SAMRAI_HAVE_SYS_TIMES_H
       // Without MPI, use POSIX time.
       struct tms tmp_tms;
       clock_t clock_ticks_since_reference = times(&tmp_tms);

--- a/source/SAMRAI/tbox/Scanner.cpp
+++ b/source/SAMRAI/tbox/Scanner.cpp
@@ -42,7 +42,7 @@
 #define YY_FLEX_MINOR_VERSION 5
 
 #include <stdio.h>
-#ifdef HAVE_UNISTD_H
+#ifdef SAMRAI_HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 

--- a/source/SAMRAI/tbox/scanner_fixup.pl
+++ b/source/SAMRAI/tbox/scanner_fixup.pl
@@ -15,7 +15,7 @@ while(<>) {
     s/.*Date:.*//;
     s/.*Header:.*//;
 
-    s/#include <unistd.h>/#ifdef HAVE_UNISTD_H\n#include <unistd.h>\n#endif/;
+    s/#include <unistd.h>/#ifdef SAMRAI_HAVE_UNISTD_H\n#include <unistd.h>\n#endif/;
 
     # substitution to replace [yylval] with SAMRAI_[yylval]
     s/yylval/SAMRAI_yylval/g;

--- a/tools/restart/main.C
+++ b/tools/restart/main.C
@@ -25,7 +25,7 @@
 #include <string>
 #include <cstring>
 
-#ifdef HAVE_UNISTD_H
+#ifdef SAMRAI_HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
Per user request, this avoids conflicting #define macros with those used by other libraries.