### PR TITLE
cmake < 3.5 is deprecated, blt min is 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 
 project(SAMRAI C CXX Fortran)
 


### PR DESCRIPTION
there is a reference to 3.5 in blt but it's just patch notes it seems