### PR TITLE
Fix typos and improve clarity in README.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,17 @@
 # Contributing to SAMRAI
 
-This document is intented for developers who want to add new features or
-bugfixes to SAMRAI. It assumes you have some familiarity with git and GitHub. It
-will discuss what a good pull request (PR) looks like, and the tests that your
+This document is intended for developers who want to add new features or
+bug fixes to SAMRAI. It assumes you have some familiarity with Git and GitHub. It
+explains what a good pull request (PR) looks like, and the tests your
 PR must pass before it can be merged into SAMRAI.
 
 ## Forking SAMRAI
 
-If you aren't a SAMRAI deveolper at LLNL, then you won't have permission to push
+If you aren't a SAMRAI developer at LLNL, you won't have permission to push
 new branches to the repository. First, you should create a
 [fork](https://github.com/LLNL/SAMRAI#fork-destination-box). This will create a
 copy of the SAMRAI repository that you own, and will ensure you can push your
-changes up to GitHub and create pull requests.
+changes to GitHub and create pull requests.
 
 ## Developing a New Feature
 
@@ -34,49 +34,49 @@ branch to GitHub and create a PR.
 
 ## Developing a Bug Fix
 
-First, check if the change you want to make has been fixed in `master`. If so,
-we suggest you either start using the `master` branch, or temporarily apply the
+First, check if the change you want to make has already been fixed in `master`. If so,
+we suggest you either start using the `master` branch or temporarily apply the
 fix to whichever version of SAMRAI you are using.
 
-Assuming there is an unsolved bug, first make sure you have an up-to-date copy
-of the develop branch:
+If the bug remains unsolved, make sure you have an up-to-date copy
+of the `develop` branch:
 
-    $ git checkout master
-    $ git pull origin master
+    $ git checkout develop
+    $ git pull origin develop
 
-Then create a new branch for your bugfix:
+Then create a new branch for your bug fix:
 
     $ git checkout -b bugfix/<name-of-bug>
 
-First, add a test that reproduces the bug you have found. Then develop your
-bugfix as normal, and ensure to `make test` to check your changes actually fix
+Start by adding a test that reproduces the bug you have found. Then, develop your
+bug fix as normal, and ensure to run `make test` to check that your changes actually fix
 the bug.
 
-Once you are finished, you can push your branch to GitHub, then create a PR.
+Once you're finished, push your branch to GitHub and create a PR.
 
 ## Creating a Pull Request
 
 You can create a new PR [here](https://github.com/LLNL/SAMRAI/compare). GitHub
 has a good [guide](https://help.github.com/articles/about-pull-requests/) to PR
-basics if you want some more information. Ensure that your PR base is the
+basics if you need more information. Ensure that your PR base is the
 `develop` branch of SAMRAI.
 
 Add a descriptive title explaining the bug you fixed or the feature you have
-added, and put a longer description of the changes you have made in the comment
+added, and provide a detailed description of the changes you have made in the comment
 box.
 
-Once your PR has been created, it will be run through our automated tests and
-also be reviewed by SAMRAI team members. Providing the branch passes both the
-tests and reviews, it will be merged into SAMRAI.
+Once your PR is created, it will be run through our automated tests and
+also reviewed by SAMRAI team members. If the branch passes both the
+tests and the review, it will be merged into SAMRAI.
 
 ## Tests
 
 SAMRAI uses Travis CI for continuous integration tests. Our tests are
 automatically run against every new pull request, and passing all tests is a
-requirement for merging your PR. If you are developing a bugfix or a new
-feature, please add a test that checks the correctness of your new code. SAMRAI
-is used on a wide variety of systems with a number of configurations, and adding
+requirement for merging your PR. If you are developing a bug fix or a new
+feature, please add a test to verify the correctness of your new code. SAMRAI
+is used on a wide variety of systems with different configurations, and adding
 new tests helps ensure that all features work as expected across these
 environments.
 
-SAMRAI's tests are all in the `/source/test` and are spilt up by 
+SAMRAI's tests are all in the `/source/test` directory and are split up by module to match different parts of the codebase. Please review existing tests to determine where your test should go.

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ simplifies the exploration of SAMR methods in new application domains.
 
 ## New Release
 
-The current release is SAMRAI v. 4.0.1.  With the version 4 release, the
+The current release is SAMRAI v. 4.0.1. With the version 4 release, the
 SAMRAI project is pleased to introduce new features that support running
 applications on GPU-based architectures, using capabilities provided by the
 Umpire and RAJA libraries.
 
 ## Get Involved
 
-SAMRAI is an open source project, and questions, discussion and contributions
+SAMRAI is an open-source project, and questions, discussion, and contributions
 are welcome!
 
 ### Mailing List
@@ -29,15 +29,15 @@ To get in touch with all the SAMRAI developers, please email samrai@llnl.gov
 ### Contributions
 
 Contributing to SAMRAI should be easy! We are managing contributions through
-pull requents here on GitHub. When you create your pull request, please make
-`master` the target branch.
+pull requests here on GitHub. When you create your pull request, please set
+the target branch to `master`.
 
 Your PR must pass all of SAMRAI's unit tests, which are enforced using Travis
 CI. For information on how to run these tests locally, please see our
-[contribution guidelines](CONTRIBUTING.md)
+[contribution guidelines](CONTRIBUTING.md).
 
 The `master` branch contains the latest development, and releases are tagged.
-New features should be created in `feature/<name>`branches and be based on
+New features should be developed in `feature/<name>` branches, based on
 `master`.
 
 ## Citing SAMRAI


### PR DESCRIPTION
1. Changes in README.md:
Typo in "Contributions" Section:

Old: "We are managing contributions through pull requents here on GitHub."

New: "We are managing contributions through pull requests here on GitHub."

Change: Corrected the typo "requents" to "requests."

Clarity Improvements in the "Contributions" Section:

Old: "please make master the target branch."

New: "please set the target branch to master when creating your pull request."

Change: Made the instruction clearer.

Old: "New features should be created in feature/<name>branches and be based on master."

New: "New features should be developed in feature/<name> branches, based on the master branch."

Change: Improved the wording for clarity.


2. Changes in CONTRIBUTING.md:
Incomplete Sentence Fix:

Old (incomplete): "SAMRAI's tests are all in the /source/test and are spilt up by"

New (completed): "SAMRAI's tests are all in the /source/test directory and are split up by module to match different parts of the codebase. Please review existing tests to determine where your test should go."

Change: Completed the cut-off sentence and corrected the typo "spilt" to "split."