### PR TITLE
clarify documentation

### DIFF
--- a/source/SAMRAI/xfer/RefineSchedule.h
+++ b/source/SAMRAI/xfer/RefineSchedule.h
@@ -135,10 +135,10 @@ public:
     * copied.
     *
     * Only data on the intersection of the source and destination patch data
-    * will be copied.  If portions of the destination level remain unfilled,
-    * then the algorithm recursively fills those unfilled portions by
-    * interpolating source data from coarser levels in the AMR hierarchy.  The
-    * source and destination patch levels must reside in the same index space.
+    * will be copied.  Non-interesecting portions will be recursively filled by
+    * the algorithm from coarser levels in the AMR hierarchy.
+    * Refinement is done before copy.
+    * The source and destination patch levels must reside in the same index space.
     * However, the levels do not have to be in the same AMR patch hierarchy.
     * In general, this constructor is called by a RefineAlgorithm object.
     *


### PR DESCRIPTION
The documentation currently says the schedule does copy and "then" refinement. Although the code seems to run in the reversed order : refinement (including pre/postprocess from refine patch strategy) and only then copy.
The order matters since users reading the doc may be misled in thinking their postprocess patch strategy method can count on copy being done already.