### PR TITLE
missing overlap for face data

### DIFF
--- a/source/SAMRAI/xfer/RefineSchedule.cpp
+++ b/source/SAMRAI/xfer/RefineSchedule.cpp
@@ -4738,14 +4738,11 @@ RefineSchedule::constructScheduleTransactions(
 
             hier::Box test_mask(dst_fill_box * transformed_src_box);
             if (test_mask.empty() && dst_pdf->dataLivesOnPatchBorder()) {
-               if ((dst_gcw == constant_zero_intvector) ||
-                   (dst_box.isSpatiallyEqual(fill_box))) {
 
                   test_mask = dst_fill_box;
                   test_mask.grow(constant_one_intvector);
                   test_mask = test_mask * transformed_src_box;
 
-               }
             }
 
             src_mask = test_mask;


### PR DESCRIPTION
This PR removes a condition that when is met wrongly prevents the calculation of an overlap.
In RefineSchedule, the code loops over level source box which box may overlap the fill box, creating a `test_mask` to pass to the user `calculateOverlap()` method.

If the destination fill box and the transformed source box do not overlap, test mask is empty, but data could live on border in which case the code tries to grow by one cell the destination fill box to see if border data may overlap the source.

However, in the current code, this growth is only happening if:

1- the ghost width is 0
OR
2- the fill box is the same as the destination box.

I guess that if using a default `PatchLevelFillPattern` the fill box is the destination ghost box (at least that's what we see) and so in these case conditions 1 and 2 are the same.

We have ghost width of 2 cells, the condition is therefore not met.


This happens to be a problem in some (rare?) cases. In regridding, we see sometimes the destination ghost box border aligned with one of the old level box border and for face data the overlap is not calculated.

See the following situation


<img width="988" alt="image" src="https://github.com/user-attachments/assets/73100786-ea55-4fb4-81c1-e34302565ac7" />


On the left are old level patches (11,12,13,14,15) in red. On the right some new level patches 16 and 18.
patch 16 has its ghost box (ghost width = 2) represented on both panels.

As you can see, most of 16's ghost box overlaps old level patches, except from some part at its bottom.
The right face of the ghost box aligns with the right face of old patches 13 and 14, and on the right face of patch 15.

Where it intersects 13 and 14, the right border of 16 is well copied from 13 and 14 face values, respectively.
However, when it intersects **only** the right face of 15, the overlap is not calculated.

The reason is that for 13 and 14 overlaps, the first `test_mask` is not empty, since a lot of 16 overlaps 13 and 14.
However, when intersecting 16 and 15, the test mask is empty. And while data lives on border, the destination fill box is not grown since we have a non-zero ghost cell width  and our ghost destination fill box is not equal to the destination box.



Below is a zoom-in view on the nodes of interest :



<img width="478" alt="Capture d’écran 2025-06-27 à 09 52 02" src="https://github.com/user-attachments/assets/c3e852a8-38a4-4051-9168-a9a5f02de41a" />



test mask thus remains empty and calculateOverlap() is not called.
As a result, these nodes remain in unfilled boxes, and will get their values from refinement.

However, on the new level neighbor patch 18, these nodes will be **copied** from old patch 15, resulting in shared border nodes having different values on new level patches 16 and 18.



Removing the inner condition as proposed in this PR allows the growth of the destination box, making a non empty source mask and calling calculateOverlap. 











