### PR TITLE
Mac OS undefined references

### DIFF
--- a/.github/workflows/cmake_macos.yml
+++ b/.github/workflows/cmake_macos.yml
@@ -1,0 +1,42 @@
+name: CMake MacOS
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, macos-latest]
+        mode: [static, shared]
+
+    steps:
+
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+
+    - name: Install system deps (openmpi, hdf5, ccache,...)
+      run: |
+        brew reinstall gcc
+        brew install open-mpi hdf5-mpi
+        echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      run: |
+        CMAKE_CONFIG=""
+        [ "${{ matrix.mode }}" = "shared" ] && CMAKE_CONFIG="-DBUILD_SHARED_LIBS=ON"
+        cmake $GITHUB_WORKSPACE -DENABLE_SAMRAI_TESTS=OFF \
+              -DCMAKE_BUILD_TYPE=Debug $CMAKE_CONFIG
+        make VERBOSE=1

--- a/source/SAMRAI/algs/CMakeLists.txt
+++ b/source/SAMRAI/algs/CMakeLists.txt
@@ -38,6 +38,7 @@ set (algs_sources
   ${CMAKE_CURRENT_BINARY_DIR}/fortran/algs_upfluxsum3d.f)
 
 set (algs_depends
+  SAMRAI_mesh
   SAMRAI_hier
   SAMRAI_tbox
   SAMRAI_pdat)

--- a/source/SAMRAI/appu/CMakeLists.txt
+++ b/source/SAMRAI/appu/CMakeLists.txt
@@ -27,6 +27,7 @@ set_source_files_properties(
   Fortran)
 
 set (appu_depends
+  SAMRAI_geom
   SAMRAI_hier
   SAMRAI_pdat
   SAMRAI_tbox)

--- a/source/SAMRAI/mesh/CMakeLists.txt
+++ b/source/SAMRAI/mesh/CMakeLists.txt
@@ -59,6 +59,7 @@ process_m4(NAME fortran/mesh_coarsentags2d)
 process_m4(NAME fortran/mesh_coarsentags3d)
 
 set (mesh_depends
+  SAMRAI_pdat
   SAMRAI_hier
   SAMRAI_tbox
   SAMRAI_xfer)

--- a/source/SAMRAI/solv/CMakeLists.txt
+++ b/source/SAMRAI/solv/CMakeLists.txt
@@ -77,6 +77,7 @@ set_source_files_properties(
   Fortran)
 
 set (solv_depends
+  SAMRAI_geom
   SAMRAI_hier
   SAMRAI_math
   SAMRAI_tbox


### PR DESCRIPTION
When trying to build SAMRAI with shared libraries on Mac OS

We see a number of undefined reference errors

These can be seen [here](https://github.com/PhilipDeegan/SAMRAI/actions/runs/16317852427/job/46087997747#step:5:1242)

We don't officially support MacOS, but we like to compile across a variety of compilers for better coverage of edge cases/

If you don't want the github action script let me know and I'll drop it, it's really just there to show the issue is A) there and B) resolved.