### PR TITLE
Caliper macro name change

### DIFF
--- a/cmake/thirdparty/SetupSAMRAIThirdParty.cmake
+++ b/cmake/thirdparty/SetupSAMRAIThirdParty.cmake
@@ -64,7 +64,7 @@ if (ENABLE_CALIPER OR caliper_DIR)
 
   find_package(caliper REQUIRED)
 
-  set (HAVE_CALIPER True)
+  set (SAMRAI_HAVE_CALIPER True)
   set (ENABLE_CALIPER On)
 
   blt_register_library(

--- a/config/SAMRAI_config.h.cmake.in
+++ b/config/SAMRAI_config.h.cmake.in
@@ -149,7 +149,7 @@
 #cmakedefine HAVE_UMPIRE
 
 /* Use Caliper */
-#cmakedefine HAVE_CALIPER
+#cmakedefine SAMRAI_HAVE_CALIPER
 
 /* PETSC library is available so use it */
 #cmakedefine HAVE_PETSC

--- a/source/SAMRAI/tbox/Utilities.h
+++ b/source/SAMRAI/tbox/Utilities.h
@@ -21,7 +21,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#if defined(HAVE_CALIPER)
+#if defined(SAMRAI_HAVE_CALIPER)
 #include <caliper/cali.h>
 #endif
 
@@ -410,7 +410,7 @@ typedef int mode_t;
    } while (0)
 #endif
 
-#if defined(HAVE_CALIPER)
+#if defined(SAMRAI_HAVE_CALIPER)
 #define SAMRAI_CALI_CXX_MARK_FUNCTION CALI_CXX_MARK_FUNCTION
 #define SAMRAI_CALI_MARK_BEGIN(label) CALI_MARK_BEGIN(label)
 #define SAMRAI_CALI_MARK_END(label)   CALI_MARK_END(label)


### PR DESCRIPTION
Change HAVE_CALIPER to SAMRAI_HAVE_CALIPER to avoid name conflicts with other codes.