### PR TITLE
Latest CMake fails with defaults

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+
+    - name: Setup
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libopenmpi-dev openmpi-bin libhdf5-openmpi-dev ccache
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{github.workspace}}/build
+
+    - name: Build
+      working-directory: ${{github.workspace}}/build
+      run: |        
+        cmake $GITHUB_WORKSPACE 
+        make VERBOSE=2
+        


### PR DESCRIPTION
Hi, 

You should see the action fail to compile as cmake by default still uses C++14, when the latest code by default is using std::optional which is C++17

```
source/SAMRAI/hier/IntVector.h:1239:27: error: no member named 'optional' in namespace 'std'
 1239 |    static std::array<std::optional<IntVector>, SAMRAI::MAX_DIM_VAL> s_zeros; 
 ```
 
 or you can see it [here](https://github.com/PhilipDeegan/SAMRAI/actions/runs/19867801003/job/56935200113?pr=3)