### PR TITLE
destructor called on non-final 'SAMRAI::hier::IntVector' that has virtual functions

### DIFF
--- a/source/SAMRAI/hier/IntVector.h
+++ b/source/SAMRAI/hier/IntVector.h
@@ -223,7 +223,7 @@ public:
    /*!
     * @brief default destructor
     */
-   ~IntVector() noexcept = default;
+   virtual ~IntVector() noexcept = default;
 
    /*!
     * @brief Return the number of blocks for this IntVector


### PR DESCRIPTION
We have `-Werror` on by default which leads to issues when warnings are in samrai headers

we only see this with clang for some reason