### PR TITLE
Remove virtual declarations from IntVector

### DIFF
--- a/source/SAMRAI/hier/IntVector.h
+++ b/source/SAMRAI/hier/IntVector.h
@@ -1113,7 +1113,7 @@ public:
     *        with the provided name.
     *
     */
-   virtual void
+   void
    putToRestart(
       tbox::Database& restart_db,
       const std::string& name) const;
@@ -1123,7 +1123,7 @@ public:
     *        state from the specified restart database.
     *
     */
-   virtual void
+   void
    getFromRestart(
       tbox::Database& restart_db,
       const std::string& name);


### PR DESCRIPTION
putToRestart and getFromRestart shouldn't be virtual, since IntVector is not intended for polymorphic use.